### PR TITLE
fix: fix infinite copybook download when ZE profile is taken from the…

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -452,6 +452,7 @@ describe("Test downloadCopybook user interaction", () => {
   });
 
   test("check profile not found", async () => {
+    ProfileUtils.getAvailableProfiles = jest.fn().mockReturnValue([]);
     ProfileUtils.getProfileNameForCopybook = jest
       .fn()
       .mockReturnValue(undefined);
@@ -468,6 +469,7 @@ describe("Test downloadCopybook user interaction", () => {
   });
 
   test("check profile not found with user interaction", async () => {
+    ProfileUtils.getAvailableProfiles = jest.fn().mockReturnValue([]);
     ProfileUtils.getProfileNameForCopybook = jest
       .fn()
       .mockReturnValue(undefined);
@@ -484,6 +486,7 @@ describe("Test downloadCopybook user interaction", () => {
   });
 
   test("check good path", async () => {
+    ProfileUtils.getAvailableProfiles = jest.fn().mockReturnValue(["profile"]);
     ProfileUtils.getProfileNameForCopybook = jest
       .fn()
       .mockReturnValue("profile");
@@ -501,6 +504,9 @@ describe("Test downloadCopybook user interaction", () => {
   });
 
   test("check locked profile", async () => {
+    ProfileUtils.getAvailableProfiles = jest
+      .fn()
+      .mockReturnValue([wrongCredProfile]);
     ProfileUtils.getProfileNameForCopybook = jest
       .fn()
       .mockReturnValue(wrongCredProfile);
@@ -512,6 +518,9 @@ describe("Test downloadCopybook user interaction", () => {
   });
 
   test("check locked profile and user kept it locked", async () => {
+    ProfileUtils.getAvailableProfiles = jest
+      .fn()
+      .mockReturnValue([wrongCredProfile]);
     ProfileUtils.getProfileNameForCopybook = jest
       .fn()
       .mockReturnValue(wrongCredProfile);
@@ -531,6 +540,9 @@ describe("Test downloadCopybook user interaction", () => {
   });
 
   test("queue locked and user unlocked it", async () => {
+    ProfileUtils.getAvailableProfiles = jest
+      .fn()
+      .mockReturnValue([wrongCredProfile]);
     ProfileUtils.getProfileNameForCopybook = jest
       .fn()
       .mockReturnValue(wrongCredProfile);

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookMessageHandlerTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookMessageHandlerTest.spec.ts
@@ -26,7 +26,7 @@ vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
 Utils.getZoweExplorerAPI = jest.fn();
 
 describe("Test the copybook message handler", () => {
-  it("checks local present copybooks are resolved", () => {
+  it("checks local present copybooks are resolved", async () => {
     SettingsService.getCopybookExtension = jest.fn().mockReturnValue([".cpy"]);
     SettingsService.getCopybookLocalPath = jest
       .fn()
@@ -35,11 +35,15 @@ describe("Test the copybook message handler", () => {
       .fn()
       .mockReturnValue("copybook content");
     expect(
-      resolveCopybookHandler("cobolFileName", "copybookName", "dialectType"),
+      await resolveCopybookHandler(
+        "cobolFileName",
+        "copybookName",
+        "dialectType",
+      ),
     ).toBe("copybook content");
   });
 
-  it("checks downloaded copybooks are resolved", () => {
+  it("checks downloaded copybooks are resolved", async () => {
     SettingsService.getCopybookExtension = jest.fn().mockReturnValue([".cpy"]);
     SettingsService.getCopybookLocalPath = jest.fn().mockReturnValue("");
     SettingsService.getDsnPath = jest
@@ -53,11 +57,15 @@ describe("Test the copybook message handler", () => {
       .mockReturnValueOnce("")
       .mockReturnValueOnce("Downloaded copybook content");
     expect(
-      resolveCopybookHandler("cobolFileName", "copybookName", "dialectType"),
+      await resolveCopybookHandler(
+        "cobolFileName",
+        "copybookName",
+        "dialectType",
+      ),
     ).toBe("Downloaded copybook content");
   });
 
-  it("checks USS downloaded copybooks are resolved", () => {
+  it("checks USS downloaded copybooks are resolved", async () => {
     SettingsService.getCopybookExtension = jest.fn().mockReturnValue([".cpy"]);
     SettingsService.getCopybookLocalPath = jest.fn().mockReturnValue("");
     SettingsService.getDsnPath = jest.fn().mockReturnValue([]);
@@ -73,7 +81,11 @@ describe("Test the copybook message handler", () => {
       .mockReturnValueOnce("")
       .mockReturnValue("Downloaded USS copybook content");
     expect(
-      resolveCopybookHandler("cobolFileName", "copybookName", "dialectType"),
+      await resolveCopybookHandler(
+        "cobolFileName",
+        "copybookName",
+        "dialectType",
+      ),
     ).toBe("Downloaded USS copybook content");
   });
 });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookResolveURITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookResolveURITest.spec.ts
@@ -65,12 +65,12 @@ function removeFolder(targetPath: string) {
   return false;
 }
 
-function buildResultArrayFrom(
+async function buildResultArrayFrom(
   settingsMockValue: string[],
   filename: string,
   profileName: string,
   ussPath: string[] = [],
-): number {
+): Promise<number> {
   vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
     get: jest.fn().mockReturnValueOnce(settingsMockValue),
   });
@@ -81,11 +81,12 @@ function buildResultArrayFrom(
   }
   ProfileUtils.getProfileNameForCopybook = jest
     .fn()
-    .mockReturnValue(profileName);
-  return (CopybookURI as any).createPathForCopybookDownloaded(
+    .mockResolvedValue(profileName);
+  const result = await (CopybookURI as any).createPathForCopybookDownloaded(
     filename,
     SettingsService.DEFAULT_DIALECT,
-  ).length;
+  );
+  return result.length;
 }
 
 beforeEach(() => {
@@ -191,24 +192,24 @@ describe("Resolve local copybook present in one or more folders specified by the
   });
 });
 describe("With invalid input parameters, the list of URI that represent copybook downloaded are not generated", () => {
-  test("given a profile but no dataset, the result list returned is empty", () => {
-    expect(buildResultArrayFrom(undefined, "file", "PRF")).toBe(0);
+  test("given a profile but no dataset, the result list returned is empty", async () => {
+    expect(await buildResultArrayFrom(undefined, "file", "PRF")).toBe(0);
   });
-  test("given a list of dataset but no profile, the result list returned is empty", () => {
+  test("given a list of dataset but no profile, the result list returned is empty", async () => {
     expect(
-      buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", undefined),
+      await buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", undefined),
     ).toBe(0);
   });
 });
 describe("With allowed input parameters, the list of URI that represent copybook downloaded is correctly generated", () => {
-  test("given profile and dataset list with one element, the result list is correctly generated with size 1 ", () => {
-    expect(buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", "PRF")).toBe(
-      1,
-    );
-  });
-  test("given profile, dataset and USS path, list with one element each, the result list is correctly generated with size 2 ", () => {
+  test("given profile and dataset list with one element, the result list is correctly generated with size 1 ", async () => {
     expect(
-      buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", "PRF", [
+      await buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", "PRF"),
+    ).toBe(1);
+  });
+  test("given profile, dataset and USS path, list with one element each, the result list is correctly generated with size 2 ", async () => {
+    expect(
+      await buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", "PRF", [
         "/test/uss/path",
       ]),
     ).toBe(2);

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/ProfileUtilsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/ProfileUtilsTest.spec.ts
@@ -39,17 +39,18 @@ Utils.getZoweExplorerAPI = jest.fn();
 describe("Test profile Utils", () => {
   const programName = "COBOLFILE.cbl";
   const profile = "profile";
-  it("checks that profile is fetched from the file path as 1st strategy", async () => {
+  it("checks a profile passed through settings is always given preference over profile from doc path for copybook download", async () => {
     Utils.getZoweExplorerAPI = getZoweExplorerMock();
     (vscode.workspace.textDocuments as any) = [];
     (vscode.workspace.textDocuments as any).push({
       fileName: path.join(profile, programName),
     } as any);
     vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
-      get: jest.fn().mockReturnValue([]),
+      get: jest.fn().mockReturnValue("profileInSettings"),
     });
+    ProfileUtils.getAvailableProfiles = jest.fn().mockReturnValue([profile]);
     expect(await ProfileUtils.getProfileNameForCopybook(programName)).toBe(
-      profile,
+      "profileInSettings",
     );
   });
 

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -399,8 +399,9 @@ export class CopybookDownloadService implements vscode.Disposable {
       return;
     }
     const profile = await ProfileUtils.getProfileNameForCopybook(documentUri);
+    const availableProfiles = ProfileUtils.getAvailableProfiles(explorerAPI);
 
-    if (!profile) {
+    if (!profile || availableProfiles.indexOf(profile) < 0) {
       if (!quiet) {
         const providedProfile: string = SettingsService.getProfileName();
         const message = providedProfile

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookMessageHandler.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookMessageHandler.ts
@@ -25,18 +25,21 @@ enum CopybookFolderKind {
   "downloaded-uss",
 }
 
-export function resolveCopybookHandler(
+export async function resolveCopybookHandler(
   documentUri: string,
   copybookName: string,
   dialectType: string,
-): string {
+): Promise<string> {
   let result: string;
   result = searchCopybook(documentUri, copybookName, dialectType);
   // check in subfolders under .copybooks (copybook downloaded from MF)
   if (!result) {
     result = searchCopybookInWorkspace(
       copybookName,
-      CopybookURI.createPathForCopybookDownloaded(documentUri, dialectType),
+      await CopybookURI.createPathForCopybookDownloaded(
+        documentUri,
+        dialectType,
+      ),
       SettingsService.getCopybookExtension(),
     );
   }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookURI.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookURI.ts
@@ -15,7 +15,10 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { C4Z_FOLDER, COPYBOOKS_FOLDER } from "../../constants";
 import { SettingsService } from "../Settings";
-import { searchCopybookInWorkspace } from "../util/FSUtils";
+import {
+  getProgramNameFromUri,
+  searchCopybookInWorkspace,
+} from "../util/FSUtils";
 import { ProfileUtils } from "../util/ProfileUtils";
 
 /**
@@ -52,7 +55,10 @@ export class CopybookURI {
     if (!result) {
       result = searchCopybookInWorkspace(
         copybookName,
-        CopybookURI.createPathForCopybookDownloaded(documentUri, dialectType),
+        await CopybookURI.createPathForCopybookDownloaded(
+          documentUri,
+          dialectType,
+        ),
         SettingsService.getCopybookExtension(),
       );
     }
@@ -95,11 +101,12 @@ export class CopybookURI {
    * @param profile represent a name of a folder within the .copybooks folder that have the same name as the
    * connection name needed to download copybooks from mainframe.
    */
-  public static createPathForCopybookDownloaded(
+  public static async createPathForCopybookDownloaded(
     documentUri: string,
     dialectType: string,
-  ): string[] {
-    const profile = ProfileUtils.getProfileNameForCopybook(documentUri);
+  ): Promise<string[]> {
+    const filename = getProgramNameFromUri(documentUri, true);
+    const profile = await ProfileUtils.getProfileNameForCopybook(filename);
 
     let result: string[] = [];
     const datasets: string[] = SettingsService.getDsnPath(

--- a/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
@@ -146,8 +146,14 @@ function globSearch(
   return result[0] ? path.join(cwd, result[0]) : undefined;
 }
 
-export function getProgramNameFromUri(uri: string): string {
+export function getProgramNameFromUri(
+  uri: string,
+  includeExt: boolean = false,
+): string {
   const fullPath = Uri.parse(uri).fsPath;
+  if (includeExt) {
+    return path.basename(fullPath);
+  }
   return path.basename(fullPath, path.extname(fullPath));
 }
 

--- a/clients/cobol-lsp-vscode-extension/src/services/util/ProfileUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/ProfileUtils.ts
@@ -25,6 +25,13 @@ export class ProfileUtils {
     if (!zoweExplorerApi) {
       return undefined;
     }
+    return ProfileUtils.getValidProfileForCopybookDownload(
+      cobolFileName,
+      ProfileUtils.getAvailableProfiles(zoweExplorerApi),
+    );
+  }
+
+  public static getAvailableProfiles(zoweExplorerApi: IApiRegisterClient) {
     let availableProfiles: string[] = [];
     zoweExplorerApi.registeredApiTypes().forEach((profileType) => {
       availableProfiles = availableProfiles.concat(
@@ -35,10 +42,7 @@ export class ProfileUtils {
           ?.map((ele) => ele.name),
       );
     });
-    return ProfileUtils.getValidProfileForCopybookDownload(
-      cobolFileName,
-      availableProfiles,
-    );
+    return availableProfiles;
   }
 
   private static getValidProfileForCopybookDownload(
@@ -50,10 +54,10 @@ export class ProfileUtils {
       availableProfiles,
     );
     const passedProfile = SettingsService.getProfileName();
-    if (!profileFromDoc && availableProfiles.indexOf(passedProfile) >= 0) {
-      return passedProfile;
+    if (!passedProfile && profileFromDoc) {
+      return profileFromDoc;
     }
-    return profileFromDoc;
+    return passedProfile;
   }
 
   private static getProfileFromDocument(


### PR DESCRIPTION
… file path.

fix infinite copybook download when ZE profile is taken from the file path rather than the one passed by user under settings.