### PR TITLE
fix: fix runtime copybook watchers

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
@@ -138,6 +138,7 @@ export class LanguageClientService {
         fileEvents: [
           vscode.workspace.createFileSystemWatcher("**/pgm_conf.json"),
           vscode.workspace.createFileSystemWatcher("**/proc_grps.json"),
+          vscode.workspace.createFileSystemWatcher("**/.copybooks/**/*")
         ],
       },
     };

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolLanguageServer.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolLanguageServer.java
@@ -24,11 +24,9 @@ import org.eclipse.lsp.cobol.common.error.ErrorCodes;
 import org.eclipse.lsp.cobol.common.message.LocaleStore;
 import org.eclipse.lsp.cobol.common.message.MessageService;
 import org.eclipse.lsp.cobol.common.utils.LogLevelUtils;
-import org.eclipse.lsp.cobol.core.engine.dialects.DialectService;
 import org.eclipse.lsp.cobol.lsp.DisposableLSPStateService;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookNameService;
 import org.eclipse.lsp.cobol.service.delegates.completions.Keywords;
-import org.eclipse.lsp.cobol.service.settings.ConfigurationService;
 import org.eclipse.lsp.cobol.service.settings.SettingsService;
 import org.eclipse.lsp.cobol.service.utils.CustomThreadPoolExecutor;
 import org.eclipse.lsp4j.*;
@@ -61,10 +59,8 @@ public class CobolLanguageServer implements LanguageServer {
   private final SettingsService settingsService;
   private final LocaleStore localeStore;
   private final CustomThreadPoolExecutor customThreadPoolExecutor;
-  private final ConfigurationService configurationService;
   private final CopybookNameService copybookNameService;
   private final Keywords keywords;
-  private final DialectService dialectService;
   private final MessageService messageService;
 
   @Inject
@@ -77,10 +73,8 @@ public class CobolLanguageServer implements LanguageServer {
       LocaleStore localeStore,
       CustomThreadPoolExecutor customThreadPoolExecutor,
       DisposableLSPStateService disposableLSPStateService,
-      ConfigurationService configurationService,
       CopybookNameService copybookNameService,
       Keywords keywords,
-      DialectService dialectService,
       MessageService messageService) {
     this.textService = textService;
     this.workspaceService = workspaceService;
@@ -89,10 +83,8 @@ public class CobolLanguageServer implements LanguageServer {
     this.localeStore = localeStore;
     this.customThreadPoolExecutor = customThreadPoolExecutor;
     this.disposableLSPStateService = disposableLSPStateService;
-    this.configurationService = configurationService;
     this.copybookNameService = copybookNameService;
     this.keywords = keywords;
-    this.dialectService = dialectService;
     this.messageService = messageService;
   }
 
@@ -147,8 +139,6 @@ public class CobolLanguageServer implements LanguageServer {
   @Override
   public void initialized(@Nullable InitializedParams params) {
     watchingService.watchConfigurationChange();
-    watchingService.watchPredefinedFolder();
-    addLocalFilesWatcher();
     getLocaleFromClient();
     getLogLevelFromClient();
     copybookNameService.collectLocalCopybookNames();
@@ -222,21 +212,6 @@ public class CobolLanguageServer implements LanguageServer {
     int exitCode = disposableLSPStateService.getExitCode();
     LOG.info("COBOL LS server exits with code: " + exitCode);
     System.exit(exitCode);
-  }
-
-  private void addLocalFilesWatcher() {
-    settingsService
-        .fetchTextConfiguration(CPY_LOCAL_PATHS.label)
-        .thenAccept(watchingService::addWatchers);
-
-    dialectService.getWatchingFolderSettings()
-            .forEach(s -> settingsService
-                .fetchTextConfiguration(s)
-                .thenAccept(watchingService::addWatchers));
-
-    settingsService
-        .fetchTextConfiguration(SUBROUTINE_LOCAL_PATHS.label)
-        .thenAccept(watchingService::addWatchers);
   }
 
   @NonNull

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolTextDocumentService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolTextDocumentService.java
@@ -96,7 +96,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -336,6 +339,7 @@ public class CobolTextDocumentService implements TextDocumentService, ExtendedAp
       registerDocument(uri, new CobolDocumentModel(uri, text));
     }
     analyzeDocumentFirstTime(uri, text, false);
+    watcherService.addRuntimeWatchers(uri);
   }
 
   private boolean isCopybook(String uri, String text, List<String> copybookExtensions) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/WatcherService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/WatcherService.java
@@ -28,9 +28,6 @@ public interface WatcherService {
   /** Subscribe to notifications that the settings.json changed */
   void watchConfigurationChange();
 
-  /** Watch all types of file system changes in .copybooks folder */
-  void watchPredefinedFolder();
-
   /**
    * Watch all types of file system changes in folders with given paths relative to workspace folder
    *
@@ -39,12 +36,12 @@ public interface WatcherService {
   void addWatchers(@NonNull List<String> paths);
 
   /**
-   * Watch all types of file system changes in folders with given paths relative to workspace folder
+   * Add Watchers for all types of file system changes for the copybooks specific to a document.
+   * This includes dialects watching folders.
    *
-   * @param paths - folders inside workspace to watch
    * @param documentUri - documents for which specified path need to be watched.
    */
-  void addRuntimeWatchers(@NonNull List<String> paths, String documentUri);
+  void addRuntimeWatchers(String documentUri);
 
   /**
    * Stop watching all types of file system changes in folders with given paths relative to

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/CachingConfigurationService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/CachingConfigurationService.java
@@ -99,6 +99,16 @@ public class CachingConfigurationService implements ConfigurationService {
     return ImmutableList.of();
   }
 
+  @Override
+  public CompletableFuture<List<String>> getListConfiguration(String documentUri, String section) {
+    return settingsService.fetchTextConfigurationWithScope(documentUri, section);
+  }
+
+  @Override
+  public List<String> getDialectWatchingFolders() {
+    return dialectService.getWatchingFolderSettings();
+  }
+
   private ConfigurationEntity parseConfig(List<Object> clientConfig, List<String> dialectsSections) {
     return Optional.ofNullable(clientConfig)
         .map(cc -> this.parseSettings(cc, dialectsSections))

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigurationService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigurationService.java
@@ -27,6 +27,7 @@ import org.eclipse.lsp.cobol.common.DialectRegistryItem;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /** This interface handles the request for configurations from the client settings */
 public interface ConfigurationService {
@@ -42,10 +43,31 @@ public interface ConfigurationService {
   AnalysisConfig getConfig(String scopeURI, CopybookProcessingMode mode);
 
   /**
-   *Get a Subroutine configuration for the analysis using the settings file
+   * Gets a client configuration for the Subroutine settings
+   *
    * @return the list from the Subroutine directories defined in user settings
    */
   List<String> getSubroutineDirectories();
+
+  /**
+   * Get a list configuration for a document.
+   * For example. "configuration-example" : ["setting1","setting2"]
+   *
+   * <p>NOTE: This method won't work for a single element setting like
+   * "configuration-example" : "setting1"
+   *
+   * @param documentUri document URI for which configuration needs to be fetched.
+   * @param section the required section in the client configuration.
+   * @return the list from the copybook directories defined in user settings
+   */
+  CompletableFuture<List<String>> getListConfiguration(String documentUri, String section);
+
+  /**
+   * Get a list of watching folders for the provided dialects.
+   *
+   * @return List of watching folders for the provided dialects
+   */
+  List<String> getDialectWatchingFolders();
 
   /**
    * A value class to store the configuration. Reflects the required values from the settings.json

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CachingConfigurationServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CachingConfigurationServiceTest.java
@@ -155,4 +155,31 @@ class CachingConfigurationServiceTest {
             ImmutableMap.of("dialect", dialectsSettings)),
         configuration.getConfig("", CopybookProcessingMode.DISABLED));
   }
+
+  @Test
+  void testFetchingListConfiguration() {
+    String expectedValue = "list-of-some-values-from-client";
+    String documentUri = "documentUri";
+    String section = "settings-section";
+    SettingsService settingsService = mock(SettingsService.class);
+    when(settingsService.fetchTextConfigurationWithScope(documentUri, section))
+            .thenReturn(CompletableFuture.completedFuture(ImmutableList.of(expectedValue)));
+    DialectService dialectService = mock(DialectService.class);
+    CachingConfigurationService configuration = new CachingConfigurationService(settingsService, dialectService);
+    configuration.getListConfiguration(documentUri, section)
+            .whenComplete((result, ex) -> {
+              assertEquals(result.size(), 1);
+              assertEquals(result.get(0), expectedValue);
+            });
+  }
+
+  @Test
+  void testGetDialectWatchingFolders() {
+    SettingsService settingsService = mock(SettingsService.class);
+    DialectService dialectService = mock(DialectService.class);
+    String expectedResult = "dialect-watch-folders";
+    when(dialectService.getWatchingFolderSettings()).thenReturn(ImmutableList.of(expectedResult));
+    CachingConfigurationService configuration = new CachingConfigurationService(settingsService, dialectService);
+    assertEquals(configuration.getDialectWatchingFolders().get(0), expectedResult);
+  }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolLanguageServerTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolLanguageServerTest.java
@@ -25,7 +25,6 @@ import org.eclipse.lsp.cobol.core.engine.dialects.DialectService;
 import org.eclipse.lsp.cobol.lsp.DisposableLSPStateService;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookNameService;
 import org.eclipse.lsp.cobol.service.delegates.completions.Keywords;
-import org.eclipse.lsp.cobol.service.settings.ConfigurationService;
 import org.eclipse.lsp.cobol.service.settings.SettingsService;
 import org.eclipse.lsp.cobol.service.settings.SettingsServiceImpl;
 import org.eclipse.lsp.cobol.service.utils.CustomThreadPoolExecutor;
@@ -51,7 +50,6 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.internal.verification.Times;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -93,7 +91,6 @@ class CobolLanguageServerTest {
     SettingsService settingsService = mock(SettingsServiceImpl.class);
     WatcherService watchingService = mock(WatcherService.class);
     LocaleStore localeStore = mock(LocaleStore.class);
-    ConfigurationService configurationService = mock(ConfigurationService.class);
     CopybookNameService copybookNameService = mock(CopybookNameService.class);
     MessageService messageService = mock(MessageService.class);
     Keywords keywords = mock(Keywords.class);
@@ -113,21 +110,16 @@ class CobolLanguageServerTest {
             localeStore,
             customExecutor,
             stateService,
-            configurationService,
             copybookNameService,
             keywords,
-            dialectService,
             messageService);
 
     server.initialized(new InitializedParams());
 
     verify(watchingService).watchConfigurationChange();
-    verify(watchingService).watchPredefinedFolder();
-    verify(settingsService).fetchConfiguration(CPY_LOCAL_PATHS.label);
     verify(settingsService).fetchConfiguration(LOCALE.label);
+    verify(settingsService).fetchConfiguration(LOGGING_LEVEL.label);
     verify(settingsService).fetchConfiguration(CPY_EXTENSIONS.label);
-    verify(settingsService).fetchConfiguration("dialect");
-    verify(watchingService, new Times(2)).addWatchers(singletonList("foo/bar"));
     verify(localeStore).notifyLocaleStore();
   }
 
@@ -156,7 +148,6 @@ class CobolLanguageServerTest {
     SettingsService settingsService = mock(SettingsServiceImpl.class);
     WatcherService watchingService = mock(WatcherService.class);
     LocaleStore localeStore = mock(LocaleStore.class);
-    ConfigurationService configurationService = mock(ConfigurationService.class);
     CopybookNameService copybookNameService = mock(CopybookNameService.class);
     Keywords keywords = mock(Keywords.class);
     CobolTextDocumentService textService = mock(CobolTextDocumentService.class);
@@ -178,10 +169,8 @@ class CobolLanguageServerTest {
             localeStore,
             customExecutor,
             stateService,
-            configurationService,
             copybookNameService,
             keywords,
-            dialectService,
             messageService);
 
     server.initialized(new InitializedParams());
@@ -204,8 +193,6 @@ class CobolLanguageServerTest {
             null,
             customExecutor,
             stateService,
-            null,
-            null,
             null,
             null,
             null);
@@ -260,8 +247,6 @@ class CobolLanguageServerTest {
             null,
             customExecutor,
             stateService,
-            null,
-            null,
             null,
             null,
             null);


### PR DESCRIPTION
## How Has This Been Tested?

- [x] In a workspace, rename a copybook associated with the analyzed COBOL document. See, that the analysis is triggered after rename. Should also check by renaming from the file explorer or terminal.
- [x] After the analyzed document is closed in the VS code, renaming doesn't have any effect.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
