### PR TITLE
fix: fetch copybook for dialect from the dialect configured settings

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/SettingsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/SettingsTest.spec.ts
@@ -197,3 +197,32 @@ describe("SettingsService returns correct tab settings", () => {
     expect(tabSettings.rules.length).toBe(2);
   });
 });
+
+describe("SettingsService returns correct Copybook Configuration Values", () => {
+  const mockConfigurationFetch = (settings, configuredValue) => jest.fn().mockReturnValue({
+    get: (args: String) => {
+      if (settings === args) {
+        return configuredValue;
+      }
+    },
+  });
+
+  test("returns empty array when dialect configuration is not provided", () => {
+    vscode.workspace.getConfiguration = mockConfigurationFetch("dialect.paths-uss", undefined);
+    expect(SettingsService.getUssPath("doc-uri", "dialect")).toHaveLength(0);
+  });
+
+  test("returns configured array when dialect configuration is provided", () => {
+    vscode.workspace.getConfiguration = mockConfigurationFetch("dialect.paths-uss", ["configured-dialect-settings"]);
+    const configuredValue = SettingsService.getUssPath("doc-uri", "dialect");
+    expect(configuredValue).toHaveLength(1);
+    expect(configuredValue[0]).toBe("configured-dialect-settings");
+  });
+
+  test("returns configured array for COBOL configuration", () => {
+    vscode.workspace.getConfiguration = mockConfigurationFetch("paths-uss", ["configured-cobol-settings"]);
+    const configuredValue = SettingsService.getUssPath("doc-uri", SettingsService.DEFAULT_DIALECT);
+    expect(configuredValue).toHaveLength(1);
+    expect(configuredValue[0]).toBe("configured-cobol-settings");
+  });
+});

--- a/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
@@ -359,13 +359,11 @@ export class SettingsService {
       const pathList: string[] = vscode.workspace
         .getConfiguration(SETTINGS_CPY_SECTION)
         .get(`${dialectType.toLowerCase()}.${section}`);
-      if (pathList && pathList.length > 0) {
         return SettingsService.evaluateVariable(
           pathList,
           "fileBasenameNoExtension",
           programFile,
         );
-      }
     }
     const pathList: string[] = vscode.workspace
       .getConfiguration(SETTINGS_CPY_SECTION)


### PR DESCRIPTION
fetch copybook for dialect from the dialect configured settings and not from the cobol configuration

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test that the idms copybooks are fetched only from the idms configured settings and not from the cobol configuration

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
