### PR TITLE
Feature/compiler option in pgrps

### DIFF
--- a/clients/cobol-lsp-vscode-extension/schema/compiler_options.schema.json
+++ b/clients/cobol-lsp-vscode-extension/schema/compiler_options.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "array",
+  "description": "List of compiler options",
+  "items": {
+    "type": "string",
+    "anyOf": [
+      {
+        "pattern": "(?i)ADATA"
+      },
+      {
+        "pattern": "(?i)(XMLPARSE|XP)\\s*\\(\\s*(COMPAT|C_CHAR|XMLSS|X_CHAR)\\s*\\)"
+      },
+      {
+        "pattern": "(?i)(QUALIFY|QUA)\\s*\\(\\s*(COMPAT|C_CHAR|EXTEND|E_CHAR)\\s*\\)"
+      }
+    ]
+  }
+}

--- a/clients/cobol-lsp-vscode-extension/schema/proc_grps.schema.json
+++ b/clients/cobol-lsp-vscode-extension/schema/proc_grps.schema.json
@@ -42,6 +42,9 @@
           "copybook-file-encoding": {
             "type": "string",
             "description": "Copybook file encoding."
+          },
+          "compiler-options": {
+            "$ref": "compiler_options.schema.json"
           }
         }
       },

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroups.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroups.spec.ts
@@ -13,6 +13,7 @@
  */
 
 import {
+  loadProcessorGroupCompileOptionsConfig,
   loadProcessorGroupCopybookEncodingConfig,
   loadProcessorGroupCopybookExtensionsConfig,
   loadProcessorGroupCopybookPaths,
@@ -33,6 +34,7 @@ jest.mock("fs", () => ({
                         "name": "DAF",
                         "copybook-extensions": [".copy"],
                         "copybook-file-encoding": "UTF-8",
+                        "compiler-options": ["QUALIFY(EXTEND)","XMLPARSE(COMPAT)"],
                         "preprocessor": [
                             "IDMS",
                             { 
@@ -193,4 +195,13 @@ it("Processor groups configuration mismatches program with *", () => {
   };
   const result = loadProcessorGroupDialectConfig(item, {});
   expect(result).toStrictEqual({});
+});
+
+it("Processor groups configuration provides compiler-options", () => {
+  const item = {
+    scopeUri: WORKSPACE_URI + "/TEST.cob",
+    section: "cobol-lsp.compiler.options",
+  };
+  const result = loadProcessorGroupCompileOptionsConfig(item, "");
+  expect(result).toStrictEqual(["QUALIFY(EXTEND)", "XMLPARSE(COMPAT)"]);
 });

--- a/clients/cobol-lsp-vscode-extension/src/constants.ts
+++ b/clients/cobol-lsp-vscode-extension/src/constants.ts
@@ -20,6 +20,7 @@ export const SETTINGS_CPY_FILE_ENCODING: string =
   "cobol-lsp.cpy-manager.copybook-file-encoding";
 export const SETTINGS_SQL_BACKEND: string = "cobol-lsp.target-sql-backend";
 export const SETTINGS_DIALECT = "cobol-lsp.dialects";
+export const SETTINGS_COMPILE_OPTIONS = "cobol-lsp.compiler.options";
 export const SETTINGS_SUBROUTINE_LOCAL_KEY =
   "cobol-lsp.subroutine-manager.paths-local";
 export const SETTINGS_TAB_CONFIG: string = "cobol-lsp.smart-tab";

--- a/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
@@ -66,6 +66,17 @@ export function loadProcessorGroupCopybookEncodingConfig(
   );
 }
 
+export function loadProcessorGroupCompileOptionsConfig(
+  item: { scopeUri: string },
+  configObject: string,
+): string {
+  return loadProcessorGroupSettings(
+    item.scopeUri,
+    "compiler-options",
+    configObject,
+  );
+}
+
 export function loadProcessorGroupSqlBackendConfig(
   item: { scopeUri: string },
   configObject: string,

--- a/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
@@ -30,10 +30,12 @@ import {
   SETTINGS_SUBROUTINE_LOCAL_KEY,
   SETTINGS_TAB_CONFIG,
   SETTINGS_SQL_BACKEND,
+  SETTINGS_COMPILE_OPTIONS,
 } from "../constants";
 import cobolSnippets = require("../services/snippetcompletion/cobolSnippets.json");
 import { DialectRegistry, DIALECT_REGISTRY_SECTION } from "./DialectRegistry";
 import {
+  loadProcessorGroupCompileOptionsConfig,
   loadProcessorGroupCopybookEncodingConfig,
   loadProcessorGroupCopybookExtensionsConfig,
   loadProcessorGroupCopybookPaths,
@@ -131,6 +133,12 @@ export function configHandler(request: any): Array<any> {
           result.push(object);
         } else if (item.section === SETTINGS_CPY_FILE_ENCODING) {
           const object = loadProcessorGroupCopybookEncodingConfig(
+            item,
+            cfg as string,
+          );
+          result.push(object);
+        } else if (item.section === SETTINGS_COMPILE_OPTIONS) {
+          const object = loadProcessorGroupCompileOptionsConfig(
             item,
             cfg as string,
           );

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/AnalysisConfig.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/AnalysisConfig.java
@@ -23,6 +23,7 @@ import org.eclipse.lsp.cobol.common.copybook.CopybookConfig;
 import org.eclipse.lsp.cobol.common.copybook.CopybookProcessingMode;
 import org.eclipse.lsp.cobol.common.copybook.SQLBackend;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,7 @@ public class AnalysisConfig {
   boolean isCicsTranslatorEnabled;
   List<DialectRegistryItem> dialectRegistry;
   Map<String, JsonElement> dialectsSettings;
+  List<String> compilerOptions = new ArrayList<>();
 
   /**
    * Create the default language features config, containing all features and the given copybook

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveName.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveName.java
@@ -33,24 +33,30 @@ public enum CompilerDirectiveName {
   QUALIFY {
     @Override
     public Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText) {
-      return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("EXTEND")))
-              .filter(cd -> isContains(directiveText, "QUALIFY(EXTEND)"));
-    }
-  },
-  QUA {
-    @Override
-    public Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText) {
-      return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("EXTEND")))
-              .filter(cd -> isContains(directiveText, "QUA(EXTEND)"));
+      if (isContains(directiveText, "QUALIFY(EXTEND)") || isContains(directiveText, "QUA(EXTEND)")) {
+        return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("EXTEND")));
+      } else if (isContains(directiveText, "QUALIFY(COMPAT)") || isContains(directiveText, "QUA(COMPAT)")) {
+        return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("COMPAT")));
+      } else if (isContains(directiveText, "QUALIFY(E_CHAR)") || isContains(directiveText, "QUA(E_CHAR)")) {
+        return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("E_CHAR")));
+      } else if (isContains(directiveText, "QUALIFY(C_CHAR)") || isContains(directiveText, "QUA(C_CHAR)")) {
+        return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("C_CHAR")));
+      } else {
+        return Optional.empty();
+      }
     }
   },
   XMLPARSE {
     @Override
     public Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText) {
-      if (isContains(directiveText, "XMLPARSE(XMLSS)")) {
+      if (isContains(directiveText, "XMLPARSE(XMLSS)") || isContains(directiveText, "XP(XMLSS)")) {
         return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("XMLSS")));
-      } else if (isContains(directiveText, "XMLPARSE(COMPAT)")) {
+      } else if (isContains(directiveText, "XMLPARSE(COMPAT)") || isContains(directiveText, "XP(COMPAT)")) {
         return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("COMPAT")));
+      } else if (isContains(directiveText, "XMLPARSE(X_CHAR)") || isContains(directiveText, "XP(X_CHAR)")) {
+        return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("X_CHAR")));
+      } else if (isContains(directiveText, "XMLPARSE(C_CHAR)") || isContains(directiveText, "XP(C_CHAR)")) {
+        return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("C_CHAR")));
       } else {
         return Optional.empty();
       }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/ProcessingContext.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/ProcessingContext.java
@@ -37,8 +37,12 @@ public class ProcessingContext {
 
     final List<SyntaxError> errors;
     final VariableAccumulator variableAccumulator;
-    private final CompilerDirectiveContext compilerDirectiveContext = new CompilerDirectiveContext();
+    private final CompilerDirectiveContext compilerDirectiveContext;
     private final Map<String, JsonElement> dialectsConfig;
+
+    public ProcessingContext(List<SyntaxError> errors, VariableAccumulator variableAccumulator, Map<String, JsonElement> dialectsConfig) {
+        this(errors, variableAccumulator, new CompilerDirectiveContext(), dialectsConfig);
+    }
 
     /**
      * Register node type processor

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/QualifiedReferenceUpdateVariableUsage.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/QualifiedReferenceUpdateVariableUsage.java
@@ -59,7 +59,7 @@ public class QualifiedReferenceUpdateVariableUsage implements Processor<Qualifie
         ctx
             .getCompilerDirectiveContext()
             .filterDirectiveList(
-                ImmutableList.of(CompilerDirectiveName.QUALIFY, CompilerDirectiveName.QUA))
+                ImmutableList.of(CompilerDirectiveName.QUALIFY))
             .stream()
             .filter(t -> !t.getValue().isEmpty())
             .map(t -> t.getValue().get(t.getValue().size() - 1).equals("EXTEND"))

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/AnalysisConfigHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/AnalysisConfigHelper.java
@@ -36,9 +36,11 @@ class AnalysisConfigHelper {
       CopybookProcessingMode mode, ConfigurationService.ConfigurationEntity entity) {
     CopybookConfig copybookConfig = new CopybookConfig(mode, entity.getSqlBackend());
 
-    return new AnalysisConfig(copybookConfig, entity.getFeatures(), entity.getDialects(),
-        entity.isCicsTranslatorEnabled(),
-        entity.getDialectRegistry(),
-        entity.getDialectsSettings());
+    AnalysisConfig analysisConfig = new AnalysisConfig(copybookConfig, entity.getFeatures(), entity.getDialects(),
+            entity.isCicsTranslatorEnabled(),
+            entity.getDialectRegistry(),
+            entity.getDialectsSettings());
+    analysisConfig.getCompilerOptions().addAll(entity.getCompilerOptions());
+    return analysisConfig;
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/CachingConfigurationService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/CachingConfigurationService.java
@@ -51,7 +51,8 @@ public class CachingConfigurationService implements ConfigurationService {
         DIALECTS.label,
         SUBROUTINE_LOCAL_PATHS.label,
         CICS_TRANSLATOR_ENABLED.label,
-        DIALECT_REGISTRY.label));
+        DIALECT_REGISTRY.label,
+        COMPILER_OPTIONS.label));
 
     List<String> dialectsSections = dialectService.getSettingsSections();
     settingsList.addAll(dialectsSections);
@@ -114,7 +115,8 @@ public class CachingConfigurationService implements ConfigurationService {
             ConfigHelper.parseSubroutineFolder((JsonElement) clientConfig.get(3)),
             ConfigHelper.parseCicsTranslatorOption((JsonElement) clientConfig.get(4)),
             ConfigHelper.parseDialectRegistry((JsonArray) clientConfig.get(5)),
-        getDialectsSettings(clientConfig.subList(6, 6 + dialectsSections.size()).toArray(), dialectsSections.toArray())
+            ConfigHelper.parseCompilerOptions(clientConfig.get(6)),
+        getDialectsSettings(clientConfig.subList(7, 7 + dialectsSections.size()).toArray(), dialectsSections.toArray())
         );
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
@@ -148,4 +148,18 @@ public class ConfigHelper {
     }
     return ImmutableList.of();
   }
+
+  /**
+   * Parse compiler options client configurations
+   * @param jsonElements configured compiler options
+   * @return List of configured compiler options
+   */
+    public static List<String> parseCompilerOptions(Object jsonElements) {
+    if (jsonElements instanceof JsonArray) {
+      return Streams.stream((JsonArray) jsonElements)
+          .map(JsonElement::getAsString)
+          .collect(toList());
+    }
+    return ImmutableList.of();
+  }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigurationService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigurationService.java
@@ -60,6 +60,7 @@ public interface ConfigurationService {
     List<String> subroutines;
     boolean cicsTranslatorEnabled;
     List<DialectRegistryItem> dialectRegistry;
+    List<String> compilerOptions;
     Map<String, JsonElement> dialectsSettings;
 
     public ConfigurationEntity() {
@@ -69,6 +70,7 @@ public interface ConfigurationService {
       subroutines = ImmutableList.of();
       cicsTranslatorEnabled = true;
       dialectRegistry = ImmutableList.of();
+      compilerOptions = ImmutableList.of();
       dialectsSettings = ImmutableMap.of();
     }
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/SettingsParametersEnum.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/SettingsParametersEnum.java
@@ -35,6 +35,7 @@ public enum SettingsParametersEnum {
   ANALYSIS_FEATURES("analysis.features"),
   DIALECTS("dialects"),
   CICS_TRANSLATOR_ENABLED("cics.translator"),
+  COMPILER_OPTIONS("compiler.options"),
   DIALECT_REGISTRY("dialect.registry");
 
   public final String label;

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CachingConfigurationServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CachingConfigurationServiceTest.java
@@ -84,6 +84,7 @@ class CachingConfigurationServiceTest {
             subroutines,
             new JsonPrimitive("true"),
             new JsonArray(),
+            new JsonArray(),
             predefinedParagraphs);
 
     when(settingsService.fetchConfigurations("",
@@ -94,6 +95,7 @@ class CachingConfigurationServiceTest {
                 SUBROUTINE_LOCAL_PATHS.label,
                 CICS_TRANSLATOR_ENABLED.label,
                 DIALECT_REGISTRY.label,
+                COMPILER_OPTIONS.label,
                 "dialect")))
         .thenReturn(supplyAsync(() -> clientConfig));
 
@@ -130,6 +132,7 @@ class CachingConfigurationServiceTest {
             subroutineSettings,
             new JsonNull(),
             new JsonArray(),
+             new JsonArray(),
             dialectsSettings);
     when(settingsService.fetchConfigurations("",
             Arrays.asList(
@@ -139,6 +142,7 @@ class CachingConfigurationServiceTest {
                 SUBROUTINE_LOCAL_PATHS.label,
                 CICS_TRANSLATOR_ENABLED.label,
                 DIALECT_REGISTRY.label,
+                COMPILER_OPTIONS.label,
                 "dialect")))
         .thenReturn(supplyAsync(() -> clientConfig));
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/DialectConfigs.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/DialectConfigs.java
@@ -49,6 +49,6 @@ public class DialectConfigs {
             ImmutableList.of(),
             ImmutableList.of("DaCo", "IDMS"), true,
             ImmutableList.of(),
-        ImmutableMap.of("daco.predefined-sections", new Gson().toJsonTree(list)));
+            ImmutableMap.of("daco.predefined-sections", new Gson().toJsonTree(list)));
   }
 }

--- a/server/test/src/main/java/org/eclipse/lsp/cobol/test/engine/UseCase.java
+++ b/server/test/src/main/java/org/eclipse/lsp/cobol/test/engine/UseCase.java
@@ -56,6 +56,9 @@ public class UseCase {
   /** Dialects config */
   @Builder.Default Map<String, JsonElement> dialectsSettings = ImmutableMap.of();
 
+  /** Compile options config */
+  @Builder.Default List<String> compilerOptions = Collections.emptyList();
+
   @Builder.Default boolean cicsTranslator = true;
   /**
    * Get the {@link AnalysisConfig} using the specified processing mode and the {@link SQLBackend}
@@ -64,12 +67,14 @@ public class UseCase {
    * @return CopybookConfig for the analysis
    */
   public AnalysisConfig getAnalysisConfig() {
-    return new AnalysisConfig(
-        new CopybookConfig(copybookProcessingMode, sqlBackend),
-        features,
-        dialects,
-        cicsTranslator,
-        ImmutableList.of(),
-        dialectsSettings);
+    AnalysisConfig analysisConfig = new AnalysisConfig(
+            new CopybookConfig(copybookProcessingMode, sqlBackend),
+            features,
+            dialects,
+            cicsTranslator,
+            ImmutableList.of(),
+            dialectsSettings);
+    analysisConfig.getCompilerOptions().addAll(compilerOptions);
+    return analysisConfig;
   }
 }

--- a/server/test/src/main/java/org/eclipse/lsp/cobol/test/engine/UseCaseEngine.java
+++ b/server/test/src/main/java/org/eclipse/lsp/cobol/test/engine/UseCaseEngine.java
@@ -215,6 +215,7 @@ public class UseCaseEngine {
                 .features(analysisConfig.getFeatures())
                 .dialects(analysisConfig.getDialects())
                 .dialectsSettings(analysisConfig.getDialectsSettings())
+                .compilerOptions(analysisConfig.getCompilerOptions())
                 .build());
     assertResultEquals(actual, document.getTestData());
     return actual;


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test below code only works when the processor group has a compiler-options configuration as QUALIFY(EXTEND)
`"compiler-options": ["QUALIFY(EXTEND)"],`
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. 'demo' RECURSIVE.
       ENVIRONMENT DIVISION.
       INPUT-OUTPUT SECTION.
       FILE-CONTROL.
       DATA DIVISION.
       FILE SECTION.
       WORKING-STORAGE SECTION.
       LOCAL-STORAGE SECTION.
       LINKAGE SECTION.
       1 s.
         3 data1.
           5 value1 USAGE POINTER.
           5 size1 PIC S9(9) COMP-5.
           5 capacity PIC S9(9) COMP-5.
       1 value1.
         3 ptr USAGE POINTER.
         3 siz PIC S9(9) COMP-5.
       PROCEDURE DIVISION USING s value1.
           >>CALLINTERFACE STATIC
           CALL "something" USING data1 IN s value1
           >>CALLINTERFACE DYNAMIC
           GOBACK.
       END PROGRAM 'demo'.
``` 


## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
