### PR TITLE
fix: warn the usage of deprecated cobol 5 compiler directives

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/CobolVisitor.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/CobolVisitor.java
@@ -593,6 +593,18 @@ public class CobolVisitor extends CobolParserBaseVisitor<List<Node>> {
   }
 
   @Override
+  public List<Node> visitDeprecatedCompilerOptions(DeprecatedCompilerOptionsContext ctx) {
+    retrieveLocality(ctx).ifPresent(locality -> errors.add(SyntaxError.syntaxError()
+            .errorSource(ErrorSource.PARSING)
+            .errorCode(() -> "IGYOS4003-E")
+            .location(locality.toOriginalLocation())
+            .suggestion(messageService.getMessage("compilerDirective.deprecatedDirectiveUse", ctx.getText()))
+            .severity(ErrorSeverity.ERROR)
+            .build()));
+    return Collections.emptyList();
+  }
+
+  @Override
   public List<Node> visitParagraphName(ParagraphNameContext ctx) {
     return addTreeNode(
         ctx, locality -> new CodeBlockUsageNode(locality, VisitorHelper.getName(ctx)));

--- a/server/engine/src/main/resources/resourceBundles/messages_en.properties
+++ b/server/engine/src/main/resources/resourceBundles/messages_en.properties
@@ -116,3 +116,5 @@ xmlParse.returnNational.phrase=RETURNING NATIONAL phrase can be specified only w
 xmlParse.unsupported.ccid=CCID not supported
 xmlParse.encoding.phrase=The ENCODING phrase can be specified only when the XMLPARSE(XMLSS) compiler option is in effect
 xmlParse.ccid.nationalItem=A national item codepage must be 1200
+compilerDirective.deprecatedDirectiveUse=%s is a deprecated compiler directive
+

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestProcessCbl.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestProcessCbl.java
@@ -457,7 +457,17 @@ class TestProcessCbl {
   @ParameterizedTest
   @MethodSource("getDeprecatedOptions")
   void testDeprecatedOption(String cblOption) {
-    UseCaseEngine.runTest(PREFIX + cblOption + SUFFIX, ImmutableList.of(), ImmutableMap.of());
+    UseCaseEngine.runTest(
+        PREFIX + "{" + cblOption + "|1}" + SUFFIX,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                new Range(),
+                String.format("%s is a deprecated compiler directive", cblOption.replace(" ", "")),
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText(),
+                "IGYOS4003-E")));
   }
 
   @Test


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Use deprecated compile directives in the code (for e.g. NOCMPR2), should show a error

## Checklist:
- [x] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
