### PR TITLE
fix: include last token as well for embedded code analysis

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/VisitorHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/VisitorHelper.java
@@ -177,7 +177,7 @@ public class VisitorHelper {
   private String retrieveIntervalText(@Nonnull ParserRuleContext ctx) {
     int start = ctx.getStart().getStartIndex();
     int stop = ctx.getStop().getStopIndex();
-    return stop < start ? "" : ctx.getStart().getInputStream().getText(new Interval(start, stop));
+    return stop < start ? "" : ctx.getStart().getInputStream().getText(new Interval(start, stop + 1));
   }
 
   /**

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestEmbeddedCodeWithIssueOnLastToken.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestEmbeddedCodeWithIssueOnLastToken.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.common.error.ErrorSource;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test that any issue with the last token of embedded code is rightly highlighted for error.
+ */
+public class TestEmbeddedCodeWithIssueOnLastToken {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST12.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*testing} pic x.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           EXEC SQL \n"
+          + "           fetch abc \n"
+          + "           into \n"
+          + "           asas,\n"
+          + "           ajsjs, \n"
+          + "           :{$testing},{|1}\n"
+          + "           END-EXEC.";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                new Range(),
+                "Unexpected end of file",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText())));
+  }
+}

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestFileDescriptor.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestFileDescriptor.java
@@ -91,7 +91,7 @@ class TestFileDescriptor {
           + System.lineSeparator()
           + "RECORDING MODE IS F"
           + System.lineSeparator()
-          + "BLOCK CONTAINS 0 RECORDS."
+          + "BLOCK CONTAINS 0 RECORDS.\n"
           + System.lineSeparator()
           + " "
           + System.lineSeparator()
@@ -105,7 +105,7 @@ class TestFileDescriptor {
           + System.lineSeparator()
           + "ACCESS MODE IS SEQUENTIAL"
           + System.lineSeparator()
-          + "FILE STATUS IS IFCODE "
+          + "FILE STATUS IS IFCODE. "
           + System.lineSeparator();
 
   private static final String NO_FILE_CONTROL_TEXT =


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Error on the last token of an embedded code should show an error.
       Issue :  Did not flag final (incorrect) comma – at end of :HOURS-TBL-AVG, 
       
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/f5cb63dc-e0d7-41aa-9698-382247975928)


## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
