### PR TITLE
fix: fix security vulnerability from import-in-the-middle

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package-lock.json
+++ b/clients/cobol-lsp-vscode-extension/package-lock.json
@@ -11,7 +11,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@code4z/cobol-dialect-api": "file:../cobol-dialect-api",
-        "@vscode/extension-telemetry": "0.8.2",
+        "@vscode/extension-telemetry": "^0.8.2",
         "glob": "10.2.7",
         "iconv-lite": "^0.6.3",
         "micromatch": "4.0.5",
@@ -158,19 +158,41 @@
       }
     },
     "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.4.tgz",
-      "integrity": "sha512-bSF2l47Od7kH+u/O67cmQCj5jmNeC+gUNDKr2cMfLBwSqk12T7B4JZQ34viEq2vhLWoKbZO7j6srPmKiSGPzNg==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.5.tgz",
+      "integrity": "sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==",
       "dependencies": {
         "@azure/core-tracing": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.14.0",
-        "@opentelemetry/instrumentation": "^0.40.0",
+        "@opentelemetry/core": "^1.15.2",
+        "@opentelemetry/instrumentation": "^0.41.2",
         "tslib": "^2.2.0"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@azure/opentelemetry-instrumentation-azure-sdk/node_modules/@opentelemetry/core": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@azure/opentelemetry-instrumentation-azure-sdk/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1697,14 +1719,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.40.0.tgz",
-      "integrity": "sha512-23TzBKPflUS1uEq5SXymnQKQDSda35KvHjnvxdcDQGE+wg6hwDHgScUCWiBmZW4sxAaPcANfs+Wc9B7yDuyT6Q==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
+      "integrity": "sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.3.5",
-        "require-in-the-middle": "^7.1.0",
-        "semver": "^7.3.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.1",
         "shimmer": "^1.2.1"
       },
       "engines": {
@@ -2160,13 +2182,19 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -2919,8 +2947,7 @@
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
-      "dev": true
+      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -4526,10 +4553,13 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
-      "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
       "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
     },
@@ -8915,16 +8945,31 @@
       }
     },
     "@azure/opentelemetry-instrumentation-azure-sdk": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.4.tgz",
-      "integrity": "sha512-bSF2l47Od7kH+u/O67cmQCj5jmNeC+gUNDKr2cMfLBwSqk12T7B4JZQ34viEq2vhLWoKbZO7j6srPmKiSGPzNg==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.5.tgz",
+      "integrity": "sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==",
       "requires": {
         "@azure/core-tracing": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.14.0",
-        "@opentelemetry/instrumentation": "^0.40.0",
+        "@opentelemetry/core": "^1.15.2",
+        "@opentelemetry/instrumentation": "^0.41.2",
         "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+          "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.15.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+          "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw=="
+        }
       }
     },
     "@babel/code-frame": {
@@ -10119,14 +10164,14 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.40.0.tgz",
-      "integrity": "sha512-23TzBKPflUS1uEq5SXymnQKQDSda35KvHjnvxdcDQGE+wg6hwDHgScUCWiBmZW4sxAaPcANfs+Wc9B7yDuyT6Q==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
+      "integrity": "sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==",
       "requires": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.3.5",
-        "require-in-the-middle": "^7.1.0",
-        "semver": "^7.3.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.1",
         "shimmer": "^1.2.1"
       },
       "dependencies": {
@@ -10513,9 +10558,13 @@
     "acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
+    },
+    "acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -11054,8 +11103,7 @@
     "cjs-module-lexer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
-      "dev": true
+      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -12232,10 +12280,13 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
-      "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
       "requires": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
     },

--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -470,7 +470,7 @@
     "glob": "10.2.7",
     "iconv-lite": "^0.6.3",
     "micromatch": "4.0.5",
-    "@vscode/extension-telemetry": "0.8.2",
+    "@vscode/extension-telemetry": "^0.8.2",
     "vscode-languageclient": "8.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
fix security vulnerability from import-in-the-middle. v1.3.4 version of the library contains a known security vulnerability: CVE-2023-38704.Updated to recommended vesion v1.4.2

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] run command `npm ls import-in-the-middle` on the clients\cobol-lsp-vscode-extension folder and check that import-in-the-middle@1.4.2 is present and not a version less than v1.4.2

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
