### PR TITLE
feature: show copybooks preprocess errors

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/copybook/CopybookService.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/copybook/CopybookService.java
@@ -15,6 +15,7 @@
 package org.eclipse.lsp.cobol.common.copybook;
 
 import lombok.NonNull;
+import org.eclipse.lsp.cobol.common.ResultWithErrors;
 
 /**
  * Provide API definition to search for copybooks files. The service also caches copybook to reduce
@@ -27,6 +28,7 @@ public interface CopybookService {
 
   /**
    * Retrieve and return the copybook by its name.
+   * Returns a CopybookModel and preprocessed errors for the resolved copybook wrapped inside {@link ResultWithErrors}.
    *
    * @param copybookId - the id of the copybook to be retrieved
    * @param copybookName - the name of the copybook to be retrieved
@@ -35,9 +37,10 @@ public interface CopybookService {
    * @param copybookConfig - contains config info like: copybook processing mode, target backend sql
    *     server
    * @param preprocess - indicates if copybook needs to be preprocessed after resolving
-   * @return a CopybookModel that contains copybook name, its URI and the content
+   * @return a CopybookModel wrapped inside {@link ResultWithErrors} which contains copybook name, its URI and the content.
+   *         Wrapped errors are preprocessed errors for the returned CopybookModel.
    */
-  CopybookModel resolve(
+  ResultWithErrors<CopybookModel> resolve(
       @NonNull CopybookId copybookId,
       @NonNull CopybookName copybookName,
       @NonNull String programDocumentUri,

--- a/server/dialect-daco/src/main/java/org/eclipse/lsp/cobol/dialects/daco/DaCoMaidProcessor.java
+++ b/server/dialect-daco/src/main/java/org/eclipse/lsp/cobol/dialects/daco/DaCoMaidProcessor.java
@@ -21,6 +21,7 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
+import org.eclipse.lsp.cobol.common.ResultWithErrors;
 import org.eclipse.lsp.cobol.common.VariableConstants;
 import org.eclipse.lsp.cobol.common.copybook.CopybookModel;
 import org.eclipse.lsp.cobol.common.copybook.CopybookName;
@@ -206,14 +207,14 @@ public class DaCoMaidProcessor {
     CopybookName copybookName =
         new CopybookName(
             makeCopybookFileName(startingLevel, layoutId, layoutUsage), DaCoDialect.NAME);
-    CopybookModel copybookModel =
-        copybookService.resolve(
+    ResultWithErrors<CopybookModel> resolvedCopybook = copybookService.resolve(
             copybookName.toCopybookId(context.getExtendedDocument().getUri()),
             copybookName,
             context.getExtendedDocument().getUri(),
             context.getExtendedDocument().getUri(),
             context.getCopybookConfig(),
             true);
+    CopybookModel copybookModel = resolvedCopybook.getResult();
 
     DaCoCopyNode cbNode =
         new DaCoCopyNode(
@@ -226,6 +227,7 @@ public class DaCoMaidProcessor {
             copybookModel.getUri());
 
     if (copybookModel.getContent() != null) {
+      errors.addAll(resolvedCopybook.getErrors());
       checkWrkSuffix(cbNode, layoutUsage, errors);
       String suffix = calculateSuffix(layoutUsage, cbNode);
       parseCopybookContent(copybookModel, startingLevel, suffix)

--- a/server/dialect-daco/src/test/java/org/eclipse/lsp/cobol/dialects/daco/usecases/DaCoCopybookErrors.java
+++ b/server/dialect-daco/src/test/java/org/eclipse/lsp/cobol/dialects/daco/usecases/DaCoCopybookErrors.java
@@ -57,7 +57,7 @@ class DaCoCopybookErrors {
             "1",
             new Diagnostic(
                 new Range(),
-                "A \"PICTURE\" or \"USAGE INDEX\" clause was not found for elementary item LDQLAB1M-XQL",
+                "postprocessing.copybookHasErrors",
                 DiagnosticSeverity.Error,
                 ErrorSource.COPYBOOK.getText()),
             "2",
@@ -65,8 +65,7 @@ class DaCoCopybookErrors {
                 new Range(),
                 "A \"PICTURE\" or \"USAGE INDEX\" clause was not found for elementary item LDQLAB1M-XQL",
                 DiagnosticSeverity.Error,
-                ErrorSource.PARSING.getText())
-        ),
+                ErrorSource.PARSING.getText())),
         ImmutableList.of(),
         DialectConfigs.getDaCoAnalysisConfig());
   }

--- a/server/dialect-daco/src/test/java/org/eclipse/lsp/cobol/dialects/daco/usecases/TestWorkingStorageSectionSize.java
+++ b/server/dialect-daco/src/test/java/org/eclipse/lsp/cobol/dialects/daco/usecases/TestWorkingStorageSectionSize.java
@@ -56,10 +56,10 @@ class TestWorkingStorageSectionSize {
       + "008400 PROCEDURE DIVISION.\n";
 
   private static final String DACO_COPY = "     1 01  {$*LDDATE1M-XDT}.\n"
-      + "     2     03 {$*F00-XDT.                                                       1\n"
-      + "     3       05 {$*JMDPRSGDV-XDT}          PIC X(8)    VALUE SPACE.              1\n"
-      + "     4       05 {$*TYD-NDT}                PIC 9(8)    VALUE ZERO.               9\n"
-      + "     5       05 {$*JMD-NDT}                PIC 9(6)    VALUE ZERO.              17\n";
+      + "     2     03 {$*F00-XDT.                                                     1\n"
+      + "     3       05 {$*JMDPRSGDV-XDT}          PIC X(8)    VALUE SPACE.            1\n"
+      + "     4       05 {$*TYD-NDT}                PIC 9(8)    VALUE ZERO.             9\n"
+      + "     5       05 {$*JMD-NDT}                PIC 9(6)    VALUE ZERO.            17\n";
 
   private static final String NAMES_COPY = "       01  {$*SUBSCHEMA-SETNAMES}.\n"
       + "           03 {$*POLBSS-POLCRI}            PIC X(16)   VALUE\n"

--- a/server/dialect-idms/src/main/java/org/eclipse/lsp/cobol/dialects/idms/IdmsCopybookVisitor.java
+++ b/server/dialect-idms/src/main/java/org/eclipse/lsp/cobol/dialects/idms/IdmsCopybookVisitor.java
@@ -23,6 +23,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.eclipse.lsp.cobol.common.ResultWithErrors;
 import org.eclipse.lsp.cobol.common.copybook.*;
 import org.eclipse.lsp.cobol.common.error.SyntaxError;
 import org.eclipse.lsp.cobol.common.message.MessageService;
@@ -85,15 +86,16 @@ class IdmsCopybookVisitor extends IdmsCopyParserBaseVisitor<List<Node>> {
     String nameToken = optionsContext.getText().toUpperCase();
     CopybookName copybookName = new CopybookName(StringUtils.trimQuotes(nameToken), IdmsDialect.NAME);
 
-    CopybookModel copybookModel = copybookService.resolve(
+    ResultWithErrors<CopybookModel> resolvedCopybook = copybookService.resolve(
             copybookName.toCopybookId(programDocumentUri),
             copybookName,
             programDocumentUri,
             documentUri,
             copybookConfig,
             true);
+    CopybookModel copybookModel = resolvedCopybook.getResult();
     Locality locality = IdmsParserHelper.buildNameRangeLocality(optionsContext, copybookName.getDisplayName(), documentUri);
-
+    errors.addAll(resolvedCopybook.getErrors());
     return idmsCopybookService.processCopybook(copybookModel, calculateLevel(getLevel(ctx)), locality)
         .unwrap(errors::addAll);
   }

--- a/server/dialect-idms/src/main/java/org/eclipse/lsp/cobol/dialects/idms/IdmsDialect.java
+++ b/server/dialect-idms/src/main/java/org/eclipse/lsp/cobol/dialects/idms/IdmsDialect.java
@@ -79,16 +79,17 @@ public final class IdmsDialect implements CobolDialect {
                                   IdmsCopybookDescriptor cb, String programDocumentUri, String currentUri,
                                   Deque<String> copybookStack) {
     CopybookName copybookName = new CopybookName(cb.getName(), IdmsDialect.NAME);
-    CopybookModel copybookModel =
-        copybookService.resolve(
+    ResultWithErrors<CopybookModel> resolvedCopybook = copybookService.resolve(
             copybookName.toCopybookId(programDocumentUri),
             copybookName,
             programDocumentUri,
             currentUri,
             ctx.getCopybookConfig(),
             true);
+    CopybookModel copybookModel = resolvedCopybook.getResult();
 
     if (copybookModel.getUri() == null || copybookModel.getContent() == null) {
+      errors.addAll(resolvedCopybook.getErrors());
       errors.add(ErrorHelper.missingCopybooks(messageService, cb.getUsage(), cb.getName()));
       if (!cb.isInsert()) {
         ctx.getExtendedDocument().replace(cb.getStatement().getRange(), "");

--- a/server/dialect-idms/src/test/java/org/eclipse/lsp/cobol/dialects/idms/IdmsCopybookVisitorTest.java
+++ b/server/dialect-idms/src/test/java/org/eclipse/lsp/cobol/dialects/idms/IdmsCopybookVisitorTest.java
@@ -25,13 +25,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,6 +44,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class IdmsCopybookVisitorTest {
 
+  private static final String PROGRAM_DOCUMENT_URI = "programDocumentUri";
   @Mock
   private CopybookService copybookService;
   @Mock
@@ -53,7 +57,7 @@ class IdmsCopybookVisitorTest {
     Set<CopybookName> processedCopybooks = new HashSet<>();
 
     visitor = new IdmsCopybookVisitor(copybookService, copybookConfig,
-        idmsCopybookService, "programDocumentUri", "documentUri", 1, processedCopybooks);
+        idmsCopybookService, PROGRAM_DOCUMENT_URI, "documentUri", 1, processedCopybooks);
   }
 
   @Test
@@ -61,6 +65,13 @@ class IdmsCopybookVisitorTest {
     IdmsCopyParser.CopyIdmsStatementContext ctx = mock(IdmsCopyParser.CopyIdmsStatementContext.class);
     IdmsCopyParser.CopyIdmsOptionsContext copyContext = mock(IdmsCopyParser.CopyIdmsOptionsContext.class);
     IdmsCopyParser.CopyIdmsSourceContext sourceContext = mock(IdmsCopyParser.CopyIdmsSourceContext.class);
+    CopybookName expectedCopybookName = new CopybookName("copybook", "IDMS");
+    when(copybookService.resolve(any(CopybookId.class), any(CopybookName.class), anyString(), anyString(),
+            any(CopybookConfig.class), anyBoolean()))
+            .thenReturn(
+                    new ResultWithErrors<>(
+                            new CopybookModel(expectedCopybookName.toCopybookId(PROGRAM_DOCUMENT_URI), expectedCopybookName, null, null),
+                            Collections.emptyList()));
 
     when(ctx.copyIdmsOptions()).thenReturn(copyContext);
     when(copyContext.copyIdmsSource()).thenReturn(sourceContext);

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/copybooks/CopybookPreprocessorService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/copybooks/CopybookPreprocessorService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.lsp.cobol.common.ResultWithErrors;
 import org.eclipse.lsp.cobol.common.copybook.*;
 import org.eclipse.lsp.cobol.common.error.SyntaxError;
 import org.eclipse.lsp.cobol.common.mapping.ExtendedDocument;
@@ -232,16 +233,18 @@ class CopybookPreprocessorService {
   }
 
   private CopybookModel read(CopybookConfig copybookConfig, CopybookName copybookName, String documentUri) {
-    CopybookModel copybookModel = copybookService.resolve(
-        copybookName.toCopybookId(programDocumentUri),
-        copybookName,
-        programDocumentUri,
-        documentUri,
-        copybookConfig,
-        true);
+    ResultWithErrors<CopybookModel> resolvedCopybook = copybookService.resolve(
+            copybookName.toCopybookId(programDocumentUri),
+            copybookName,
+            programDocumentUri,
+            documentUri,
+            copybookConfig,
+            true);
+    CopybookModel copybookModel = resolvedCopybook.getResult();
     if (copybookModel.getContent() == null) {
       return null;
     }
+    errors.addAll(resolvedCopybook.getErrors());
     return copybookModel;
   }
 


### PR DESCRIPTION
show copybooks preprocess errors

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A

      1.        Introduce an error in a copybook by inserting chars past 80 chars.
      2.        OPen a cobol program which uses the above copybook
      3.        Expect error in the copybook for chars more than 80 in a line
      4.        Remove unwanted chars from the copybook, this should remove the error from the problem view

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
