### PR TITLE
fix: allow fetch into variable

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/Db2SqlParser.g4
@@ -667,7 +667,7 @@ dbs_fetch_multi: dbs_fetch_rowsetpos? FROM? dbs_cursor_name dbs_fetch_multirow;
 dbs_fetch_rowsetpos: (ROWSET STARTING AT (ABSOLUTE | RELATIVE) (dbs_host_variable | dbs_integer_constant) | (NEXT | PRIOR |
                     FIRST | LAST | CURRENT) ROWSET);
 dbs_fetch_multirow: (FOR (dbs_host_variable | dbs_integer_constant) ROWS)? ((INTO | USING) (DESCRIPTOR dbs_descriptor_name |
-                    dbs_host_variable_array (dbs_comma_separator dbs_host_variable_array)*))?;
+                    dbs_fetch_target_variable (dbs_comma_separator dbs_fetch_target_variable)*))?;
 
 
 /*FREE LOCATOR */

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlAllAlterStatements.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlAllAlterStatements.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases.sql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Parse FETCH NEXT ROWSET FROM TEST INTO :VAR
+ */
+class TestSqlColonsInFetchStatements {
+
+  private static final String TEXT = "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. CASE1.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*VAR} PIC X(3).\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           EXEC SQL FETCH NEXT ROWSET FROM TEST INTO :{$VAR} END-EXEC.";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+}


### PR DESCRIPTION
```
       IDENTIFICATION DIVISION.
       PROGRAM-ID. CASE1.
       ENVIRONMENT DIVISION.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 VAR PIC X(3).
       PROCEDURE DIVISION.
           EXEC SQL FETCH NEXT ROWSET FROM TEST INTO :VAR END-EXEC.
```

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
