### PR TITLE
chore: set maven to use UTF-8

### DIFF
--- a/server/common/pom.xml
+++ b/server/common/pom.xml
@@ -39,6 +39,8 @@
         <maven.cobertura.plugin.version>2.7</maven.cobertura.plugin.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/server/dialect-daco/pom.xml
+++ b/server/dialect-daco/pom.xml
@@ -37,6 +37,8 @@
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/server/dialect-idms/pom.xml
+++ b/server/dialect-idms/pom.xml
@@ -38,6 +38,8 @@
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/server/parser/pom.xml
+++ b/server/parser/pom.xml
@@ -37,6 +37,8 @@
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
         <maven.cobertura.plugin.version>2.7</maven.cobertura.plugin.version>
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
     <dependencies>
         <dependency>

--- a/server/test/pom.xml
+++ b/server/test/pom.xml
@@ -28,6 +28,8 @@
         <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
         <guice.version>4.2.2</guice.version>
         <autoservice.version>1.0.1</autoservice.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Encoding warnings in the build should go away now.
# Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
