### PR TITLE
fix: compiler directive at the beginning of line

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -91,7 +91,7 @@
           "COBOL"
         ],
         "configuration": "./syntaxes/lang-config.json",
-        "firstLine": "^[0-9 ]{6}([*].*|[ Dd] *([Ii][Dd]([Ee][Nn][Tt][Ii][Ff][Ii][Cc][Aa][Tt][Ii][Oo][Nn])? +[Dd][Ii][Vv][Ii][Ss][Ii][Oo][Nn][. ]|[0-9][0-9] +[@#$A-Z][-A-Z0-9]*[. ]|[*]?(CBL|PROCESS) ).*)$"
+        "firstLine": "^[0-9 ]{6}([*].*|[ Dd] *([Ii][Dd]([Ee][Nn][Tt][Ii][Ff][Ii][Cc][Aa][Tt][Ii][Oo][Nn])? +[Dd][Ii][Vv][Ii][Ss][Ii][Oo][Nn][. ]|[0-9][0-9] +[@#$A-Z][-A-Z0-9]*[. ]|[*](CBL|PROCESS) ).*)$|^([0-9].{5})?[ ]*(CBL|PROCESS) "
       }
     ],
     "grammars": [

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
@@ -212,42 +212,72 @@ describe("Check recognition of COBOL from first line", () => {
     expect(pgm).toEqual(cobol);
   });
 
-  test("Compiler Directive SEQ in column 8", () => {
-    const pgm = `000010 PROCESS `;
+  test("Compiler Directive at the beginnig of a line", () => {
+    const pgm = `CBL `;
     expect(pgm).toEqual(cobol);
   });
 
-  test("Compiler Directive NOSEQ in column 8", () => {
+  test("Compiler Directive after 3 spaces", () => {
+    const pgm = `   CBL `;
+    expect(pgm).toEqual(cobol);
+  });
+
+  test("Compiler Directive after 6 spaces", () => {
+    const pgm = `      CBL `;
+    expect(pgm).toEqual(cobol);
+  });
+
+  test("Compiler Directive after 7 spaces", () => {
     const pgm = `       CBL `;
     expect(pgm).toEqual(cobol);
   });
 
-  test("Compiler Directive SEQ after column 8", () => {
+  test("Compiler Directive after spaces 8 spaces", () => {
+    const pgm = `        CBL `;
+    expect(pgm).toEqual(cobol);
+  });
+
+  test("Compiler Directive after more spaces", () => {
+    const pgm = `           CBL `;
+    expect(pgm).toEqual(cobol);
+  });
+
+  test("Incorrect compiler directive", () => {
+    const pgm = `a    CBL `;
+    expect(pgm).not.toEqual(cobol);
+  });
+
+  test("Compiler Directive after \"sequence number\"", () => {
+    const pgm = `0abcdePROCESS `;
+    expect(pgm).toEqual(cobol);
+  });
+
+  test("Compiler Directive in column 8 - SEQ", () => {
+    const pgm = `000010 PROCESS `;
+    expect(pgm).toEqual(cobol);
+  });
+
+  test("Compiler Directive after column 8 - SEQ", () => {
     const pgm = `000010     CBL `;
     expect(pgm).toEqual(cobol);
   });
 
-  test("Compiler Directive NOSEQ after column 8", () => {
-    const pgm = `           PROCESS `;
-    expect(pgm).toEqual(cobol);
-  });
-
-  test("Listing control SEQ in column 8", () => {
+  test("Listing control in column 8 - SEQ", () => {
     const pgm = `000010 *PROCESS `;
     expect(pgm).toEqual(cobol);
   });
 
-  test("Listing control NOSEQ in column 8", () => {
+  test("Listing control in column 8 - NOSEQ", () => {
     const pgm = `       *CBL `;
     expect(pgm).toEqual(cobol);
   });
 
-  test("Listing control SEQ after column 8", () => {
+  test("Listing control after column 8 - SEQ ", () => {
     const pgm = `000010    *CBL `;
     expect(pgm).toEqual(cobol);
   });
 
-  test("Listing control NOSEQ after column 8", () => {
+  test("Listing control after column 8 - NOSEQ ", () => {
     const pgm = `          *PROCESS `;
     expect(pgm).toEqual(cobol);
   });


### PR DESCRIPTION
Recognize COBOL language id if a compiler directive is specified in the first 7 columns of the first line.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested first line logic of including `CBL OPT(2)` in various parts of the first line of a COBOL program against the behaviour of the IBM Enterprise COBOL Compiler

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
