### PR TITLE
fix: fix completion error for COBOL document

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookNameServiceImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookNameServiceImpl.java
@@ -206,7 +206,7 @@ public class CopybookNameServiceImpl implements CopybookNameService {
   private List<CopybookName> createCopybookNamesList(String uri, Predicate<CopybookName> predicate) {
     CobolLanguageClient cobolLanguageClient = clientProvider.get();
     CompletableFuture<List<WorkspaceFolder>> copybookWorkspaces = cobolLanguageClient.workspaceFolders();
-    CompletableFuture<List<String>> copybooksExtensions = settingsService.fetchTextConfigurationWithScope(CPY_EXTENSIONS.label, uri);
+    CompletableFuture<List<String>> copybooksExtensions = settingsService.fetchTextConfigurationWithScope(uri, CPY_EXTENSIONS.label);
     CompletableFuture<List<String>> copybookLocalFolders = copybookLocalFolders(uri);
     return resolveNames(copybookWorkspaces.join(), copybookLocalFolders.join(), copybooksExtensions.join(),
             extractProgramName(uri), predicate);

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/SettingsServiceImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/SettingsServiceImpl.java
@@ -62,7 +62,7 @@ public class SettingsServiceImpl implements SettingsService {
 
   @Override
   public CompletableFuture<List<String>> fetchTextConfigurationWithScope(String scopeUri, String section) {
-    return fetchConfiguration(scopeUri, section).thenApply(objects -> objects.stream()
+    return fetchConfigurations(scopeUri, singletonList(section)).thenApply(objects -> objects.stream()
             .map(JsonArray.class::cast)
             .flatMap(Streams::stream)
             .map(JsonElement::getAsString)

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookNameServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookNameServiceTest.java
@@ -61,7 +61,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CopybookNameServiceTest {
   private static String absoluteValidCpyPath;
-  private static String relativeValidCpyPath;
   private static String workspaceProgramPath;
   private static String workspaceProgramUri;
 
@@ -81,7 +80,7 @@ class CopybookNameServiceTest {
     String pathPrefix = FileSystem.WINDOWS.equals(FileSystem.getCurrent()) ? "c:/" : "/";
     workspaceProgramPath = pathPrefix + "workspace";
     absoluteValidCpyPath = pathPrefix + "copybooks";
-    relativeValidCpyPath = "copybooks";
+    String relativeValidCpyPath = "copybooks";
     workspaceProgramUri = "file:///" + workspaceProgramUri;
     workspace.add(new WorkspaceFolder(workspaceProgramUri));
     copyNames.addAll(ImmutableList.of(absoluteValidCpyPath, relativeValidCpyPath, workspaceProgramPath));
@@ -165,8 +164,8 @@ class CopybookNameServiceTest {
   ) {
 
     validFoldersMock();
-    when(settingsService.fetchTextConfigurationWithScope(
-            eq(CPY_EXTENSIONS.label), anyString())).thenReturn(CompletableFuture.completedFuture(extensionsInConfig));
+    when(settingsService.fetchTextConfigurationWithScope(anyString(),
+            eq(CPY_EXTENSIONS.label))).thenReturn(CompletableFuture.completedFuture(extensionsInConfig));
     when(files.listFilesInDirectory(anyString())).thenReturn(emptyList());
     when(files.listFilesInDirectory(anyString())).thenReturn(Arrays.asList("A.CPY", "A.COPY", "A.cpy", "A.copy", "A"));
 
@@ -190,8 +189,8 @@ class CopybookNameServiceTest {
           int expectedCopybookFound
   ) {
     validFoldersMock();
-    when(settingsService.fetchTextConfigurationWithScope(
-            eq(CPY_EXTENSIONS.label), anyString())).thenReturn(CompletableFuture.completedFuture(extensionsInCofig));
+    when(settingsService.fetchTextConfigurationWithScope(anyString(),
+            eq(CPY_EXTENSIONS.label))).thenReturn(CompletableFuture.completedFuture(extensionsInCofig));
     when(files.listFilesInDirectory(absoluteValidCpyPath)).thenReturn(filesInCopybookDirectory);
 
     CopybookNameService copybookNameService =
@@ -205,7 +204,7 @@ class CopybookNameServiceTest {
     CopybookNameService copybookNameService =
             new CopybookNameServiceImpl(settingsService, files, provider);
 
-    when(settingsService.fetchTextConfigurationWithScope(eq(CPY_EXTENSIONS.label), anyString()))
+    when(settingsService.fetchTextConfigurationWithScope(anyString(), eq(CPY_EXTENSIONS.label)))
             .thenReturn(CompletableFuture.completedFuture(Collections.singletonList("cpy")));
     when(settingsService.fetchConfigurations(any(), any())).thenReturn(CompletableFuture.completedFuture(ImmutableList.of()));
     when(files.decodeURI(absoluteValidCpyPath)).thenReturn(null);


### PR DESCRIPTION
fix completion error for COBOL document. Wrong settings label request (cpy-manager.copybook-extensions.file:///uri/copybook.CPY) triggered to fetch copybook extensions.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Try autocompletion on any COBOL document

## Checklist:
- [x] Each my commit contains one meaningful change
- [x] I have performed rebase my branch on top of development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
