### PR TITLE
fix: show no error for inline comment with just comment tag

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/TechnicalLexer.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/TechnicalLexer.g4
@@ -23,7 +23,7 @@ ASTERISKCHAR : '*';
 DOUBLEASTERISKCHAR : '**';
 COLONCHAR : ':';
 COMMACHAR : ',';
-COMMENTTAG : '*>';
+COMMENTTAG : '*>' -> channel(COMMENTS);
 DOLLARCHAR : '$';
 DOUBLEQUOTE : '"';
 DOUBLEEQUALCHAR : '==';
@@ -77,7 +77,7 @@ HEX_NUMBERS : HEXNUMBER;
 
 // whitespace, line breaks, comments, ...
 NEWLINE : '\r'? '\n' -> channel(HIDDEN);
-COMMENTLINE : COMMENTTAG WS ~('\n' | '\r')* -> channel(COMMENTS);
+COMMENTLINE : COMMENTTAG ~('\n' | '\r')* -> channel(COMMENTS);
 WS : [ \t\f]+ -> channel(HIDDEN);
 COMPILERLINE : DOUBLEMORETHANCHAR ~('\n' | '\r')* -> channel(HIDDEN);
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestInlineCommentWithOnlyCommentTag.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestInlineCommentWithOnlyCommentTag.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** Tests inline comment with just the comment tag doesn't throw error. */
+public class TestInlineCommentWithOnlyCommentTag {
+  private static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST1.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION. *>\n"
+          + "       77 {$*VARNAME} USAGE INDEX.\n"
+          + "       PROCEDURE DIVISION.\n";
+
+  private static final String TEXT2 =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST1.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION. *>no space after tag\n"
+          + "       77 {$*VARNAME} USAGE INDEX.\n"
+          + "       PROCEDURE DIVISION.\n";
+
+  @Test
+  void testNoErrorWhenCommentTagNotFollowedByText() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void testNoErrorWhenCommentTagisFollowedByTextWithoutSpace() {
+    UseCaseEngine.runTest(TEXT2, ImmutableList.of(), ImmutableMap.of());
+  }
+}

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/TechnicalLexer.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/TechnicalLexer.g4
@@ -23,7 +23,7 @@ ASTERISKCHAR : '*';
 DOUBLEASTERISKCHAR : '**';
 COLONCHAR : ':';
 COMMACHAR : ',';
-COMMENTTAG : '*>';
+COMMENTTAG : '*>' -> channel(COMMENTS);
 DOLLARCHAR : '$';
 DOUBLEMORETHANCHAR : '>>';
 
@@ -65,7 +65,7 @@ HEX_NUMBERS : HEXNUMBER;
 
 // whitespace, line breaks, comments, ...
 NEWLINE : '\r'? '\n' -> channel(HIDDEN);
-COMMENTLINE : COMMENTTAG WS ~('\n' | '\r')* -> channel(COMMENTS);
+COMMENTLINE : COMMENTTAG ~('\n' | '\r')* -> channel(COMMENTS);
 WS : [ \t\f]+ -> channel(HIDDEN);
 COMPILERLINE : DOUBLEMORETHANCHAR ~('\n' | '\r')* -> channel(HIDDEN);
 


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test inline comment with just comment tag do not throw error

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
