### PR TITLE
fix: add default compiler directives while processing in case no comp…

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveContext.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveContext.java
@@ -22,7 +22,21 @@ import java.util.stream.Stream;
 
 /** Compiler directive context */
 public class CompilerDirectiveContext {
-  @Getter private final Map<CompilerDirectiveName, List<String>> compilerDirectiveMap = new HashMap<>();
+  @Getter private final Map<CompilerDirectiveName, List<String>> compilerDirectiveMap;
+
+  public CompilerDirectiveContext() {
+    this.compilerDirectiveMap = defaultCompilerDirective();
+  }
+
+  private Map<CompilerDirectiveName, List<String>> defaultCompilerDirective() {
+    return Arrays.stream(CompilerDirectiveName.values())
+        .map(directive -> directive.getDirectiveOption(""))
+        .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
+        .collect(
+            Collectors.toMap(
+                CompilerDirectiveOption::getCompilerDirectiveName,
+                CompilerDirectiveOption::getValue));
+  }
 
   /**
    * Updates the compiler directive options

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveName.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveName.java
@@ -42,7 +42,7 @@ public enum CompilerDirectiveName {
       } else if (isContains(directiveText, "QUALIFY(C_CHAR)") || isContains(directiveText, "QUA(C_CHAR)")) {
         return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("C_CHAR")));
       } else {
-        return Optional.empty();
+        return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("COMPAT")));
       }
     }
   },
@@ -58,7 +58,7 @@ public enum CompilerDirectiveName {
       } else if (isContains(directiveText, "XMLPARSE(C_CHAR)") || isContains(directiveText, "XP(C_CHAR)")) {
         return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("C_CHAR")));
       } else {
-        return Optional.empty();
+        return Optional.of(new CompilerDirectiveOption(this, ImmutableList.of("XMLSS")));
       }
     }
   };

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveContextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveContextTest.java
@@ -32,13 +32,16 @@ class CompilerDirectiveContextTest {
   @Test
   void testCompilerOptionsContextFetch() {
     CompilerDirectiveContext context = new CompilerDirectiveContext();
+
+    assertEquals(context.getCompilerDirectiveMap().entrySet().size(), 2);
     context.updateDirectiveOptions(
         new CompilerDirectiveOption(CompilerDirectiveName.ADATA, ImmutableList.of(EXTEND)));
     Optional<CompilerDirectiveOption> result1 =
         context.filterDirectiveList(ImmutableList.of(CompilerDirectiveName.QUALIFY));
     Optional<CompilerDirectiveOption> result2 =
         context.filterDirectiveList(ImmutableList.of(CompilerDirectiveName.ADATA));
-    assertFalse(result1.isPresent());
+    assertTrue(result1.isPresent());
+    assertTrue(result1.get().getValue().contains("COMPAT"));
     assertTrue(result2.isPresent());
     Assertions.assertTrue(result2.get().getValue().contains(EXTEND));
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestXMLParseStatement.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestXMLParseStatement.java
@@ -87,6 +87,13 @@ public class TestXMLParseStatement {
           + "           {_VALIDATING WITH {$QUESTION}|3_}\n"
           + "           PROCESSING PROCEDURE {#XML-HANDLER}\n";
 
+  private static final String XMP_PARSE_STATEMENT_XMLSS =
+          "           XML PARSE {$XML-DOC} \n"
+                  + "           WITH ENCODING 1200\n"
+                  + "           RETURNING NATIONAL\n"
+                  + "           VALIDATING WITH {$QUESTION}\n"
+                  + "           PROCESSING PROCEDURE {#XML-HANDLER}\n";
+
   public static final String TEXT =
       XML_PARSE_STATEMENT_PRECESSED + XMP_PARSE_STATEMENT + XML_PARSE_SUCCESSOR;
 
@@ -179,7 +186,10 @@ public class TestXMLParseStatement {
   @Test
   void xmlParse_whenXmlssNotSet_provideHints() {
     UseCaseEngine.runTest(
-        XML_PARSE_STATEMENT_PRECESSED + XMP_PARSE_STATEMENT_NO_XMLSS + XML_PARSE_SUCCESSOR,
+        "     PROCESS XMLPARSE(COMPAT)\n"
+            + XML_PARSE_STATEMENT_PRECESSED
+            + XMP_PARSE_STATEMENT_NO_XMLSS
+            + XML_PARSE_SUCCESSOR,
         ImmutableList.of(),
         ImmutableMap.of(
             "1",
@@ -200,6 +210,14 @@ public class TestXMLParseStatement {
                 "Validating phrase can be specified only when XMLPARSE(XMLSS) compiler option is in effect",
                 DiagnosticSeverity.Hint,
                 ErrorSource.PARSING.getText())));
+  }
+
+  @Test
+  void xmlParse_whenCompilerOptionNotProvided_XMLPARSE_XMLSS_isConsideredDefault() {
+    UseCaseEngine.runTest(
+        XML_PARSE_STATEMENT_PRECESSED + XMP_PARSE_STATEMENT_XMLSS + XML_PARSE_SUCCESSOR,
+        ImmutableList.of(),
+        ImmutableMap.of());
   }
 
   @Test


### PR DESCRIPTION
…iler directive configuration present

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Compiler option QUALIFY(COMPAT) and XMLPARSE(XMLSS) are set by default

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
