### PR TITLE
fix: allow EXEC SQL in LOCAL STORAGE

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlExecInDataSection.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlExecInDataSection.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases.sql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test EXEC SQL in data definition section
+ */
+class TestSqlExecInDataSection {
+  private static final String TEXT = "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. SQLISSUE.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       DATA DIVISION.\n"
+          + "       LOCAL-STORAGE SECTION.\n"
+          + "           EXEC SQL\n"
+          + "               BEGIN DECLARE SECTION\n"
+          + "           END-EXEC.\n"
+          + "       01  {$*ROOT}.\n"
+          + "           03  {$*A} PIC X(8).\n"
+          + "           EXEC SQL\n"
+          + "               END DECLARE SECTION\n"
+          + "           END-EXEC.\n";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+}

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -736,7 +736,12 @@ linkageSection
 // -- local storage section ----------------------------------
 
 localStorageSection
-   : LOCAL_STORAGE SECTION DOT_FS dataDescriptionEntries
+   : LOCAL_STORAGE SECTION DOT_FS dataDescriptionEntryForLocalStorageSection*
+   ;
+
+dataDescriptionEntryForLocalStorageSection
+   : execSqlStatementInLocalStorage
+   | dataDescriptionEntry
    ;
 
 dataDescriptionEntries
@@ -1386,6 +1391,10 @@ execSqlStatementInProcedureDivision
    ;
 
 execSqlStatementInWorkingStorage
+   : execSqlStatement DOT_FS?
+   ;
+
+execSqlStatementInLocalStorage
    : execSqlStatement DOT_FS?
    ;
 


### PR DESCRIPTION
## How Has This Been Tested?

```
       IDENTIFICATION DIVISION.
       PROGRAM-ID. SQLISSUE.
       ENVIRONMENT DIVISION.
       DATA DIVISION.
       LOCAL-STORAGE SECTION.
           EXEC SQL
               BEGIN DECLARE SECTION
           END-EXEC.
       01  ROOT.
           03  A PIC X(8).
           EXEC SQL
               END DECLARE SECTION
           END-EXEC.
```

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
