### PR TITLE
fix: allow SYMBOL as variable name

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/variables/TestSymbolVariableName.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/variables/TestSymbolVariableName.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases.variables;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Symbol variable name should not cause an error.
+ */
+public class TestSymbolVariableName {
+
+  private static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID.  SYMVAR.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*SYMBOL} PIC X(10).\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           DISPLAY {$SYMBOL}.\n";
+
+    @Test
+    void test() {
+        UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+    }
+}

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -2502,7 +2502,7 @@ basis
    ;
 
 cobolWord
-   : IDENTIFIER
+   : IDENTIFIER | SYMBOL
    | cobolCompilerDirectivesKeywords | cobolKeywords
    | cicsTranslatorCompileDirectivedKeywords | cics_conditions
    ;


### PR DESCRIPTION
## How Has This Been Tested?

This code should not cause any error diagnostics.

```
       IDENTIFICATION DIVISION.
       PROGRAM-ID.  SYMVAR.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 SYMBOL PIC X(10).
       PROCEDURE DIVISION.
            DISPLAY SYMBOL.
```

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
