### PR TITLE
chore: don't stop all platform jobs on one error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
           path: 'cobol-dialect-support-for-daco*.vsix'
   buildNative:
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, macos-11, ubuntu-latest]
         arch: [x64, arm64]


### PR DESCRIPTION
 In case of some of the native build fails, we will still try to finish native builds on other platforms