### PR TITLE
fix: fix programId paragraph syntax as per docs.

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
@@ -114,59 +114,37 @@ suite("Integration Test Suite", () => {
     .timeout(2000)
     .slow(1000);
 
-  test("TC152047/ TC152052/ TC152051/ TC152050/ TC152053 Error case - file has syntax errors and semantic errors are marked and have detailed hints", async () => {
-    await helper.showDocument("USER2.cbl");
-    editor = helper.get_editor("USER2.cbl");
-    await helper.sleep(2000);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
-    assert.strictEqual(diagnostics.length, 3);
-    assert.ok(diagnostics.length === 3);
+    test('TC152047/ TC152052/ TC152051/ TC152050/ TC152053 Error case - file has syntax errors and are marked with detailed hints', async () => {
+        await helper.showDocument("USER2.cbl");
+        editor = helper.get_editor("USER2.cbl");
+        await helper.sleep(2000);
+        const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+        assert.strictEqual(diagnostics.length, 2);
+        assert.ok(diagnostics.length === 2);
 
-    assert.strictEqual(
-      diagnostics[0].message,
-      "Syntax error on 'Program1-id' expected PROGRAM-ID",
-    );
-    helper.assertRangeIsEqual(
-      diagnostics[0].range,
-      new vscode.Range(new vscode.Position(14, 7), new vscode.Position(14, 18)),
-    );
-    assert.strictEqual(diagnostics[0].severity, diagnostics[1].severity);
-    assert.strictEqual(
-      diagnostics[0].severity,
-      vscode.DiagnosticSeverity.Error,
-      "No syntax errors detected in USER2.cbl",
-    );
+        assert.strictEqual(diagnostics[0].message, "Missing token PROGRAM-ID at programIdParagraph");
+        helper.assertRangeIsEqual(diagnostics[0].range, new vscode.Range(new vscode.Position(13, 30), new vscode.Position(13, 31)));
+        assert.strictEqual(diagnostics[0].severity, diagnostics[1].severity);
+        assert.strictEqual(diagnostics[0].severity, vscode.DiagnosticSeverity.Error, 'No syntax errors detected in USER2.cbl');
 
-    assert.strictEqual(
-      diagnostics[1].message,
-      "Variable USER-CITY1 is not defined",
-    );
-    helper.assertRangeIsEqual(
-      diagnostics[1].range,
-      new vscode.Range(
-        new vscode.Position(39, 28),
-        new vscode.Position(39, 38),
-      ),
-    );
+        assert.strictEqual(diagnostics[1].message, "Syntax error on 'HELLO-WORLD' expected {AUTHOR, CBL, DATA, DATE-COMPILED, DATE-WRITTEN, END, ENVIRONMENT, ID, IDENTIFICATION, INSTALLATION, PROCEDURE, PROCESS, SECURITY}");
+        helper.assertRangeIsEqual(diagnostics[1].range, new vscode.Range(new vscode.Position(14, 20), new vscode.Position(14, 31)));
 
-    assert.strictEqual(
-      diagnostics[2].message,
-      "There is an issue with PROGRAM-ID paragraph",
-    );
-    assert.strictEqual(
-      diagnostics[2].severity,
-      vscode.DiagnosticSeverity.Warning,
-    );
-    helper.assertRangeIsEqual(
-      diagnostics[2].range,
-      new vscode.Range(
-        new vscode.Position(49, 19),
-        new vscode.Position(49, 30),
-      ),
-    );
-  })
-    .timeout(5000)
-    .slow(1000);
+    }).timeout(5000).slow(1000);
+
+    test('TC152050/ TC152053 Error case - file has semantic errors and are marked with detailed hints', async () => {
+        await helper.showDocument("REPLACING.CBL");
+        editor = helper.get_editor("REPLACING.CBL");
+        await helper.sleep(2000);
+        const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+        assert.strictEqual(diagnostics.length, 1);
+
+        assert.strictEqual(diagnostics[0].severity, diagnostics[0].severity);
+        assert.strictEqual(diagnostics[0].severity, vscode.DiagnosticSeverity.Error, 'No semantic errors detected in REPLACING.cbl');
+        assert.strictEqual(diagnostics[0].message, "Variable ABC-ID is not defined");
+        helper.assertRangeIsEqual(diagnostics[0].range, new vscode.Range(new vscode.Position(21, 21), new vscode.Position(21, 27)));
+
+    }).timeout(5000).slow(1000);
 
   test("TC152054 Auto format of right trailing spaces", async () => {
     await helper.insertString(editor, new vscode.Position(34, 57), "        ");

--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -217,7 +217,7 @@ identificationDivisionBody
 // - program id paragraph ----------------------------------
 
 programIdParagraph
-   : PROGRAM_ID DOT_FS programName (IS? (COMMON | INITIAL | LIBRARY | DEFINITION | RECURSIVE) PROGRAM?)? DOT_FS?
+   : PROGRAM_ID DOT_FS? programName (IS? (COMMON | INITIAL | LIBRARY | DEFINITION | RECURSIVE) PROGRAM?)? DOT_FS?
    ;
 
 // - author paragraph ----------------------------------

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookIdentificationServiceBasedOnContent.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookIdentificationServiceBasedOnContent.java
@@ -30,7 +30,7 @@ public class CopybookIdentificationServiceBasedOnContent implements CopybookIden
   private final List<Pattern> patterns = new LinkedList<>();
   public CopybookIdentificationServiceBasedOnContent() {
     patterns.add(Pattern.compile(
-        "(?i)^(?<sequence>.{0,6})(?<indicator>.?)\\s*(PROGRAM-ID)\\s*\\.\\s*(?<programName>.{1,30})\\s*\\.",
+        "(?i)^(?<sequence>.{0,6})(?<indicator>.?)\\s*(PROGRAM-ID)\\s*\\.?\\s*(?<programName>.{1,30})\\s*\\.?$",
         Pattern.MULTILINE | Pattern.CASE_INSENSITIVE));
     patterns.add(Pattern.compile("(?i)^(?<sequence>.{0,6})(?<indicator>.?)\\s*((IDENTIFICATION|ID)\\s+DIVISION)\\s*\\.",
         Pattern.MULTILINE | Pattern.CASE_INSENSITIVE));

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestControlCompilerDirective.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestControlCompilerDirective.java
@@ -34,9 +34,9 @@ class TestControlCompilerDirective {
           + "       Program-Id. control-dir.";
 
   private static final String TEXT_WRONG_ARG =
-      "       Identification Division.\n"
-          + "       *{CONTROL|1} {MAP1|2}\n"
-          + "       *{CBL|3} MAP1\n"
+      "       Identification Division{.|4}\n"
+          + "       *{CONTROL|1} MAP1\n"
+          + "       *{CBL|3} {MAP1|2}\n"
           + "       Program-Id. control-dir.";
 
   private static final String TEXT_CONTINUATION_FOR_COMPILER_DIR =
@@ -49,6 +49,7 @@ class TestControlCompilerDirective {
   void testNoErrorOnControlCompilerDirective() {
     UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
   }
+
   @Test
   void testErrorOnWrongArgumentToControlDirective() {
     UseCaseEngine.runTest(
@@ -64,12 +65,23 @@ class TestControlCompilerDirective {
             "2",
             new Diagnostic(
                 new Range(),
-                "Syntax error on 'MAP1' expected PROGRAM-ID",
+                "Syntax error on 'MAP1' expected {AUTHOR, CBL, COMMON, DATA, DATE-COMPILED, DATE-WRITTEN, " +
+                        "DEFINITION, END, ENVIRONMENT, ID, IDENTIFICATION, INITIAL, INSTALLATION, IS, LIBRARY, " +
+                        "PROCEDURE, PROCESS, RECURSIVE, SECURITY, '.'}",
                 DiagnosticSeverity.Error,
                 ErrorSource.PARSING.getText()),
             "3",
             new Diagnostic(
-                new Range(), "No arguments found for *CBL", DiagnosticSeverity.Error, ErrorSource.PREPROCESSING.getText())));
+                new Range(),
+                "No arguments found for *CBL",
+                DiagnosticSeverity.Error,
+                ErrorSource.PREPROCESSING.getText()),
+            "4",
+            new Diagnostic(
+                new Range(),
+                "Missing token PROGRAM-ID at programIdParagraph",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText())));
   }
 
   @Test

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestControlCompilerDirective.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestControlCompilerDirective.java
@@ -65,9 +65,9 @@ class TestControlCompilerDirective {
             "2",
             new Diagnostic(
                 new Range(),
-                "Syntax error on 'MAP1' expected {AUTHOR, CBL, COMMON, DATA, DATE-COMPILED, DATE-WRITTEN, " +
-                        "DEFINITION, END, ENVIRONMENT, ID, IDENTIFICATION, INITIAL, INSTALLATION, IS, LIBRARY, " +
-                        "PROCEDURE, PROCESS, RECURSIVE, SECURITY, '.'}",
+                "Syntax error on 'MAP1' expected {AUTHOR, CBL, COMMON, DATA, DATE-COMPILED, DATE-WRITTEN, "
+                    + "DEFINITION, END, ENVIRONMENT, ID, IDENTIFICATION, INITIAL, INSTALLATION, IS, LIBRARY, "
+                    + "PROCEDURE, PROCESS, RECURSIVE, SECURITY, '.'}",
                 DiagnosticSeverity.Error,
                 ErrorSource.PARSING.getText()),
             "3",

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestOutlineTreeLineNumbers.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestOutlineTreeLineNumbers.java
@@ -35,6 +35,7 @@ class TestOutlineTreeLineNumbers {
   private static final String TEXT =
       "01     COPY BAR.\n"
           + "02     IDENTIFICATION DIVISION.\n"
+          + "02     PROGRAM-ID. TEST.\n"
           + "03     DATA DIVISION.\n"
           + "04     WORKING-STORAGE SECTION.\n"
           + "05     01 STRUCTNAME.\n"
@@ -49,12 +50,13 @@ class TestOutlineTreeLineNumbers {
     Map<String, LineRange> expectedRanges =
         new ImmutableMap.Builder<String, LineRange>()
             .put("COPY BAR", new LineRange(0, 0))
-            .put("PROGRAM", new LineRange(1, 5))
-            .put("IDENTIFICATION DIVISION", new LineRange(1, 1))
-            .put("DATA DIVISION", new LineRange(2, 5))
-            .put("WORKING-STORAGE SECTION", new LineRange(3, 5))
-            .put("STRUCTNAME", new LineRange(4, 5))
-            .put("VARNAME", new LineRange(5, 5))
+            .put("PROGRAM: TEST", new LineRange(1, 6))
+            .put("IDENTIFICATION DIVISION", new LineRange(1, 2))
+            .put("PROGRAM-ID TEST", new LineRange(2, 2))
+            .put("DATA DIVISION", new LineRange(3, 6))
+            .put("WORKING-STORAGE SECTION", new LineRange(4, 6))
+            .put("STRUCTNAME", new LineRange(5, 6))
+            .put("VARNAME", new LineRange(6, 6))
             .build();
     assertEquals(
         expectedRanges,

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestProgramIdSyntaxRule.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestProgramIdSyntaxRule.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests program-id syntax. Ref -
+ * https://www.ibm.com/docs/en/developer-for-zos/14.1?topic=structure-cobol-program
+ */
+public class TestProgramIdSyntaxRule {
+  public static final String TEXT1 =
+      "      *\n" + "       IDENTIFICATION DIVISION.\n" + "       PROGRAM-ID SLICKB0";
+
+  public static final String TEXT2 =
+      "      *\n" + "       IDENTIFICATION DIVISION.\n" + "       PROGRAM-ID. SLICKB0";
+
+  public static final String TEXT3 =
+      "      *\n" + "       IDENTIFICATION DIVISION.\n" + "       PROGRAM-ID. SLICKB0.";
+
+  @Test
+  void testWhenProgramIdAndProgramNameNotFollowedByDot_ThenNoError() {
+    UseCaseEngine.runTest(TEXT1, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void testWhenProgramNameNotFollowedByDot_ThenNoError() {
+    UseCaseEngine.runTest(TEXT2, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void testWhenProgramIdAndProgramNameFollowedByDot_ThenNoError() {
+    UseCaseEngine.runTest(TEXT3, ImmutableList.of(), ImmutableMap.of());
+  }
+}

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSemicolonNotAllowedInIdentificationDivision.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSemicolonNotAllowedInIdentificationDivision.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 class TestSemicolonNotAllowedInIdentificationDivision {
   private static final String TEXT =
       "       IDENTIFICATION DIVISION;\n"
-          + "       {PROGRAM-ID|1}. {TEST1|2}.\n"
+          + "       {PROGRAM-ID|1}{.|2} TEST1.\n"
           + "       DATA DIVISION.\n"
           + "       working-storage section.\n"
           + "       01 {$*LINE-SPACING} PIC 9.\n"
@@ -50,7 +50,7 @@ class TestSemicolonNotAllowedInIdentificationDivision {
             "2",
             new Diagnostic(
                 new Range(),
-                "Syntax error on 'TEST1' expected PROGRAM-ID",
+                "Missing token PROGRAM-ID at programIdParagraph",
                 DiagnosticSeverity.Error,
                 ErrorSource.PARSING.getText())));
   }


### PR DESCRIPTION
fix programId paragraph syntax as per docs.
Reference - https://www.ibm.com/docs/en/developer-for-zos/14.1?topic=structure-cobol-program

Making changes in grammar as per the documentation results in slightly different diagnostics for some input. PR has a screenshot of prev state vs the new state. 