### PR TITLE
fix: respect processor group configuration for copybookName autocompl…

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookResolveURITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookResolveURITest.spec.ts
@@ -13,7 +13,7 @@
  */
 jest.mock("glob");
 
-import { sync } from "glob";
+import { globSync } from "glob";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as vscode from "vscode";
@@ -105,10 +105,10 @@ describe("Resolve local copybook against bad configuration of target folders", (
     expect(
       fsUtils.searchCopybookInWorkspace(copybookName, [], COPYBOOK_EXT_ARRAY),
     ).toBe(undefined);
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
   test("given a folder that not contains copybooks, the target copybook is not retrieved", () => {
-    (sync as any).mockReturnValue([]);
+    (globSync as any) = jest.fn().mockReturnValue([]);
     expect(
       fsUtils.searchCopybookInWorkspace(
         copybookName,
@@ -116,10 +116,10 @@ describe("Resolve local copybook against bad configuration of target folders", (
         COPYBOOK_EXT_ARRAY,
       ),
     ).toBe(undefined);
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
   test("given a not empty folder, a copybook that is not present in that folder is not retrivied and the uri returned is undefined", () => {
-    (sync as any).mockReturnValue([]);
+    (globSync as any) = jest.fn().mockReturnValue([]);
     expect(
       fsUtils.searchCopybookInWorkspace(
         "NSTCPY2",
@@ -127,12 +127,12 @@ describe("Resolve local copybook against bad configuration of target folders", (
         COPYBOOK_EXT_ARRAY,
       ),
     ).toBeUndefined();
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
 });
 describe("Resolve local copybook present in one or more folders specified by the user", () => {
   test("given a folder that contains the target copybook, it is found and its uri is returned", () => {
-    (sync as any).mockReturnValue([copybookName]);
+    (globSync as any) = jest.fn().mockReturnValue([copybookName]);
     expect(
       fsUtils.searchCopybookInWorkspace(
         copybookName,
@@ -140,10 +140,10 @@ describe("Resolve local copybook present in one or more folders specified by the
         COPYBOOK_EXT_ARRAY,
       ),
     ).toBeDefined();
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
   test("given two times the same folder that contains the target copybook, one uri is still returned", () => {
-    (sync as any).mockReturnValue([copybookName]);
+    (globSync as any) = jest.fn().mockReturnValue([copybookName]);
     expect(
       fsUtils.searchCopybookInWorkspace(
         copybookName,
@@ -151,10 +151,10 @@ describe("Resolve local copybook present in one or more folders specified by the
         COPYBOOK_EXT_ARRAY,
       ),
     ).toBeDefined();
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
   test("Given a copybook with extension on filesystem, the uri is correctly returned", () => {
-    (sync as any).mockReturnValue(["NSTCOPY2"]);
+    (globSync as any) = jest.fn().mockReturnValue(["NSTCOPY2"]);
     expect(
       fsUtils.searchCopybookInWorkspace(
         "NSTCOPY2",
@@ -162,10 +162,10 @@ describe("Resolve local copybook present in one or more folders specified by the
         COPYBOOK_EXT_ARRAY,
       ),
     ).toBeDefined();
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
   test("Given a valid relative path for copybook with extension on filesystem, the uri is correctly returned", () => {
-    (sync as any).mockReturnValue(["NSTCOPY2"]);
+    (globSync as any) = jest.fn().mockReturnValue(["NSTCOPY2"]);
     const dir = path.join(__dirname, RELATIVE_CPY_FOLDER_NAME);
     createDirectory(dir);
     createFile(copybookNameWithExtension, dir);
@@ -177,10 +177,10 @@ describe("Resolve local copybook present in one or more folders specified by the
       ),
     ).toBeDefined();
     removeFolder(dir);
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
   test("Given a valid absolute path for copybook with extension on filesystem, the uri is correctly returned", () => {
-    (sync as any).mockReturnValue(["NSTCOPY2"]);
+    (globSync as any) = jest.fn().mockReturnValue(["NSTCOPY2"]);
     expect(
       fsUtils.searchCopybookInWorkspace(
         "NSTCOPY2",
@@ -188,7 +188,7 @@ describe("Resolve local copybook present in one or more folders specified by the
         COPYBOOK_EXT_ARRAY,
       ),
     ).toBeDefined();
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
 });
 describe("With invalid input parameters, the list of URI that represent copybook downloaded are not generated", () => {
@@ -232,7 +232,7 @@ describe("Prioritize search criteria for copybooks test suite", () => {
     vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
       get: jest.fn().mockReturnValue([CPY_FOLDER_NAME]),
     });
-    (sync as any).mockReturnValue([CPY_FOLDER_NAME]);
+    (globSync as any) = jest.fn().mockReturnValue([CPY_FOLDER_NAME]);
     const uri: string = await CopybookURI.resolveCopybookURI(
       copybookName,
       "PRGNAME",
@@ -240,10 +240,10 @@ describe("Prioritize search criteria for copybooks test suite", () => {
     );
     expect(uri).toMatch(CPY_FOLDER_NAME);
     expect(spySearchInWorkspace).toBeCalledTimes(1);
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
   test("With no settings provided, two search strategies are applied and function return an empty string", async () => {
-    (sync as any).mockReturnValue([]);
+    (globSync as any) = jest.fn().mockReturnValue([]);
     provideMockValueForLocalAndDSN("", "");
     ProfileUtils.getProfileNameForCopybook = jest
       .fn()
@@ -255,13 +255,13 @@ describe("Prioritize search criteria for copybooks test suite", () => {
     );
     expect(uri).toBe("");
     expect(spySearchInWorkspace).toBeCalledTimes(2);
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
   test(
     "With both local and dsn references defined in the settings.json, the search is applied on local resources" +
       "first",
     async () => {
-      (sync as any).mockReturnValue(["hi.cbl"]);
+      (globSync as any) = jest.fn().mockReturnValue(["hi.cbl"]);
       provideMockValueForLocalAndDSN(CPY_FOLDER_NAME, "");
       const uri: string = await CopybookURI.resolveCopybookURI(
         copybookName,
@@ -270,14 +270,14 @@ describe("Prioritize search criteria for copybooks test suite", () => {
       );
       expect(uri).not.toBe("");
       expect(spySearchInWorkspace).toBeCalledTimes(1);
-      (sync as any).mockReturnValue((x) => x);
+      (globSync as any) = jest.fn().mockReturnValue((x) => x);
     },
   );
   test("With only a local folder defined for the dialect in the settings.json, the search is applied locally", async () => {
     vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
       get: jest.fn().mockReturnValue([CPY_FOLDER_NAME]),
     });
-    (sync as any).mockReturnValue([CPY_FOLDER_NAME]);
+    (globSync as any) = jest.fn().mockReturnValue([CPY_FOLDER_NAME]);
     const uri: string = await CopybookURI.resolveCopybookURI(
       copybookName,
       "PRGNAME",
@@ -285,6 +285,6 @@ describe("Prioritize search criteria for copybooks test suite", () => {
     );
     expect(uri).toMatch(CPY_FOLDER_NAME);
     expect(spySearchInWorkspace).toBeCalledTimes(1);
-    (sync as any).mockReturnValue((x) => x);
+    (globSync as any) = jest.fn().mockReturnValue((x) => x);
   });
 });

--- a/clients/cobol-lsp-vscode-extension/src/constants.ts
+++ b/clients/cobol-lsp-vscode-extension/src/constants.ts
@@ -27,6 +27,7 @@ export const SETTINGS_TAB_CONFIG: string = "cobol-lsp.smart-tab";
 
 export const SERVER_PORT = "cobol-lsp.server.port";
 export const SERVER_RUNTIME = "cobol-lsp.serverRuntime";
+export const DIALECT_LIBS = "cobol-lsp.dialect.libs";
 export const PATHS_LOCAL_KEY = "paths-local";
 export const PATHS_ZOWE = "paths-dsn";
 export const PATHS_USS = "paths-uss";

--- a/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
@@ -18,6 +18,7 @@ import { Minimatch } from "minimatch";
 import { SettingsUtils } from "./util/SettingsUtils";
 import { globSync } from "glob";
 import { Uri } from "vscode";
+import { backwardSlashRegex, cleanWorkspaceFolder } from "./util/FSUtils";
 
 const PROCESSOR_GROUP_FOLDER = ".cobolplugin";
 const PROCESSOR_GROUP_PGM = "pgm_conf.json";
@@ -43,7 +44,12 @@ export function loadProcessorGroupCopybookPathsConfig(
     ...loadProcessorGroupSettings(item.scopeUri, "libs", [] as string[]),
     ...configObject,
   ];
-  return globSync(config);
+  return SettingsUtils.getWorkspaceFoldersPath(true)
+    .map((folder) => globSync(config.map(ele => ele.replace(backwardSlashRegex, "/")),
+     { cwd: cleanWorkspaceFolder(folder) }))
+    .reduce((acc, curVal) => {
+      return acc.concat(curVal);
+    }, []);
 }
 
 export function loadProcessorGroupCopybookExtensionsConfig(

--- a/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
@@ -31,6 +31,7 @@ import {
   SETTINGS_TAB_CONFIG,
   SETTINGS_SQL_BACKEND,
   SETTINGS_COMPILE_OPTIONS,
+  DIALECT_LIBS,
 } from "../constants";
 import cobolSnippets = require("../services/snippetcompletion/cobolSnippets.json");
 import { DialectRegistry, DIALECT_REGISTRY_SECTION } from "./DialectRegistry";
@@ -119,6 +120,9 @@ export function configHandler(request: any): Array<any> {
             cfg as string[],
           );
           result.push(object);
+        } else if (item.section === DIALECT_LIBS && !!item.dialect) {
+          const dialectLibs = SettingsService.getCopybookLocalPath(item.scopeUri, item.dialect);
+          result.push(dialectLibs);
         } else if (item.section === SETTINGS_CPY_EXTENSIONS) {
           const object = loadProcessorGroupCopybookExtensionsConfig(
             item,

--- a/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
@@ -89,7 +89,7 @@ export function searchCopybookInWorkspace(
   extensions: string[],
 ): string | undefined {
   for (const workspaceFolderPath of SettingsUtils.getWorkspaceFoldersPath()) {
-    const workspaceFolder = workspaceFolderPath.replace(/\/(.*:)/, "$1");
+    const workspaceFolder = cleanWorkspaceFolder(workspaceFolderPath);
     for (const p of copybookFolders) {
       for (const ext of extensions) {
         const searchResult = globSearch(workspaceFolder, p, copybookName, ext);
@@ -108,7 +108,12 @@ export function searchCopybookInWorkspace(
   return undefined;
 }
 
-const backwardSlashRegex = new RegExp("\\\\", "g");
+export const backwardSlashRegex = new RegExp("\\\\", "g");
+
+export function cleanWorkspaceFolder(workspaceFolderPath: string) {
+  return workspaceFolderPath.replace(/\/(.*:)/, "$1");
+}
+
 function globSearch(
   workspaceFolder: string,
   resource: string,

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/CobolConfigItem.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/CobolConfigItem.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.service.settings;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.eclipse.lsp4j.ConfigurationItem;
+
+/**
+ * Represents a text configuration at the client as per LSP. This is an extension of {@link
+ * ConfigurationItem} to accommodate dialect in the configuration requests.
+ */
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
+public class CobolConfigItem extends ConfigurationItem {
+  private String dialect;
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/SettingsService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/SettingsService.java
@@ -49,6 +49,15 @@ public interface SettingsService {
   CompletableFuture<List<String>> fetchTextConfigurationWithScope(String scopeUri, String section);
 
   /**
+   * Fetch the required dialect specific text configuration section from the client.
+   * @param scopeUri the required section
+   * @param section the required section.
+   * @param dialect
+   * @return a list of string of one configuration object.
+   */
+  CompletableFuture<List<String>> fetchTextConfigurationWithScope(String scopeUri, String section, String dialect);
+
+  /**
    * Fetch the required configuration sections from the client. Note that Scope URI is null. The
    * {@link SettingsParametersEnum#LSP_PREFIX LSP prefix} will be added to each specified section.
    *

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/SettingsServiceImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/SettingsServiceImpl.java
@@ -18,6 +18,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Streams;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -57,6 +58,7 @@ public class SettingsServiceImpl implements SettingsService {
             .filter(JsonArray.class::isInstance)
             .map(JsonArray.class::cast)
             .flatMap(Streams::stream)
+            .filter(ele -> !(ele instanceof JsonNull))
             .map(JsonElement::getAsString)
             .collect(toList()));
   }
@@ -67,8 +69,25 @@ public class SettingsServiceImpl implements SettingsService {
             .filter(JsonArray.class::isInstance)
             .map(JsonArray.class::cast)
             .flatMap(Streams::stream)
+            .filter(ele -> !(ele instanceof JsonNull))
             .map(JsonElement::getAsString)
             .collect(toList()));
+  }
+
+  @Override
+  public CompletableFuture<List<String>> fetchTextConfigurationWithScope(String scopeUri, String section, String dialect) {
+    CobolConfigItem item = new CobolConfigItem();
+    item.setSection(section);
+    item.setDialect(dialect);
+    item.setScopeUri(scopeUri);
+    return clientProvider.get().configuration(new ConfigurationParams(singletonList(item)))
+            .thenApply(objects -> objects.stream()
+                    .filter(JsonArray.class::isInstance)
+                    .map(JsonArray.class::cast)
+                    .flatMap(Streams::stream)
+                    .filter(ele -> !(ele instanceof JsonNull))
+                    .map(JsonElement::getAsString)
+                    .collect(toList()));
   }
 
   @NonNull

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookNameServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookNameServiceTest.java
@@ -84,9 +84,9 @@ class CopybookNameServiceTest {
     copyNames.addAll(ImmutableList.of(absoluteValidCpyPath, relativeValidCpyPath, workspaceProgramPath));
     when(provider.get()).thenReturn(client);
     when(client.workspaceFolders()).thenReturn(CompletableFuture.completedFuture(workspace));
-    when(settingsService.fetchConfigurations(any(), eq(ImmutableList.of(CPY_LOCAL_PATHS.label))))
-            .thenReturn(CompletableFuture.completedFuture(ImmutableList.of(toJsonArray(copyNames))));
-    when(settingsService.fetchTextConfiguration(DIALECTS.label))
+    when(settingsService.fetchTextConfigurationWithScope(any(), eq(CPY_LOCAL_PATHS.label)))
+            .thenReturn(CompletableFuture.completedFuture(copyNames));
+    when(settingsService.fetchTextConfigurationWithScope(any(), eq(DIALECTS.label)))
             .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
   }
 


### PR DESCRIPTION
…etion

## How Has This Been Tested?

- [x] Test copybook Name completion for a dialect with configuration present in only processor groups (No settings.json)

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
