### PR TITLE
fix: tolerate FD data records mismatch clause as per IBM doc

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestFDDataRecordToleration.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestFDDataRecordToleration.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test that COBOL LS engine tolerate wrong syntax for label record like compiler. As per <a
+ * href="https://www.ibm.com/docs/en/cobol-zos/6.3?topic=division-data-file-description-entries">IBM
+ * Doc</a> DATA RECORDS should e followed by ARE and DATA RECORD should be followed by IS. But the
+ * cobol compiler tolerate DATA RECORD ARE and RECORDS IS, this class tests this toleration.
+ */
+public class TestFDDataRecordToleration {
+
+  private static final String BASE =
+      "       CBL TRUNC(BIN),ARITH(EXTEND)\n"
+          + "       ID DIVISION.\n"
+          + "       PROGRAM-ID.    TEST12.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "      ****************************************************************\n"
+          + "      *          CONFIGURATION SECTION                               *\n"
+          + "      ****************************************************************\n"
+          + "       CONFIGURATION SECTION.\n"
+          + "       SOURCE-COMPUTER. IBM-3090.\n"
+          + "       OBJECT-COMPUTER. IBM-3090.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       FILE-CONTROL.\n"
+          + "           SELECT {$VAR}  ASSIGN TO VAR.\n"
+          + "       DATA DIVISION.\n"
+          + "       FILE SECTION.\n"
+          + "       FD  {$*VAR}\n"
+          + "           BLOCK  CONTAINS 0 RECORDS\n"
+          + "           RECORDING MODE  IS V\n"
+          + "           LABEL  RECORD  ARE STANDARD\n";
+  private static final String SUFFIX =
+      "           RECORD IS VARYING IN SIZE FROM 1 TO 10108 CHARACTERS\n"
+          + "                                     DEPENDING ON {$WS-LG}.\n"
+          + "       01  {$*ENR-VAR}.\n"
+          + "           05 {$*F}           PIC X         OCCURS 10108\n"
+          + "                                     DEPENDING ON {$WS-LG}.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01  {$*LT}.\n"
+          + "           05 {$*WS-LG}         PIC  9(08) VALUE ZERO.\n";
+  private static final String TEXT_TOLERATE_RECORD_ARE =
+      BASE + "           DATA   RECORD  ARE {$ENR-VAR}\n" + SUFFIX;
+
+  private static final String TEXT_TOLERATE_RECORDS_IS =
+      BASE + "           DATA   RECORDS  IS {$ENR-VAR}\n" + SUFFIX;
+
+  @Test
+  void test1() {
+    UseCaseEngine.runTest(TEXT_TOLERATE_RECORDS_IS, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void test2() {
+    UseCaseEngine.runTest(TEXT_TOLERATE_RECORD_ARE, ImmutableList.of(), ImmutableMap.of());
+  }
+}

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -683,7 +683,7 @@ valuePair
    ;
 
 dataRecordsClause
-   : DATA (RECORD IS? | RECORDS ARE?) qualifiedDataName+
+   : DATA (RECORD | RECORDS) (IS | ARE)? qualifiedDataName+
    ;
 
 linageClause


### PR DESCRIPTION
As per https://www.ibm.com/docs/en/cobol-zos/6.3?topic=division-data-file-description-entries DATA RECORDS should be followed by ARE and DATA RECORD should be followed by optional IS. But the cobol compiler tolerates mismatch i.e. RECORDS IS and RECORD ARE. This PR adds the same toleration to COBOL LS.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test DATA RECORD ARE and DATA RECORDS IS doesn't show error for FD statements.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
