### PR TITLE
fix: fix copybookName completion list in case of glob patterns

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroups.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroups.spec.ts
@@ -11,7 +11,7 @@
  * Contributors:
  *   Broadcom, Inc. - initial API and implementation
  */
-
+jest.mock("glob");
 import {
   loadProcessorGroupCopybookEncodingConfig,
   loadProcessorGroupCopybookExtensionsConfig,
@@ -20,6 +20,7 @@ import {
   loadProcessorGroupDialectConfig,
   loadProcessorGroupSqlBackendConfig,
 } from "../../services/ProcessorGroups";
+import { globSync } from "glob";
 
 const WORKSPACE_URI = "file:///my/workspace";
 
@@ -111,8 +112,12 @@ it("Processor groups configuration provides lib path", () => {
     scopeUri: WORKSPACE_URI + "/TEST.cob",
     section: "cobol-lsp.cpy-manager.paths-local",
   };
+  (globSync as any) = jest.fn().mockImplementation((config: string[]) => {
+    if (config[0] === "/copy") return ["/copy-resolved-from-glob"];
+    else throw Error("some issue with input param");
+  });
   const result = loadProcessorGroupCopybookPathsConfig(item, []);
-  expect(result).toStrictEqual(["/copy"]);
+  expect(result).toStrictEqual(["/copy-resolved-from-glob"]);
 });
 
 it("Processor groups configuration understend absolute paths", () => {
@@ -120,8 +125,12 @@ it("Processor groups configuration understend absolute paths", () => {
     scopeUri: WORKSPACE_URI + "/abs/TEST.cob",
     section: "cobol-lsp.cpy-manager.paths-local",
   };
+  (globSync as any) = jest.fn().mockImplementation((config: string[]) => {
+    if (config[0] === "/abs") return ["/copy-resolved-from-glob"];
+    else throw Error("some issue with input param");
+  });
   const result = loadProcessorGroupCopybookPathsConfig(item, []);
-  expect(result).toStrictEqual(["/abs"]);
+  expect(result).toStrictEqual(["/copy-resolved-from-glob"]);
 });
 
 it("Processor groups configuration provides copybook-extensions", () => {

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroupsWindows.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroupsWindows.spec.ts
@@ -11,8 +11,9 @@
  * Contributors:
  *   Broadcom, Inc. - initial API and implementation
  */
-
+jest.mock("glob");
 import { loadProcessorGroupCopybookPathsConfig } from "../../services/ProcessorGroups";
+import { globSync } from "glob";
 
 const WORKSPACE_URI = "file:///my/workspace";
 
@@ -100,7 +101,10 @@ it.only("Processor groups configuration provides lib path in Windows", () => {
     scopeUri: "file:///c%3A/my/workspace" + "/TEST.cob",
     section: "cobol-lsp.cpy-manager.paths-local",
   };
-
+  (globSync as any) = jest.fn().mockImplementation((config: string[]) => {
+    if (config[0] === "/copy") return ["/copy-resolved-from-glob"];
+    else throw Error("some issue with input param");
+  });
   const result = loadProcessorGroupCopybookPathsConfig(item, []);
-  expect(result).toStrictEqual(["/copy"]);
+  expect(result).toStrictEqual(["/copy-resolved-from-glob"]);
 });

--- a/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
@@ -16,6 +16,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { Minimatch } from "minimatch";
 import { SettingsUtils } from "./util/SettingsUtils";
+import { globSync } from "glob";
 import { Uri } from "vscode";
 
 const PROCESSOR_GROUP_FOLDER = ".cobolplugin";
@@ -38,10 +39,11 @@ export function loadProcessorGroupCopybookPathsConfig(
   item: { scopeUri: string },
   configObject: string[],
 ): string[] {
-  return [
+  const config = [
     ...loadProcessorGroupSettings(item.scopeUri, "libs", [] as string[]),
     ...configObject,
   ];
+  return globSync(config);
 }
 
 export function loadProcessorGroupCopybookExtensionsConfig(

--- a/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
@@ -15,7 +15,7 @@
 import { existsSync, readdirSync } from "fs";
 import * as fs from "fs";
 import * as path from "path";
-import * as glob from "glob";
+import { globSync, hasMagic } from "glob";
 import * as urlUtil from "url";
 import { SettingsUtils } from "./SettingsUtils";
 import { Uri } from "vscode";
@@ -121,7 +121,7 @@ function globSearch(
   const segments = pathName.split(path.sep);
   const cwdSegments: string[] = [];
   for (const s of segments) {
-    if (!glob.hasMagic(s)) {
+    if (!hasMagic(s)) {
       cwdSegments.push(s);
     } else {
       break;
@@ -141,9 +141,9 @@ function globSearch(
     copybookName +
     ext;
   pattern = pattern + suffix;
-  const result = glob.sync(pattern, { cwd, dot: true });
+  const result = globSync(pattern, { cwd, dot: true });
   // TODO report the case with more then one copybook fit the pattern.
-  return result[0] ? path.join(cwd, result[0]) : undefined;
+  return result[0] ? path.resolve(cwd, result[0]) : undefined;
 }
 
 export function getProgramNameFromUri(


### PR DESCRIPTION
The idea is to resolve the glob pattern at the client end so that the glob pattern behaves in the same manner for all functionality. 

## How Has This Been Tested?
- [x] Test copybookName completion for a copybook resolved by a configuration with a glob pattern in its value.
For e.g. `cobol-lsp.cpy-manager.paths-local: ["/somePath/**/COPY]` , And try to get completion for copybooks in this folder

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
