### PR TITLE
fix: Fix copybook error processing

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.copybooks.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.copybooks.test.ts
@@ -86,10 +86,10 @@ suite("Integration Test Suite: Copybooks", function () {
       () => vscode.languages.getDiagnostics(editor.document.uri).length > 0,
     );
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
-    assert.strictEqual(diagnostics.length, 4);
+    assert.strictEqual(diagnostics.length, 3);
     helper.assertRangeIsEqual(
       diagnostics[0].range,
-      new vscode.Range(pos(18, 7), pos(18, 19)),
+      new vscode.Range(pos(18, 12), pos(18, 18)),
     );
     assert.strictEqual(
       diagnostics[0].message,
@@ -106,13 +106,13 @@ suite("Integration Test Suite: Copybooks", function () {
       () => vscode.languages.getDiagnostics(editor.document.uri).length > 0,
     );
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
-    assert.strictEqual(diagnostics.length, 7);
+    assert.strictEqual(diagnostics.length, 4);
     helper.assertRangeIsEqual(
-      diagnostics[6].range,
+      diagnostics[3].range,
       range(pos(51, 38), pos(51, 56)),
     );
     assert.strictEqual(
-      diagnostics[6].message,
+      diagnostics[3].message,
       "Variable USER-PHONE-MOBILE1 is not defined",
     );
   })

--- a/server/dialect-idms/src/test/java/org/eclipse/lsp/cobol/dialects/idms/usecases/TestCopyIdmsError.java
+++ b/server/dialect-idms/src/test/java/org/eclipse/lsp/cobol/dialects/idms/usecases/TestCopyIdmsError.java
@@ -53,7 +53,7 @@ class TestCopyIdmsError {
             "1",
             new Diagnostic(
                 new Range(),
-                "semantics.emptyStructure",
+                "postprocessing.copybookHasErrors",
                 DiagnosticSeverity.Error,
                 ErrorSource.COPYBOOK.getText()),
             "2",

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/CopybookHierarchy.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/CopybookHierarchy.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp.cobol.common.copybook.CopybookName;
 import org.eclipse.lsp.cobol.common.error.SyntaxError;
 import org.eclipse.lsp.cobol.common.mapping.ExtendedDocument;
-import org.eclipse.lsp.cobol.common.model.Locality;
 import org.eclipse.lsp.cobol.core.model.CopyStatementModifier;
 import org.eclipse.lsp.cobol.core.model.CopybookUsage;
 import org.eclipse.lsp.cobol.core.preprocessor.delegates.replacement.ReplaceData;
@@ -78,12 +77,6 @@ public class CopybookHierarchy {
     recursiveReplaceStmtStack.pollFirst();
   }
 
-  /** @return root document URI */
-  public Optional<String> getRootDocumentUri() {
-    return Optional.ofNullable(copybookStack.peekLast())
-            .map(CopybookUsage::getLocality)
-            .map(Locality::getUri);
-  }
   /**
    * Add a pattern for replacing from COPY statement
    *

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolTextDocumentService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolTextDocumentService.java
@@ -487,7 +487,11 @@ public class CobolTextDocumentService implements TextDocumentService, ExtendedAp
     registerFutureTask(
         uri,
         () -> {
-          doAnalysis(uri, text, userRequest, true);
+          try {
+            doAnalysis(uri, text, userRequest, true);
+          } catch (Throwable th) {
+            LOG.error("Error while processing file: {}, {}", uri, th.getMessage());
+          }
           return null;
         });
     if (!isCopybook(uri, text, copybookExtensions)) {

--- a/server/engine/src/main/resources/resourceBundles/messages_en.properties
+++ b/server/engine/src/main/resources/resourceBundles/messages_en.properties
@@ -35,6 +35,7 @@ parsers.alphaNumeric=Only alphanumerics are allowed for %s
 parsers.startsWith=String must starts with %s values
 parsers.stringLengthRange=String length must be between %s and %s
 parsers.allowedStringValues=Only allowed value(s): %s
+postprocessing.copybookHasErrors=Errors inside the copybook
 ErrorStrategy.endOfFile=Unexpected end of file
 ErrorStrategy.reportInputMismatch=Syntax error on %s expected %s
 ErrorStrategy.reportMissingToken=Missing token %s at %s

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/ClientServerIntegrationTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/ClientServerIntegrationTest.java
@@ -77,9 +77,9 @@ public class ClientServerIntegrationTest extends ConfigurableTest {
           + "           Move {$inner2} of {$outer1} to {$Str}.\n"
           + "           Move {$inner1} of {$outer2} to {$Str}.\n"
           + "           Move {$inner2} of {$outer2} to {$Str}.\n"
-          + "       {_COPY {~CPYBK1}.|1_}\n"
-          + "       {_COPY {~CPYBK2}.|2_}\n"
-          + "       {_COPY {~CPYBK1}.|1_}\n"
+          + "       {_COPY {~CPYBK1|1}.|3_}\n"
+          + "       {_COPY {~CPYBK2|2}.|3_}\n"
+          + "       {_COPY {~CPYBK1|1}.|3_}\n"
           + "       End program ProgramId.";
   @Inject TextDocumentService service;
   @Inject MockLanguageClient client;

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/ClientServerIntegrationTestImpl.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/ClientServerIntegrationTestImpl.java
@@ -50,6 +50,14 @@ public class ClientServerIntegrationTestImpl implements LanguageEngineFacade {
                 new Range(),
                 "Recursive copybook declaration for: CPYBK2",
                 DiagnosticSeverity.Error,
-                ErrorSource.COPYBOOK.getText())));
+                ErrorSource.COPYBOOK.getText()),
+            "3",
+            new Diagnostic(
+                new Range(),
+                "Errors inside the copybook",
+                DiagnosticSeverity.Error,
+                ErrorSource.COPYBOOK.getText())
+        )
+    );
   }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCopybookWithIndirectRecursiveDependencyIsDetected.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCopybookWithIndirectRecursiveDependencyIsDetected.java
@@ -38,10 +38,10 @@ class TestCopybookWithIndirectRecursiveDependencyIsDetected {
           + "        PROGRAM-ID. test1.\n"
           + "        DATA DIVISION.\n"
           + "        WORKING-STORAGE SECTION.\n"
-          + "        {_COPY {~INDIRECT-COPY|3}.|1|3|4_}\n"
+          + "        {_COPY {~INDIRECT-COPY|1|3}.|2_}\n"
           + "        PROCEDURE DIVISION.\n";
 
-  private static final String INDIRECT = "        {_COPY {~INNER-COPY|4}.|1|3_}";
+  private static final String INDIRECT = "        {_COPY {~INNER-COPY|1|4}.|2_}";
   private static final String INNER_COPY = "        {_COPY {~INDIRECT-COPY|3}.|1_}";
 
   private static final String INDIRECT_NAME = "INDIRECT-COPY";
@@ -63,7 +63,7 @@ class TestCopybookWithIndirectRecursiveDependencyIsDetected {
                 new Range(), MESSAGE_RECURSION + INDIRECT_NAME, Error, ErrorSource.COPYBOOK.getText()),
             "2",
             new Diagnostic(
-                new Range(), MESSAGE_RECURSION + INNER_COPY_NAME, Error, ErrorSource.COPYBOOK.getText()),
+                new Range(), "Errors inside the copybook", Error, ErrorSource.COPYBOOK.getText()),
             "3",
             new Diagnostic(
                 new Range(),

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCopybookWithRecursiveDependencyIsDetected.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCopybookWithRecursiveDependencyIsDetected.java
@@ -36,10 +36,10 @@ class TestCopybookWithRecursiveDependencyIsDetected {
           + "        PROGRAM-ID. test1.\r\n"
           + "        DATA DIVISION.\r\n"
           + "        WORKING-STORAGE SECTION.\r\n"
-          + "        {_COPY {~REC-CPY}.|1_}\n\n"
+          + "        {_COPY {~REC-CPY|2}.|1_}\n\n"
           + "        PROCEDURE DIVISION.\n\n";
 
-  private static final String REC_CPY = "        {_COPY {~REC-CPY}.|1_}";
+  private static final String REC_CPY = "        {_COPY {~REC-CPY}.|2_}";
   private static final String REC_CPY_NAME = "REC-CPY";
   private static final String MESSAGE = "Recursive copybook declaration for: " + REC_CPY_NAME;
 
@@ -51,6 +51,9 @@ class TestCopybookWithRecursiveDependencyIsDetected {
         ImmutableList.of(new CobolText(REC_CPY_NAME, REC_CPY)),
         ImmutableMap.of(
             "1",
+            new Diagnostic(
+                new Range(), "Errors inside the copybook", DiagnosticSeverity.Error, ErrorSource.COPYBOOK.getText()),
+            "2",
             new Diagnostic(
                 new Range(), MESSAGE, DiagnosticSeverity.Error, ErrorSource.COPYBOOK.getText())));
   }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestErrorsInDifferentFiles.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestErrorsInDifferentFiles.java
@@ -40,7 +40,7 @@ class TestErrorsInDifferentFiles {
           + "3      Working-Storage Section.\n"
           + "4      Procedure Division.\n"
           + "5      {#*000-Main-Logic}.\n"
-          + "6      {_COPY {~ASDASD}.|child1|areaA1|areaA2|pic_} \n"
+          + "6      {_COPY {~ASDASD}.|error_} \n"
           + "7          DISPLAY {CHILD1|invalid}.\n"
           + "8      End program ProgramId.";
 
@@ -102,11 +102,11 @@ class TestErrorsInDifferentFiles {
                     Warning,
                     ErrorSource.PARSING.getText()))
             .put(
-                "areaA2",
+                "error",
                 new Diagnostic(
                     new Range(),
-                    "The following token must start in Area A: CHILD1",
-                    Warning,
+                    "Errors inside the copybook",
+                    Error,
                     ErrorSource.COPYBOOK.getText()))
                 .put(
                 "areaA22",

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestIdentificationDivisionInCopybookWithError.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestIdentificationDivisionInCopybookWithError.java
@@ -57,7 +57,7 @@ class TestIdentificationDivisionInCopybookWithError {
         ImmutableList.of(new CobolText(IDDIV_NAME, IDDIV), new CobolText(STRUCT1_NAME, STRUCT1)),
         ImmutableMap.of(
             "1",
-            new Diagnostic(new Range(), MESSAGE, Error, ErrorSource.COPYBOOK.getText()),
+            new Diagnostic(new Range(), "Errors inside the copybook", Error, ErrorSource.COPYBOOK.getText()),
             "2",
             new Diagnostic(new Range(), MESSAGE, Error, ErrorSource.PARSING.getText())));
   }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestLineContinuation2.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestLineContinuation2.java
@@ -47,7 +47,7 @@ class TestLineContinuation2 {
             "CBBMAIN",
             new Diagnostic(
                 new Range(),
-                "The following paragraph is not defined: MISSING-PAR",
+                "Errors inside the copybook",
                 Error,
                 "COBOL Language Support (copybook)",
                 null),

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMappingComplexCopybook.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMappingComplexCopybook.java
@@ -82,7 +82,7 @@ class TestMappingComplexCopybook {
             "3",
             new Diagnostic(
                 new Range(new Position(8, 11), new Position(14, 18)),
-                "Variable WRK-DS-05V00-O005-001 is not defined",
+                "Errors inside the copybook",
                 Error,
                 ErrorSource.COPYBOOK.getText())
         )

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMissingNestedCopybookProducesError.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMissingNestedCopybookProducesError.java
@@ -55,10 +55,9 @@ class TestMissingNestedCopybookProducesError {
             "missing",
             new Diagnostic(
                 new Range(),
-                "CPYNAME: Copybook not found",
+                "Errors inside the copybook",
                 Error,
-                ErrorSource.COPYBOOK.getText(),
-                    ErrorCodes.MISSING_COPYBOOK.getLabel()),
+                ErrorSource.COPYBOOK.getText()),
             "missingCpy",
             new Diagnostic(
                 new Range(),

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestNestedCopyReplaceClause.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestNestedCopyReplaceClause.java
@@ -69,7 +69,7 @@ class TestNestedCopyReplaceClause {
             "1",
             new Diagnostic(
                 new Range(),
-                "More than one nested copy replace statement for copybook declaration of: STRUCT1",
+                "Errors inside the copybook",
                 DiagnosticSeverity.Error,
                 ErrorSource.COPYBOOK.getText()),
             "2",

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestReplacingForSeveralTokensInOneLine.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestReplacingForSeveralTokensInOneLine.java
@@ -56,7 +56,7 @@ class TestReplacingForSeveralTokensInOneLine {
         DOCUMENT,
         ImmutableList.of(new CobolText(REPL_NAME, REPL)),
         ImmutableMap.of(
-            "invalid", new Diagnostic(new Range(), MESSAGE, DiagnosticSeverity.Error,  ErrorSource.COPYBOOK.getText()),
+            "invalid", new Diagnostic(new Range(), "Errors inside the copybook", DiagnosticSeverity.Error,  ErrorSource.COPYBOOK.getText()),
             "invalidS", new Diagnostic(new Range(), MESSAGE, DiagnosticSeverity.Error,  ErrorSource.PARSING.getText())
                 ));
   }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSameCopybookStatementsInDifferentPlacesTreatedAsDifferentEntries.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSameCopybookStatementsInDifferentPlacesTreatedAsDifferentEntries.java
@@ -48,8 +48,7 @@ class TestSameCopybookStatementsInDifferentPlacesTreatedAsDifferentEntries {
             "1",
             new Diagnostic(
                 new Range(),
-                "Syntax error on 'DATA' expected {CBL, END, EXEC, FILE, ID, IDENTIFICATION, "
-                    + "LINKAGE, LOCAL-STORAGE, PROCEDURE, PROCESS, WORKING-STORAGE}",
+                "Errors inside the copybook",
                 DiagnosticSeverity.Error,
                 ErrorSource.COPYBOOK.getText(),
                 null),

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSemanticErrorsFromCopybooksShownInDocument.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSemanticErrorsFromCopybooksShownInDocument.java
@@ -52,7 +52,7 @@ class TestSemanticErrorsFromCopybooksShownInDocument {
             "1",
             new Diagnostic(
                 new Range(),
-                "Variable SMTH is not defined",
+                "Errors inside the copybook",
                 DiagnosticSeverity.Error,
                 ErrorSource.COPYBOOK.getText()),
             "2",

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSyntaxErrorTraversedThroughHierarchy.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSyntaxErrorTraversedThroughHierarchy.java
@@ -40,11 +40,11 @@ class TestSyntaxErrorTraversedThroughHierarchy {
           + "       DATA DIVISION.\n"
           + "       WORKING-STORAGE SECTION.\n"
           + "       PROCEDURE DIVISION.\n"
-          + "       {_COPY {~CONT}.|1|2_}\n"
+          + "       {_COPY {~CONT}.|1_}\n"
           + "       {#*MAINLINE}. \n"
           + "           GOBACK. ";
 
-  private static final String CONT = "       {_COPY {~REPL}.|1|2_}";
+  private static final String CONT = "       {_COPY {~REPL}.|1_}";
   private static final String CONT_NAME = "CONT";
 
   private static final String REPL = "       {@*05} {@*TAG-ID|3} {PIC|4} 9.\n";
@@ -59,14 +59,7 @@ class TestSyntaxErrorTraversedThroughHierarchy {
             "1",
             new Diagnostic(
                 new Range(),
-                "Syntax error on 'TAG-ID' expected SECTION",
-                Error,
-                ErrorSource.COPYBOOK.getText(),
-                null),
-            "2",
-            new Diagnostic(
-                new Range(),
-                "Syntax error on 'PIC' expected SECTION",
+                "Errors inside the copybook",
                 Error,
                 ErrorSource.COPYBOOK.getText(),
                 null),


### PR DESCRIPTION
## How Has This Been Tested?
1. Create a COBOL program with a copybook statement
2. Add 2 or more lines that produces errors to the copybook file
3. Ensure that a COBOL program has only 1 error for copybook statement: "Errors inside the copybook" 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
