### PR TITLE
fix: tolerate CICS LINK EXCI statement

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CICSParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CICSParser.g4
@@ -26,7 +26,7 @@ allCicsRules: cics_send | cics_receive | cics_add | cics_address | cics_allocate
           cics_soapfault | cics_spoolclose | cics_spoolopen | cics_spoolread | cics_spoolwrite | cics_start |
           cics_startbr | cics_startbrowse | cics_suspend | cics_syncpoint | cics_test | cics_transform | cics_unlock |
           cics_update | cics_verify | cics_wait | cics_waitcics | cics_web | cics_write | cics_writeq | cics_wsacontext |
-          cics_wsaepr | cics_xctl | cics_converse | cics_abend | cics_acquire
+          cics_wsaepr | cics_xctl | cics_converse | cics_abend | cics_acquire | cics_exci_link
         ;
 
 /** RECEIVE: */
@@ -489,6 +489,22 @@ cics_link_commarea: COMMAREA cics_data_area (LENGTH cics_data_value | DATALENGTH
 cics_link_inputmsg: INPUTMSG cics_data_area (INPUTMSGLEN cics_data_value)?;
 cics_link_acqprocess: (ACQPROCESS | INPUTEVENT cics_data_value | cics_resp)+;
 cics_link_activity: (ACTIVITY cics_data_value | ACQACTIVITY | INPUTEVENT cics_data_value | cics_resp)+;
+
+/** EXCI LINK, ref: https://www.ibm.com/docs/en/cics-ts/6.1?topic=interface-exec-cics-link-command-exci*/
+cics_exci_link: LINK cics_link_program_exci;
+cics_link_commarea_exci: COMMAREA cics_data_area (LENGTH cics_data_value)? (DATALENGTH cics_data_value)?;
+cics_link_channel_exci: CHANNEL cics_name;
+cics_link_program_exci: PROGRAM cics_name
+                     (
+                        cics_link_commarea_exci
+                        | cics_link_channel_exci
+                        | APPLID cics_data_area
+                        | TRANSID cics_name
+                        | RETCODE cics_data_area
+                        | SYNCONRETURN
+                        | cics_resp
+                     )+;
+
 
 /** LOAD */
 cics_load: LOAD (PROGRAM cics_name | SET cics_ref | LENGTH cics_data_area | FLENGTH cics_data_area | ENTRY cics_ref | HOLD | cics_resp)*;

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCicsLinkExciStatementToleration.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCicsLinkExciStatementToleration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the toleration of CICS EXCI LINK statement toleration. Ref:
+ * https://www.ibm.com/docs/en/cics-ts/6.1?topic=interface-exec-cics-link-command-exci
+ */
+public class TestCicsLinkExciStatementToleration {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.              \n"
+          + "              PROGRAM-ID.      TESTA.     \n"
+          + "       ENVIRONMENT DIVISION.      \n"
+          + "       DATA DIVISION.            \n"
+          + "       WORKING-STORAGE SECTION.     \n"
+          + "       01  {$*WC}.          \n"
+          + "           03 {$*WC-HOST-PGM}  PIC X(8) VALUE 'TEST-A'.    \n"
+          + "       01  {$*WW}.       \n"
+          + "           03 {$*WW-RETCODE}     PIC S9(8) COMP-5 VALUE ZERO.  \n"
+          + "           03 {$*WW-PARM}.      \n"
+          + "              05 {$*WW-HOST-APPLID}  PIC X(8).   \n"
+          + "       PROCEDURE DIVISION.        \n"
+          + "                 EXEC CICS LINK      \n"
+          + "                    PROGRAM({$WC-HOST-PGM})      \n"
+          + "                    APPLID({$WW-HOST-APPLID})    \n"
+          + "                    RETCODE({$WW-RETCODE})      \n"
+          + "                    SYNCONRETURN         \n"
+          + "                 END-EXEC .       \n";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+}

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMappingMaintainedForEmbeddedCode.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMappingMaintainedForEmbeddedCode.java
@@ -63,7 +63,7 @@ public class TestMappingMaintainedForEmbeddedCode {
           + "      *  some comments                                              \n"
           + "      *                                                                         \n"
           + "                 EXEC CICS LINK                                                 \n"
-          + "                    PROGRAM({$PGM})                                        \n"
+          + "                    PROGRAM(PGM)                                        \n"
           + "                    {DUMMY-CMD|1}()                            \n"
           + "                    SYNCONRETURN                                                \n"
           + "                 END-EXEC                                                       \n"
@@ -117,7 +117,7 @@ public class TestMappingMaintainedForEmbeddedCode {
             "1",
             new Diagnostic(
                 new Range(),
-                "Syntax error on 'DUMMY-CMD' expected {CHANNEL, COMMAREA, INPUTMSG, RESP, RESP2, SYNCONRETURN, SYSID, TRANSID}",
+                    "No viable alternative at input LINK\n                    PROGRAM(PGM)\n                    DUMMY-CMD",
                 Error,
                 ErrorSource.PARSING.getText())));
   }


### PR DESCRIPTION
tolerate CICS LINK EXCI statement. This is a temporary fix.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test syntax from https://www.ibm.com/docs/en/cics-ts/6.1?topic=interface-exec-cics-link-command-exci is supported

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
