### PR TITLE
fix: Add compiler_options.schema.json to the bundled vsix

### DIFF
--- a/clients/cobol-lsp-vscode-extension/.vscodeignore
+++ b/clients/cobol-lsp-vscode-extension/.vscodeignore
@@ -29,6 +29,7 @@
 !schema/pgm_conf.schema.json
 !schema/preprocessor_entry.schema.json
 !schema/proc_grps.schema.json
+!schema/compiler_options.schema.json
 # * bundled extension code
 !dist/extension.js
 !dist/extension.js.map


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] 
   1.    install vsix
   2. open proc_grps.json
   3. No warning for missing compiler_options.schema.json is observed

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
