### PR TITLE
fix: fix coloring for exec block

### DIFF
--- a/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
+++ b/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
@@ -37,10 +37,10 @@
               "include": "#picture"
             },
             {
-              "include": "#sql-block"
+              "include": "#cics-keywords"
             },
             {
-              "include": "#cics-block"
+              "include": "#db2-sql-keywords"
             },
             {
               "include": "#cobol-keywords"
@@ -107,58 +107,6 @@
     "cobol-preprocessor-keywords": {
       "match": "(?<![\\-\\w])(?i:CBL|CONTROL|COPY|BY|CR|DB|END-EXEC|ENTER|EXEC|FILE|FUNCTION|IDMS|IN|INCLUDE|LEADING|LINKAGE|PROCEDURE|DIVISION|LIST|MAID|MAP|MAP-CONTROL|MODULE|NO|NOLIST|NOMAP|NOSOURCE|OF|OFF|PIC|PICTURE|RECORD|REDEFINES|REPLACING|REPLACE|TITLE|TRAILING|SECTION|SOURCE|SQL|SUPPRESS|VERSION|WORKING-STORAGE|IS)(?![\\-\\w])",
       "name": "keyword.cobol"
-    },
-    "sql-block": {
-      "begin": "(?i:exec\\s+sql)",
-      "name": "string.quoted.cobol.sql",
-      "contentName": "meta.embedded.block.sql",
-      "patterns": [
-        {
-          "include": "#db2-sql-keywords"
-        },
-        {
-          "include": "#comment-line"
-        },
-        {
-          "include": "#comment-floating"
-        },
-        {
-          "include": "#number-constant"
-        },
-        {
-          "include": "#string-quoted-constant"
-        },
-        {
-          "include": "#string-double-quoted-constant"
-        }
-      ],
-      "end": "(?i:end\\-exec)\\.?"
-    },
-    "cics-block": {
-      "begin": "(?i:exec\\s+cics)",
-      "name": "string.quoted.cobol.cics",
-      "contentName": "meta.embedded.block.cics",
-      "patterns": [
-        {
-          "include": "#cics-keywords"
-        },
-        {
-          "include": "#comment-line"
-        },
-        {
-          "include": "#comment-floating"
-        },
-        {
-          "include": "#number-constant"
-        },
-        {
-          "include": "#string-quoted-constant"
-        },
-        {
-          "include": "#string-double-quoted-constant"
-        }
-      ],
-      "end": "(?i:end\\-exec)\\.?"
     },
     "cics-translator-keywords": {
       "match": "(?<![\\-\\w])(?i:APOST|CBLCARD|CICS|COBOL2|COBOL3|CPSM|DBCS|DEBUG|DLI|EDF|EXCI|FEPI|LENGTH|LINKAGE|NATLANG|NOCBLCARD|NOCPSM|NODEBUG|NOEDF|NOFEPI|NOLENGTH|NOLINKAGE|NONUM|NOOPTIONS|NOSEQ|NOSPIE|NOVBREF|NUM|OPTIONS|QUOTE|SEQ|SP|SPIE|SYSEIB|VBREF|XOPTS)(?![\\-\\w])",


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Check the coloring of the exec block
```cobol
EXEC CICS READ  FILE ('ACCTFILE')  END-EXEC.
``` 
```cobol
           EXEC CICS READ  FILE ('ACCTFILE') 
            END-EXEC.
``` 
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/c64323f3-6b83-4e87-ac33-0d93d8d45981)
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/768a3eb0-4641-49d2-a05b-6cb96ea10202)
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/a87d10c6-e7de-4b6f-97d9-211296df66d1)

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
