### PR TITLE
fix: coloring for quoted string

### DIFF
--- a/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
+++ b/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
@@ -2,41 +2,60 @@
   "scopeName": "source.cobol",
   "patterns": [
     {
-      "include": "#comment-line"
+      "include": "#comment-cobol-source"
     },
     {
-      "include": "#comment-floating"
-    },
-    {
-      "include": "#number-constant"
-    },
-    {
-      "include": "#string-quoted-constant"
-    },
-    {
-      "include": "#string-double-quoted-constant"
-    },
-    {
-      "include": "#picture"
-    },
-    {
-      "include": "#sql-block"
-    },
-    {
-      "include": "#cics-block"
-    },
-    {
-      "include": "#cobol-keywords"
-    },
-    {
-      "include": "#cobol-preprocessor-keywords"
-    },
-    {
-      "include": "#idms-keywords"
+      "include": "#cobol-source"
     }
   ],
   "repository": {
-    "comment-line": {
+    "cobol-source": {
+      "match": "(^.{6})(.)(.*?$)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#number-constant"
+            }
+          ]
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#comment-floating"
+            },
+            {
+              "include": "#string-quoted-constant"
+            },
+            {
+              "include": "#string-double-quoted-constant"
+            },
+            {
+              "include": "#number-constant"
+            },
+            {
+              "include": "#picture"
+            },
+            {
+              "include": "#sql-block"
+            },
+            {
+              "include": "#cics-block"
+            },
+            {
+              "include": "#cobol-keywords"
+            },
+            {
+              "include": "#cobol-preprocessor-keywords"
+            },
+            {
+              "include": "#idms-keywords"
+            }
+          ] 
+        }
+      }
+    },
+    "comment-cobol-source": {
       "match": "^(.{6})(\\/.*|\\*.*)$",
       "captures": {
         "1": {
@@ -45,8 +64,8 @@
         "2": {
           "name": "comment.line.cobol.fixed"
         }
-      }
-    },
+    }
+  },
     "comment-floating": {
       "match": "\\s\\*>\\s.*",
       "name": "comment.line.cobol.floating"


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
NOTE: Issue is not fully resolved, its just localized to 7th position with the PR
- [x] Test coloring for the below code
```cobol
PC0704 FD  VFF998S                                                              
  "        LABEL RECORD STANDARD                                                
  "        BLOCK CONTAINS 0 RECORDS                                             
  "        RECORDING MODE IS F                                                  
  "        DATA RECORD IS F998-REC-VFF998. 
``` 
 wrong coloring:
 
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/95b215e7-fba0-43f8-9e68-ff921c4fa1d9)

expected coloring:
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/6336a836-8c17-48ab-931a-caef28558210)


## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
