### PR TITLE
fix: change sql preprocessor name to "SQL"

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroups.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroups.spec.ts
@@ -40,7 +40,7 @@ jest.mock("fs", () => ({
                                 "libs": ["/daco"]
                             },
                             {
-                                "name": "DB2/DATACOM",
+                                "name": "SQL",
                                 "target-sql-backend": "DATACOM_SERVER"
                             }
                         ], 

--- a/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
@@ -74,7 +74,7 @@ export function loadProcessorGroupSqlBackendConfig(
     item.scopeUri,
     "target-sql-backend",
     configObject,
-    "DB2/DATACOM",
+    "SQL",
   );
 }
 
@@ -101,8 +101,8 @@ export function loadProcessorGroupDialectConfig(
       }
     }
 
-    // "DB2/DATACOM" is not a real dialect, we will use it only to set up sql backend for now
-    return dialects.filter((name) => name != "DB2/DATACOM") || configObject;
+    // "SQL" is not a real dialect, we will use it only to set up sql backend for now
+    return dialects.filter((name) => name != "SQL") || configObject;
   } catch (e) {
     console.error(JSON.stringify(e));
     return configObject;


### PR DESCRIPTION
## How Has This Been Tested?

1. Put "SQL" preprocessor into processor groups configuration and setup the backend (DB2 or DATACOM)
---
Backend settings should be populated to the parser.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
