### PR TITLE
fix: remove area A warning for exec sql block

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/CobolVisitor.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/CobolVisitor.java
@@ -549,7 +549,6 @@ public class CobolVisitor extends CobolParserBaseVisitor<List<Node>> {
 
   @Override
   public List<Node> visitExecSqlStatement(ExecSqlStatementContext ctx) {
-    areaBWarning(ctx);
     return Collections.emptyList();
   }
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestExecVarDoesNotProduceNPE.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestExecVarDoesNotProduceNPE.java
@@ -32,7 +32,7 @@ class TestExecVarDoesNotProduceNPE {
           + "       PROGRAM-ID. TEST1.\n"
           + "       DATA DIVISION.\n"
           + "       WORKING-STORAGE SECTION.\n"
-          + "       {01|1} {EXEC|2|3}\n";
+          + "       {01|1} {EXEC|2}\n";
 
   @Test
   void test() {
@@ -62,12 +62,6 @@ class TestExecVarDoesNotProduceNPE {
                     + "RDATT, REDEFINES, RES, SIGN, SYMBOL, SYNC, SYNCHRONIZED, SZ, TRAILING, TRIG, UNEXPIN, USAGE, UTF-8,"
                     + " VALUE, VALUES, YEARWINDOW, YW, '.', IDENTIFIER}",
                 DiagnosticSeverity.Error,
-                ErrorSource.PARSING.getText()),
-            "3",
-            new Diagnostic(
-                new Range(),
-                "The following token must start in Area B: EXEC",
-                DiagnosticSeverity.Warning,
                 ErrorSource.PARSING.getText())));
   }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlStatementMustCodedInAreaB.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlStatementMustCodedInAreaB.java
@@ -17,11 +17,7 @@ package org.eclipse.lsp.cobol.usecases;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.eclipse.lsp.cobol.common.error.ErrorSource;
 import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
-import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 
 /** This test checks if SQL statements coded in Area B */
@@ -33,8 +29,8 @@ class TestSqlStatementMustCodedInAreaB {
           + "       WORKING-STORAGE SECTION.\n"
           + "       PROCEDURE DIVISION."
           + "              EXEC SQL\n"
-          + "         {SELECT|1} * FROM EMP;\n"
-          + "         {WHERE|2} ID = 0;\n"
+          + "         SELECT * FROM EMP;\n"
+          + "         WHERE ID = 0;\n"
           + "              END-EXEC.\n";
 
   @Test
@@ -42,18 +38,6 @@ class TestSqlStatementMustCodedInAreaB {
     UseCaseEngine.runTest(
         TEXT,
         ImmutableList.of(),
-        ImmutableMap.of(
-            "1",
-            new Diagnostic(
-                new Range(),
-                "The following token must start in Area B: SELECT",
-                DiagnosticSeverity.Warning,
-                ErrorSource.PARSING.getText()),
-            "2",
-            new Diagnostic(
-                new Range(),
-                "The following token must start in Area B: WHERE",
-                DiagnosticSeverity.Warning,
-                ErrorSource.PARSING.getText())));
+        ImmutableMap.of());
   }
 }

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -987,17 +987,17 @@ paragraph
    ;
 
 sentence
-   : statement* (endClause | dialectStatement)
+   : (statement | execSqlStatementInProcedureDivision) * (endClause | dialectStatement)
    ;
 
 conditionalStatementCall
-   : statement | dialectStatement
+   : statement | dialectStatement | execSqlStatementInProcedureDivision
    ;
 
 statement
    : acceptStatement | addStatement | allocateStatement | alterStatement | callStatement | cancelStatement | closeStatement | computeStatement | continueStatement | deleteStatement |
     disableStatement | displayStatement | divideStatement | enableStatement | entryStatement | evaluateStatement | exhibitStatement | execCicsStatement |
-    execSqlStatementInProcedureDivision | execSqlImsStatement | exitStatement | freeStatement | generateStatement | gobackStatement | goToStatement | ifStatement | initializeStatement |
+    execSqlImsStatement | exitStatement | freeStatement | generateStatement | gobackStatement | goToStatement | ifStatement | initializeStatement |
     initiateStatement | inspectStatement | mergeStatement | moveStatement | multiplyStatement | openStatement | performStatement | purgeStatement |
     readStatement | readyResetTraceStatement | receiveStatement | releaseStatement | returnStatement | rewriteStatement | searchStatement | sendStatement |
     serviceReloadStatement | serviceLabelStatement | setStatement | sortStatement | startStatement | stopStatement | stringStatement | subtractStatement |


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Expect no area A warning for exec sql block

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
