### PR TITLE
fix: Stop processing if dialect was not found

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/dialects/DialectOutcome.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/dialects/DialectOutcome.java
@@ -29,9 +29,24 @@ import java.util.List;
 public class DialectOutcome {
   List<Node> dialectNodes;
   DialectProcessingContext context;
+  boolean dialectMissed;
 
   public DialectOutcome(DialectProcessingContext context) {
     this.context = context;
     this.dialectNodes = ImmutableList.of();
+    this.dialectMissed = false;
   }
+
+  public DialectOutcome(List<Node> dialectNodes, DialectProcessingContext context) {
+    this.context = context;
+    this.dialectNodes = dialectNodes;
+    this.dialectMissed = false;
+  }
+
+  public DialectOutcome(DialectProcessingContext context, boolean hasMissedDialect) {
+    this.context = context;
+    this.dialectNodes = ImmutableList.of();
+    this.dialectMissed = hasMissedDialect;
+  }
+
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/analysis/AnalysisContext.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/analysis/AnalysisContext.java
@@ -25,7 +25,6 @@ import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp.cobol.core.semantics.CopybooksRepository;
 
 import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * Contains related to analysis state
@@ -34,58 +33,10 @@ import java.util.function.Supplier;
 @Slf4j
 public class AnalysisContext {
   private final @Getter ExtendedSource extendedSource;
-  private final @Getter Map<Activity, Timing> timing = new EnumMap<>(Activity.class);
   private final @Getter AnalysisConfig config;
   private final @Getter String documentUri;
   private final @Getter List<SyntaxError> accumulatedErrors = new ArrayList<>();
 
   private @Getter @Setter List<Node> dialectNodes;
   private @Getter @Setter CopybooksRepository copybooksRepository;
-
-  /**
-   * Measure run time of supplier
-   * @param activity current activity
-   * @param supplier execution logic
-   * @return result of execution
-   * @param <T> type of execution result
-   */
-  public <T> T measure(Activity activity, Supplier<T> supplier) {
-    return timing.computeIfAbsent(activity, a -> new Timing()).measure(supplier);
-  }
-
-  /**
-   * Measure run time of runnable
-   * @param activity current activity
-   * @param runnable execution logic
-   */
-  public void measure(Activity activity, Runnable runnable) {
-    timing.computeIfAbsent(activity, a -> new Timing()).measure(runnable);
-  }
-
-  /**
-   * Log the timing of analysis
-   */
-  public void logTiming() {
-    LOG.debug(
-            "Timing for parsing {}. Dialects: {}, preprocessor: {}, parser: {}, visitor: {}, syntaxTree: {}, "
-                    + "late error processing: {}",
-            getExtendedSource().getUri(),
-            timing.get(Activity.DIALECTS).getTime(),
-            timing.get(Activity.PREPROCESSOR).getTime(),
-            timing.get(Activity.PARSER).getTime(),
-            timing.get(Activity.VISITOR).getTime(),
-            timing.get(Activity.SYNTAX_TREE).getTime(),
-            timing.get(Activity.LATE_ERROR_PROCESSING).getTime());
-  }
-  /**
-   * Type of activities we want to measure time for
-   */
-  public enum Activity {
-    DIALECTS,
-    PREPROCESSOR,
-    PARSER,
-    VISITOR,
-    SYNTAX_TREE,
-    LATE_ERROR_PROCESSING
-  }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/PipelineResult.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/PipelineResult.java
@@ -14,15 +14,22 @@
  */
 package org.eclipse.lsp.cobol.core.engine.pipeline;
 
+import lombok.AllArgsConstructor;
 import lombok.Value;
 
 /**
  * Processing Pipeline Stage Result
  */
 @Value
+@AllArgsConstructor
 public class PipelineResult<T> {
   T data;
+  boolean stopProcessing;
 
+  public PipelineResult(T data) {
+    this.data = data;
+    stopProcessing = false;
+  }
   /**
    * Creates an empty stage processing result
    * @return an empty stage processing result
@@ -36,6 +43,6 @@ public class PipelineResult<T> {
    * @return true if processing needs to be stopped and false otherwise
    */
   public boolean stopProcessing() {
-    return false;
+    return stopProcessing;
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/Stage.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/Stage.java
@@ -27,4 +27,10 @@ public interface Stage<T, R> {
    * @return the result of the current stage processing
    */
   PipelineResult<T> run(AnalysisContext context, PipelineResult<R> prevPipelineResult);
+
+  /**
+   * Returns the name of the stage
+   * @return the name of the stage
+   */
+  String getName();
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/DialectProcessingStage.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/DialectProcessingStage.java
@@ -27,8 +27,6 @@ import org.eclipse.lsp.cobol.core.engine.pipeline.PipelineResult;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.eclipse.lsp.cobol.core.engine.analysis.AnalysisContext.Activity.DIALECTS;
-
 /**
  * Dialect Processing Stage
  */
@@ -41,7 +39,13 @@ public class DialectProcessingStage implements Stage<DialectOutcome, Void> {
   public PipelineResult<DialectOutcome> run(AnalysisContext context, PipelineResult<Void> prevPipelineResult) {
     // Dialect processing
     dialectService.updateDialects(context.getConfig().getDialectRegistry());
-    return new PipelineResult<>(context.measure(DIALECTS, () -> processDialects(context)));
+    DialectOutcome dialectOutcome = processDialects(context);
+    return new PipelineResult<>(dialectOutcome, dialectOutcome.isDialectMissed());
+  }
+
+  @Override
+  public String getName() {
+    return "Dialects processing";
   }
 
   private DialectOutcome processDialects(AnalysisContext ctx) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/EmbeddedCodeStage.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/EmbeddedCodeStage.java
@@ -46,4 +46,9 @@ public class EmbeddedCodeStage implements Stage<Pair<ParserStageResult, List<Nod
     Pair<ParserStageResult, List<Node>> result = Pair.of(prevPipelineResult.getData(), embeddedNodes);
     return new PipelineResult<>(result);
   }
+
+  @Override
+  public String getName() {
+    return "Embedded code processing";
+  }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/ParserStage.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/ParserStage.java
@@ -29,8 +29,6 @@ import org.eclipse.lsp.cobol.core.semantics.CopybooksRepository;
 import org.eclipse.lsp.cobol.core.strategy.CobolErrorStrategy;
 import org.eclipse.lsp.cobol.core.visitor.ParserListener;
 
-import static org.eclipse.lsp.cobol.core.engine.analysis.AnalysisContext.Activity.PARSER;
-
 /**
  * Parser stage
  */
@@ -48,10 +46,15 @@ public class ParserStage implements Stage<ParserStageResult, CopybooksRepository
     lexer.removeErrorListeners();
     CommonTokenStream tokens = new CommonTokenStream(lexer);
 
-    CobolParser.StartRuleContext tree = context.measure(PARSER, () -> runParser(listener, lexer, tokens));
+    CobolParser.StartRuleContext tree = runParser(listener, lexer, tokens);
 
     context.getAccumulatedErrors().addAll(listener.getErrors());
     return new PipelineResult<>(new ParserStageResult(tokens, tree));
+  }
+
+  @Override
+  public String getName() {
+    return "Parsing stage";
   }
 
   private CobolParser.StartRuleContext runParser(ParserListener listener, CobolLexer lexer, CommonTokenStream tokens) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/PreprocessorStage.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/PreprocessorStage.java
@@ -31,8 +31,6 @@ import org.eclipse.lsp.cobol.core.semantics.CopybooksRepository;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.eclipse.lsp.cobol.core.engine.analysis.AnalysisContext.Activity.PREPROCESSOR;
-
 /**
  * Preprocessor stage
  */
@@ -43,12 +41,17 @@ public class PreprocessorStage implements Stage<CopybooksRepository, DialectOutc
   @Override
   public PipelineResult<CopybooksRepository> run(AnalysisContext context, PipelineResult<DialectOutcome> prevPipelineResult) {
     // Preprocessor (replacement, copybooks)
-    CopybooksRepository copybooksRepository = context.measure(PREPROCESSOR, () -> runPreprocessor(context.getDocumentUri(), context));
+    CopybooksRepository copybooksRepository = runPreprocessor(context.getDocumentUri(), context);
     applyDialectCopybooks(copybooksRepository, prevPipelineResult.getData().getDialectNodes());
 
     context.setDialectNodes(prevPipelineResult.getData().getDialectNodes());
     context.setCopybooksRepository(copybooksRepository);
     return new PipelineResult<>(copybooksRepository);
+  }
+
+  @Override
+  public String getName() {
+    return "Preprocessing";
   }
 
   private void applyDialectCopybooks(CopybooksRepository copybooksRepository, List<Node> dialectNodes) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/TransformTreeStage.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/TransformTreeStage.java
@@ -47,9 +47,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static org.eclipse.lsp.cobol.core.engine.analysis.AnalysisContext.Activity.SYNTAX_TREE;
-import static org.eclipse.lsp.cobol.core.engine.analysis.AnalysisContext.Activity.VISITOR;
-
 /**
  * Transform Tree Stage
  */
@@ -66,25 +63,25 @@ public class TransformTreeStage implements Stage<ProcessingResult, Pair<ParserSt
   @Override
   public PipelineResult<ProcessingResult> run(AnalysisContext context, PipelineResult<Pair<ParserStageResult, List<Node>>> prevPipelineResult) {
     // Transform parsed tree to AST
-    List<Node> syntaxTree = context.measure(VISITOR,
-        () -> transformAST(
+    List<Node> syntaxTree = transformAST(
             context,
             context.getDialectNodes(),
             context.getCopybooksRepository(),
             prevPipelineResult.getData().getKey().getTokens(),
-            prevPipelineResult.getData().getKey().getTree()));
+            prevPipelineResult.getData().getKey().getTree());
 
     addEmbeddedNodes(syntaxTree.get(0), prevPipelineResult.getData().getRight());
 
     SymbolAccumulatorService symbolAccumulatorService = new SymbolAccumulatorService();
-    Node rootNode = context.measure(SYNTAX_TREE,
-        () -> {
-          Node root = processSyntaxTree(context.getConfig(), symbolAccumulatorService, context, syntaxTree);
-          symbolsRepository.updateSymbols(symbolAccumulatorService.getProgramSymbols());
-          return root;
-        });
+    Node rootNode = processSyntaxTree(context.getConfig(), symbolAccumulatorService, context, syntaxTree);
+    symbolsRepository.updateSymbols(symbolAccumulatorService.getProgramSymbols());
 
     return new PipelineResult<>(new ProcessingResult(symbolAccumulatorService.getProgramSymbols(), rootNode));
+  }
+
+  @Override
+  public String getName() {
+    return "Transform tree";
   }
 
   private List<Node> transformAST(AnalysisContext ctx, List<Node> dialectNodes,

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMissedDialect.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMissedDialect.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.common.AnalysisConfig;
+import org.eclipse.lsp.cobol.common.copybook.CopybookConfig;
+import org.eclipse.lsp.cobol.common.copybook.CopybookProcessingMode;
+import org.eclipse.lsp.cobol.common.copybook.SQLBackend;
+import org.eclipse.lsp.cobol.common.error.ErrorSource;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test that missed dialect stops processing
+ */
+class TestMissedDialect {
+  private static final String TEXT =
+       "{|1}        IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. MIN.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       TEST-DIALECT RELATED SENTENCE\n"
+          + "       PROCEDURE DIVISION.\n";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(new Range(), "TESTDIALECT dialect is missing (required for file:///c:/workspace/document.cbl)", DiagnosticSeverity.Error, ErrorSource.DIALECT.getText())),
+        ImmutableList.of(),
+        new AnalysisConfig(new CopybookConfig(CopybookProcessingMode.ENABLED, SQLBackend.DB2_SERVER), ImmutableList.of(),
+            ImmutableList.of("TESTDIALECT"), false, ImmutableList.of(), ImmutableMap.of()));
+  }
+}


### PR DESCRIPTION
## How Has This Been Tested?

```COBOL
       IDENTIFICATION DIVISION.
       PROGRAM-ID. MIN.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       TEST-DIALECT RELATED SENTENCE
       PROCEDURE DIVISION.
```
This COBOL program contains a syntax error on line 5. 

1. Add "TESTDIALECT" to the dialect settings list
2. Ensure that there is only 1 error related to the missing dialect and no syntax errors. It means that processing was stopped after the dialect processing stage.

- [x] TestMissedDialect

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
