### PR TITLE
fix: fix semantics analysis for XML Parse statement

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/JsonGenerateProcess.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/JsonGenerateProcess.java
@@ -19,8 +19,6 @@ import org.eclipse.lsp.cobol.common.error.ErrorSeverity;
 import org.eclipse.lsp.cobol.common.error.ErrorSource;
 import org.eclipse.lsp.cobol.common.error.SyntaxError;
 import org.eclipse.lsp.cobol.common.message.MessageTemplate;
-import org.eclipse.lsp.cobol.common.model.NodeType;
-import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp.cobol.common.model.tree.variable.*;
 import org.eclipse.lsp.cobol.common.processor.ProcessingContext;
 import org.eclipse.lsp.cobol.common.processor.Processor;
@@ -38,7 +36,6 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.groupingBy;
 import static org.eclipse.lsp.cobol.common.OutlineNodeNames.FILLER_NAME;
-import static org.eclipse.lsp.cobol.common.model.tree.Node.hasType;
 
 /** Apply all the validation for the JSON Generate statement and return found errors. */
 public class JsonGenerateProcess implements Processor<JsonGenerateNode> {
@@ -62,22 +59,25 @@ public class JsonGenerateProcess implements Processor<JsonGenerateNode> {
    */
   @Override
   public void accept(JsonGenerateNode jsonGenerateNode, ProcessingContext processingContext) {
-    List<VariableUsageNode> identifier1Nodes = getIdentifier(jsonGenerateNode, jsonGenerateNode.getIdentifier1());
+    List<VariableUsageNode> identifier1Nodes = VariableUsageUtils.getVariableUsageNode(jsonGenerateNode, jsonGenerateNode.getIdentifier1());
     if (identifier1Nodes.isEmpty()) return;
-    List<VariableNode> identifier1FoundDefinitions = getIdentifierDefinitions(jsonGenerateNode, identifier1Nodes);
+    List<VariableNode> identifier1FoundDefinitions =
+            VariableUsageUtils.getDefinitionNode(symbolAccumulatorService, jsonGenerateNode, identifier1Nodes);
     if (identifier1FoundDefinitions.isEmpty()) return;
     semanticAnalysisForIdentifier1(processingContext, identifier1Nodes, identifier1FoundDefinitions);
 
-    List<VariableUsageNode> identifier2Nodes = getIdentifier(jsonGenerateNode, jsonGenerateNode.getIdentifier2());
+    List<VariableUsageNode> identifier2Nodes = VariableUsageUtils.getVariableUsageNode(jsonGenerateNode, jsonGenerateNode.getIdentifier2());
     if (identifier2Nodes.isEmpty()) return;
-    List<VariableNode> identifier2FoundDefinitions = getIdentifierDefinitions(jsonGenerateNode, identifier2Nodes);
+    List<VariableNode> identifier2FoundDefinitions =
+            VariableUsageUtils.getDefinitionNode(symbolAccumulatorService, jsonGenerateNode, identifier2Nodes);
     if (identifier2FoundDefinitions.isEmpty()) return;
     semanticAnalysisForIdentifier2(processingContext, identifier2Nodes, identifier2FoundDefinitions, identifier1FoundDefinitions);
 
     if (Objects.nonNull(jsonGenerateNode.getIdentifier3())) {
-      List<VariableUsageNode> identifier3Nodes = getIdentifier(jsonGenerateNode, jsonGenerateNode.getIdentifier3());
+      List<VariableUsageNode> identifier3Nodes = VariableUsageUtils.getVariableUsageNode(jsonGenerateNode, jsonGenerateNode.getIdentifier3());
       if (identifier3Nodes.isEmpty()) return;
-      List<VariableNode> identifier3FoundDefinitions = getIdentifierDefinitions(jsonGenerateNode, identifier3Nodes);
+      List<VariableNode> identifier3FoundDefinitions =
+              VariableUsageUtils.getDefinitionNode(symbolAccumulatorService, jsonGenerateNode, identifier3Nodes);
       semanticAnalysisForIdentifier3(
           processingContext,
           identifier3Nodes,
@@ -102,8 +102,9 @@ public class JsonGenerateProcess implements Processor<JsonGenerateNode> {
   private void semanticAnalysisForIdentifier6(JsonGenerateNode jsonGenerateNode, ProcessingContext ctx) {
     jsonGenerateNode.getPhases().forEach(phase -> {
       VariableNameAndLocality identifier6 = phase.getIdentifier6();
-      List<VariableUsageNode> identifier6Nodes = getIdentifier(jsonGenerateNode, identifier6);
-      List<VariableNode> foundDefinitionsForIdentifier6 = getIdentifierDefinitions(jsonGenerateNode, identifier6Nodes);
+      List<VariableUsageNode> identifier6Nodes = VariableUsageUtils.getVariableUsageNode(jsonGenerateNode, identifier6);
+      List<VariableNode> foundDefinitionsForIdentifier6 =
+              VariableUsageUtils.getDefinitionNode(symbolAccumulatorService, jsonGenerateNode, identifier6Nodes);
       if (foundDefinitionsForIdentifier6.isEmpty()) return;
       if (Objects.nonNull(phase.getConditionNames())) {
         semanticCheckForCondition(jsonGenerateNode, ctx, phase, foundDefinitionsForIdentifier6);
@@ -127,8 +128,9 @@ public class JsonGenerateProcess implements Processor<JsonGenerateNode> {
   }
 
   private void semanticCheckForCondition(JsonGenerateNode jsonGenerateNode, ProcessingContext ctx, JsonGenerateNode.JsonGenPhase phase, List<VariableNode> foundDefinitionsForIdentifier6) {
-    List<VariableUsageNode> conditionNodes = getIdentifier(jsonGenerateNode, phase.getConditionNames());
-    List<VariableNode> conditionNodeDefn = getIdentifierDefinitions(jsonGenerateNode, conditionNodes);
+    List<VariableUsageNode> conditionNodes = VariableUsageUtils.getVariableUsageNode(jsonGenerateNode, phase.getConditionNames());
+    List<VariableNode> conditionNodeDefn =
+            VariableUsageUtils.getDefinitionNode(symbolAccumulatorService, jsonGenerateNode, conditionNodes);
     if (foundDefinitionsForIdentifier6
             .get(0)
             .getDepthFirstStream()
@@ -151,9 +153,10 @@ public class JsonGenerateProcess implements Processor<JsonGenerateNode> {
   }
 
   private void semanticAnalysisForIdentifier5(JsonGenerateNode jsonGenerateNode, ProcessingContext ctx, List<VariableNode> identifier2FoundDefinitions) {
-    List<VariableUsageNode> identifier5Nodes = getIdentifier(jsonGenerateNode, jsonGenerateNode.getIdentifier5());
+    List<VariableUsageNode> identifier5Nodes = VariableUsageUtils.getVariableUsageNode(jsonGenerateNode, jsonGenerateNode.getIdentifier5());
     identifier5Nodes.forEach(identifier5 -> {
-      List<VariableNode> foundDefinitionsForIdentifier5 = getIdentifierDefinitions(jsonGenerateNode, Collections.singletonList(identifier5));
+      List<VariableNode> foundDefinitionsForIdentifier5 =
+              VariableUsageUtils.getDefinitionNode(symbolAccumulatorService, jsonGenerateNode, Collections.singletonList(identifier5));
       if (foundDefinitionsForIdentifier5.isEmpty() || identifier2FoundDefinitions.isEmpty()) {
         return;
       }
@@ -183,9 +186,10 @@ public class JsonGenerateProcess implements Processor<JsonGenerateNode> {
   }
 
   private void semanticAnalysisForIdentifier4(JsonGenerateNode jsonGenerateNode, ProcessingContext ctx, List<VariableNode> identifier2FoundDefinitions) {
-    List<VariableUsageNode> identifier4Nodes = getIdentifier(jsonGenerateNode, jsonGenerateNode.getIdentifier4());
+    List<VariableUsageNode> identifier4Nodes = VariableUsageUtils.getVariableUsageNode(jsonGenerateNode, jsonGenerateNode.getIdentifier4());
     identifier4Nodes.forEach(identifier4 -> {
-      List<VariableNode> foundDefinitionsForIdentifier4 = getIdentifierDefinitions(jsonGenerateNode, Collections.singletonList(identifier4));
+      List<VariableNode> foundDefinitionsForIdentifier4 =
+              VariableUsageUtils.getDefinitionNode(symbolAccumulatorService, jsonGenerateNode, Collections.singletonList(identifier4));
       if (foundDefinitionsForIdentifier4.isEmpty() || identifier2FoundDefinitions.isEmpty()) {
         return;
       }
@@ -465,47 +469,5 @@ public class JsonGenerateProcess implements Processor<JsonGenerateNode> {
                                       MessageTemplate.of("jsonParseProcess.identifier1.groupItemError"))
                               .build());
     }
-  }
-
-  private List<VariableUsageNode> getIdentifier(
-      JsonGenerateNode jsonGenerateNode, VariableNameAndLocality identifier) {
-    return jsonGenerateNode.getChildren().stream()
-        .flatMap(Node::getDepthFirstStream)
-        .filter(hasType(NodeType.VARIABLE_USAGE))
-        .map(VariableUsageNode.class::cast)
-        .filter(
-            node ->
-                node.getName().equalsIgnoreCase(identifier.getName())
-                    && node.getLocality().equals(identifier.getLocality()))
-        .collect(Collectors.toList());
-  }
-
-  private List<VariableUsageNode> getIdentifier(
-          JsonGenerateNode jsonGenerateNode, List<VariableNameAndLocality> identifiers) {
-    return jsonGenerateNode.getChildren().stream()
-            .flatMap(Node::getDepthFirstStream)
-            .filter(hasType(NodeType.VARIABLE_USAGE))
-            .map(VariableUsageNode.class::cast)
-            .filter(
-                    node ->
-                            identifiers.stream()
-                                    .anyMatch(
-                                       str -> str.getLocality().getUri().equals(node.getLocality().getUri())
-                                    && str.getLocality().getRange().getStart().getLine() == node.getLocality().getRange().getStart().getLine()
-                                    && str.getLocality().getRange().getStart().getCharacter() <= node.getLocality().getRange().getStart().getCharacter()
-                                    && str.getLocality().getRange().getEnd().getCharacter() >= node.getLocality().getRange().getEnd().getCharacter()
-                                    && str.getName().contains(node.getName())))
-            .collect(Collectors.toList());
-  }
-
-  private List<VariableNode> getIdentifierDefinitions(
-      JsonGenerateNode jsonGenerateNode, List<VariableUsageNode> identifier1Nodes) {
-    return jsonGenerateNode
-        .getProgram()
-        .map(
-            programNode ->
-                symbolAccumulatorService.getVariableDefinition(
-                    programNode, Collections.singletonList(identifier1Nodes.get(0))))
-        .orElseGet(ImmutableList::of);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/XMLParseProcess.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/XMLParseProcess.java
@@ -20,7 +20,6 @@ import org.eclipse.lsp.cobol.common.error.ErrorSource;
 import org.eclipse.lsp.cobol.common.error.SyntaxError;
 import org.eclipse.lsp.cobol.common.mapping.OriginalLocation;
 import org.eclipse.lsp.cobol.common.message.MessageTemplate;
-import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp.cobol.common.model.tree.variable.*;
 import org.eclipse.lsp.cobol.common.processor.CompilerDirectiveName;
 import org.eclipse.lsp.cobol.common.processor.CompilerDirectiveOption;
@@ -111,12 +110,12 @@ public class XMLParseProcess implements Processor<XMLParseNode> {
   private List<VariableNode> getVariableDefinition(
       XMLParseNode xmlParseNode, VariableNameAndLocality identifier) {
     if (Objects.nonNull(identifier)) {
-      Optional<VariableUsageNode> variableUsageNodeForIdentifier =
+      List<VariableUsageNode> variableUsageNodeForIdentifier =
           VariableUsageUtils.getVariableUsageNode(xmlParseNode, identifier);
-      if (!variableUsageNodeForIdentifier.isPresent()) {
+      if (variableUsageNodeForIdentifier.isEmpty()) {
         return Collections.emptyList();
       }
-      return getIdentifierDefinitions(xmlParseNode, variableUsageNodeForIdentifier.get());
+      return VariableUsageUtils.getDefinitionNode(symbolAccumulatorService, xmlParseNode, variableUsageNodeForIdentifier);
     }
     return Collections.emptyList();
   }
@@ -272,14 +271,5 @@ public class XMLParseProcess implements Processor<XMLParseNode> {
     return compilerDirectiveOption
         .map(CompilerDirectiveOption::getValue)
         .orElse(Collections.emptyList());
-  }
-
-  private List<VariableNode> getIdentifierDefinitions(Node node, VariableUsageNode identifier) {
-    return node.getProgram()
-        .map(
-            programNode ->
-                symbolAccumulatorService.getVariableDefinition(
-                    programNode, Collections.singletonList(identifier)))
-        .orElseGet(ImmutableList::of);
   }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestXMLParseStatement.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestXMLParseStatement.java
@@ -170,6 +170,28 @@ public class TestXMLParseStatement {
           + "           DISPLAY {$XML-EVENT} (1:22) ':' {$XML-TEXT}\n"
           + "           .";
 
+  public static final String XML_PARSE_SUBSTRING_IDENTIFIER =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TDXMLTST.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*XML-STRING}                PIC X(1000) VALUE SPACES.\n"
+          + "       01 {$*EZ-PTR}                    PIC S9(4) COMP VALUE 1.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "          {#*MAINLINE}.\n"
+          + "             DISPLAY 'XML-DOCUMENT=' {$XML-STRING}(1:{$EZ-PTR})\n"
+          + "             XML PARSE {$XML-STRING}(1:{$EZ-PTR}) {_RETURNING NATIONAL|1_}\n"
+          + "                                PROCESSING PROCEDURE {#XML-HANDLER}\n"
+          + "               ON EXCEPTION\n"
+          + "                 DISPLAY 'XML DOCUMENT ERROR ' {$XML-CODE}\n"
+          + "               NOT ON EXCEPTION\n"
+          + "                 DISPLAY 'XML DOCUMENT SUCCESSFULLY PARSED'\n"
+          + "              END-XML.\n"
+          + "       {#*XML-HANDLER}.\n"
+          + "           DISPLAY 'XML-EVENT=' {$XML-EVENT}.";
+
   @Test
   void xmlParsePositiveTest() {
     UseCaseEngine.runTest(
@@ -256,5 +278,19 @@ public class TestXMLParseStatement {
                 "Variable NAME is not defined",
                 DiagnosticSeverity.Error,
                 ErrorSource.PARSING.getText())));
+  }
+
+  @Test
+  void test_whenIdentifier1HasMoreThanOneDefinitions_thenProcess() {
+    UseCaseEngine.runTest(
+            XML_PARSE_SUBSTRING_IDENTIFIER,
+            ImmutableList.of(),
+            ImmutableMap.of(
+                    "1",
+                    new Diagnostic(
+                            new Range(),
+                            "RETURNING NATIONAL phrase can be specified only when the XMLPARSE(XMLSS) compiler option is in effect",
+                            DiagnosticSeverity.Hint,
+                            ErrorSource.PARSING.getText())));
   }
 }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test the below code. It should give a warning for returning national in the XML parse statement
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. TDXMLTST.
       ENVIRONMENT DIVISION.
       INPUT-OUTPUT SECTION.
      *************************
       FILE-CONTROL.
           SELECT  XMLDATA       ASSIGN TO XMLFILE.
       DATA DIVISION.
          FILE SECTION.
      *=================================================================
          FD  XMLDATA
              RECORDING MODE IS F
              LABEL RECORD STANDARD
              DATA RECORD IS XMLREC.
          01  XMLREC   PIC X(80).
       WORKING-STORAGE SECTION.
      ******************************************************************
      * XML DOCUMENT, ENCODED AS INITIAL VALUES OF DATA ITEMS.         *
      ******************************************************************
       01 NOT-EOF                   PIC X(01)      VALUE 'N'.
       01 I-FROM                    PIC S9(4)   COMP VALUE 0.
       01 XML-STRING                PIC X(1000) VALUE SPACES.
       01 EZ-PTR                    PIC S9(4) COMP VALUE 1.
      ******************************************************************

      ******************************************************************
      * SAMPLE DATA DEFINITIONS FOR PROCESSING NUMERIC XML CONTENT.    *
      ******************************************************************

       1 CURRENT-ELEMENT PIC X(30).
       1 LIST-PRICE COMPUTATIONAL PIC 9V99 VALUE 0.
       1 DISCOUNT COMPUTATIONAL PIC 9V99 VALUE 0.
       1 DISPLAY-PRICE PIC $$9.99.
       1 XML-DOCUMENT-LENGTH COMPUTATIONAL PIC 9V99 VALUE 0.
   
       PROCEDURE DIVISION.
          MAINLINE SECTION.
             DISPLAY 'XML-DOCUMENT=' XML-STRING(1:EZ-PTR)
             XML PARSE XML-STRING(1:EZ-PTR) RETURNING NATIONAL
                                PROCESSING PROCEDURE XML-HANDLER
               ON EXCEPTION
                 DISPLAY 'XML DOCUMENT ERROR ' XML-CODE
               NOT ON EXCEPTION
                 DISPLAY 'XML DOCUMENT SUCCESSFULLY PARSED'
              END-XML.
       XML-HANDLER SECTION.
           DISPLAY 'XML-EVENT=' XML-EVENT.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
