### PR TITLE
fix: coloring for quoted string

### DIFF
--- a/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
+++ b/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
@@ -8,13 +8,13 @@
       "include": "#comment-floating"
     },
     {
-      "include": "#number-constant"
-    },
-    {
       "include": "#string-quoted-constant"
     },
     {
       "include": "#string-double-quoted-constant"
+    },
+    {
+      "include": "#number-constant"
     },
     {
       "include": "#picture"
@@ -56,14 +56,70 @@
       "name": "constant.numeric.integer"
     },
     "string-quoted-constant": {
-      "begin": "'",
-      "end": "'|$",
-      "name": "string.quoted.single.cobol"
+      "match": "(^.{7}.*?)('.*?('|$))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#number-constant"
+            },
+            {
+              "include": "#picture"
+            },
+            {
+              "include": "#sql-block"
+            },
+            {
+              "include": "#cics-block"
+            },
+            {
+              "include": "#cobol-keywords"
+            },
+            {
+              "include": "#cobol-preprocessor-keywords"
+            },
+            {
+              "include": "#idms-keywords"
+            }
+          ]
+        },
+        "2": {
+          "name": "string.quoted.single.cobol"
+        }
+      }
     },
     "string-double-quoted-constant": {
-      "begin": "\"",
-      "end": "\"|$",
-      "name": "string.quoted.double.cobol"
+      "match": "(^.{7}.*?)(\".*?(\"|$))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#number-constant"
+            },
+            {
+              "include": "#picture"
+            },
+            {
+              "include": "#sql-block"
+            },
+            {
+              "include": "#cics-block"
+            },
+            {
+              "include": "#cobol-keywords"
+            },
+            {
+              "include": "#cobol-preprocessor-keywords"
+            },
+            {
+              "include": "#idms-keywords"
+            }
+          ]
+        },
+        "2": {
+          "name": "string.quoted.double.cobol"
+        }
+      }
     },
     "picture": {
       "match": "(?i:\\b(picture|pic)\\s+(is\\s+)?\\S+)(?<!\\.)",


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test coloring for the below code
```cobol
PC0704 FD  VFF998S                                                              
  "        LABEL RECORD STANDARD                                                
  "        BLOCK CONTAINS 0 RECORDS                                             
  "        RECORDING MODE IS F                                                  
  "        DATA RECORD IS F998-REC-VFF998. 
``` 
 wrong coloring:
 
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/95b215e7-fba0-43f8-9e68-ff921c4fa1d9)

expected coloring:
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/6336a836-8c17-48ab-931a-caef28558210)


## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
