### PR TITLE
fix: fix copybook cache resolution

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookReferenceRepoImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookReferenceRepoImpl.java
@@ -18,6 +18,7 @@ import com.google.inject.Singleton;
 import org.eclipse.lsp.cobol.common.copybook.CopybookModel;
 import org.eclipse.lsp.cobol.common.copybook.CopybookName;
 
+import java.io.File;
 import java.util.*;
 
 /**
@@ -42,7 +43,11 @@ public class CopybookReferenceRepoImpl implements CopybookReferenceRepo {
    */
   @Override
   public Set<CopybookModel> getCopybookUsageReference(String copybookUri) {
-    return copybookRef.getOrDefault(copybookUri, Collections.emptySet());
+    return copybookRef.entrySet().stream()
+            .filter(entry -> new File(entry.getKey()).equals(new File(copybookUri)))
+            .map(Map.Entry::getValue)
+            .findFirst()
+            .orElse(Collections.emptySet());
   }
 
   /** Clears all copybook references. */

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookReferenceRepoImplTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookReferenceRepoImplTest.java
@@ -20,6 +20,8 @@ import java.util.Set;
 import org.eclipse.lsp.cobol.common.copybook.CopybookModel;
 import org.eclipse.lsp.cobol.common.copybook.CopybookName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /** Test @{@link CopybookReferenceRepo} */
 class CopybookReferenceRepoImplTest {
@@ -43,6 +45,17 @@ class CopybookReferenceRepoImplTest {
     CopybookModel referencedCopybookModels = copybookUsageReference.toArray(new CopybookModel[0])[0];
     assertEquals(COPYBOOK_CONTENT, referencedCopybookModels.getContent());
     assertEquals(DOCUMENT_URI, referencedCopybookModels.getUri());
+  }
+
+  @Test
+  @EnabledOnOs({OS.WINDOWS})
+  void getCopybookUsageReference_whenUriIsCaseInsensitive() {
+    CopybookReferenceRepo repo = storeReferences();
+    Set<CopybookModel> copybookUsageReference = repo.getCopybookUsageReference("file:///C:/workspace/.c4z/.copybooks/PARENT.CPY");
+    CopybookModel referencedCopybookModels = copybookUsageReference.toArray(new CopybookModel[0])[0];
+    assertEquals(1, copybookUsageReference.size());
+    assertEquals(DOCUMENT_URI, referencedCopybookModels.getUri());
+    assertEquals(COPYBOOK_CONTENT, referencedCopybookModels.getContent());
   }
 
   private Set<CopybookModel> setUpRepo() {


### PR DESCRIPTION
fix copybook cache resolution. URI's 'file:///C:/Users' and 'file:///c:/Users' should be resolved the same if it points to the same File.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Make syntactical errors in a copybook associated with a cool doc. The error should be reported in the problem view. Once the errors in the copybooks are reverted, the errors from the problem view should vanish. 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
