### PR TITLE
fix: tolerate FD label records mis match clause as per IBM doc

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestFDLabelRecordToleration.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestFDLabelRecordToleration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test that COBOL LS engine tolerate wrong syntax for label record like compiler. As per <a
+ * href="https://www.ibm.com/docs/en/cobol-zos/6.3?topic=division-data-file-description-entries">IBM
+ * Doc</a> LABEL RECORDS should e followed by ARE and LABEL RECORD should be followed by IS. But the
+ * cobol compiler tolerate LABEL RECORD ARE and RECORDS IS, this class tests this toleration.
+ */
+public class TestFDLabelRecordToleration {
+
+  private static final String BASE =
+      "000900 IDENTIFICATION DIVISION.                                         00000900\n"
+          + "001000 PROGRAM-ID. ABCDEFGH.                                            00001000\n"
+          + "001100 ENVIRONMENT DIVISION.                                            00001100\n"
+          + "001200 INPUT-OUTPUT SECTION.                                            00001200\n"
+          + "001300 FILE-CONTROL.                                                    00001300\n"
+          + "001400     SELECT {$ABCD} ASSIGN TO ABCDEFG                           \n"
+          + "001500            ORGANIZATION IS INDEXED. \n"
+          + "002300 DATA DIVISION.                                                   00002300\n"
+          + "002400 FILE SECTION.                                                    00002400\n"
+          + "002500 FD  {$*ABCD}                                                         00002500\n";
+  private static final String SUFFIX =
+      "002800     DATA RECORD IS {$AAAAAAAAAA}.                                   00002800\n"
+          + "       01 {$*AAAAAAAAAA} PIC 9(2).\n";
+  private static final String TEXT_TOLERATE_RECORDS_IS =
+      BASE
+          + "               LABEL RECORDS IS OMITTED                                 01510000\n"
+          + SUFFIX;
+
+  private static final String TEXT_TOLERATE_RECORD_ARE =
+      BASE + "               LABEL RECORD ARE OMITTED                              \n" + SUFFIX;
+
+  @Test
+  void test1() {
+    UseCaseEngine.runTest(TEXT_TOLERATE_RECORDS_IS, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void test2() {
+    UseCaseEngine.runTest(TEXT_TOLERATE_RECORD_ARE, ImmutableList.of(), ImmutableMap.of());
+  }
+}

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -642,7 +642,7 @@ recordContainsTo
    ;
 
 labelRecordsClause
-   : LABEL (RECORD IS? | RECORDS ARE?) (OMITTED | STANDARD | dataName*)
+   : LABEL (RECORD | RECORDS) (IS | ARE)? (OMITTED | STANDARD | dataName*)
    ;
 
 valueOfClause


### PR DESCRIPTION
As per https://www.ibm.com/docs/en/cobol-zos/6.3?topic=division-data-file-description-entries LABEL RECORDS should be followed by ARE and LABEL RECORD should be followed by optional IS. But the cobol compiler tolerates mismatch i.e. RECORDS IS and RECORD ARE. This PR adds the same toleration to COBOL LS.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Following code should not throw any error
```cobol
       IDENTIFICATION DIVISION.                                         00010000
      *-----------------------                                          00020000
       PROGRAM-ID.       DEMO.                                          00030014
       ENVIRONMENT DIVISION.                                            01290000
      *--------------------                                             01300000
       CONFIGURATION SECTION.                                           01310000
       INPUT-OUTPUT SECTION.                                            01330000
       FILE-CONTROL.                                                    01340000
           SELECT REPOUT                                                01370000
                  ASSIGN TO UT-S-SYSPRINT.                              01380002
                                                                        01390000
       DATA DIVISION.                                                   01400000
      *-------------                                                    01410000
       FILE SECTION.                                                    01420000
       FD  REPOUT                                                       01490000
               RECORD CONTAINS 120 CHARACTERS                           01500000
               LABEL RECORDS IS OMITTED                                 01510000
               DATA RECORD IS REPREC.                                   01520000
       01  REPREC                     PIC X(120).                       01530000

``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
