### PR TITLE
fix: db2 predefined variables

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/processors/implicit/Db2ImplicitVariablesGenerator.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/processors/implicit/Db2ImplicitVariablesGenerator.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.engine.processors.implicit;
+
+import lombok.experimental.UtilityClass;
+import org.eclipse.lsp.cobol.common.model.Locality;
+import org.eclipse.lsp.cobol.common.model.tree.variable.ElementaryItemNode;
+import org.eclipse.lsp.cobol.common.model.tree.variable.GroupItemNode;
+import org.eclipse.lsp.cobol.common.model.tree.variable.UsageFormat;
+import org.eclipse.lsp.cobol.common.model.tree.variable.VariableNode;
+import org.eclipse.lsp.cobol.common.utils.ImplicitCodeUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Generates SQLCA data structure for DB2
+ */
+@UtilityClass
+public class Db2ImplicitVariablesGenerator {
+  static final Locality LOCALITY = Locality.builder()
+          .uri(ImplicitCodeUtils.createFullUrl("implicit-code-SQLCA_DB2"))
+          .build();
+
+  /**
+   * Generates SQLCA data structure for DB2
+   *
+   * @return SQLCA data structure
+   */
+  public List<VariableNode> generate() {
+  /*
+        01 SQLCA.
+                05 SQLCAID      PIC X(8).
+                05 SQLCABC      PIC S9(9) COMP-5.
+                05 SQLCODE      PIC S9(9) COMP-5.
+                05 SQLERRM.
+                49 SQLERRML  PIC S9(4) COMP-5.
+                49 SQLERRMC  PIC X(70).
+                05 SQLERRP      PIC X(8).
+                05 SQLERRD      OCCURS 6 TIMES
+                                PIC S9(9) COMP-5.
+                05 SQLWARN.
+                10 SQLWARN0  PIC X.
+                10 SQLWARN1  PIC X.
+                10 SQLWARN2  PIC X.
+                10 SQLWARN3  PIC X.
+                10 SQLWARN4  PIC X.
+                10 SQLWARN5  PIC X.
+                10 SQLWARN6  PIC X.
+                10 SQLWARN7  PIC X.
+                05 SQLEXT.
+                10 SQLWARN8  PIC X.
+                10 SQLWARN9  PIC X.
+                10 SQLWARNA  PIC X.
+                10 SQLSTATE  PIC X(5).
+   */
+    VariableNode variable = new GroupItemNode(LOCALITY, 1, "SQLCA", false, false, UsageFormat.UNDEFINED);
+    addElement(variable, 5, "SQLCAID", "X(8)");
+    addElement(variable, 5, "SQLCABC", "S9(9)", UsageFormat.COMP_5);
+    addElement(variable, 5, "SQLCODE", "S9(9)", UsageFormat.COMP_5);
+    GroupItemNode sqlerrm = new GroupItemNode(LOCALITY, 5, "SQLERRM", false, false, UsageFormat.UNDEFINED);
+    variable.addChild(sqlerrm);
+    addElement(sqlerrm, 49, "SQLERRML", "S9(4)", UsageFormat.COMP_5);
+    addElement(sqlerrm, 49, "SQLERRMC", "X(70)");
+    addElement(variable, 5, "SQLERRP", "X(8)");
+    addElement(variable, 5, "SQLERRD", "S9(9)", UsageFormat.COMP_5);
+    GroupItemNode sqlwarn = new GroupItemNode(LOCALITY, 5, "SQLWARN", false, false, UsageFormat.UNDEFINED);
+    variable.addChild(sqlwarn);
+
+    addElement(sqlwarn, 10, "SQLWARN0", "X");
+    addElement(sqlwarn, 10, "SQLWARN1", "X");
+    addElement(sqlwarn, 10, "SQLWARN2", "X");
+    addElement(sqlwarn, 10, "SQLWARN3", "X");
+    addElement(sqlwarn, 10, "SQLWARN4", "X");
+    addElement(sqlwarn, 10, "SQLWARN5", "X");
+    addElement(sqlwarn, 10, "SQLWARN6", "X");
+    addElement(sqlwarn, 10, "SQLWARN7", "X");
+
+    GroupItemNode sqlext = new GroupItemNode(LOCALITY, 5, "SQLEXT", false, false, UsageFormat.UNDEFINED);
+    variable.addChild(sqlext);
+    addElement(sqlext, 10, "SQLWARN8", "X");
+    addElement(sqlext, 10, "SQLWARN9", "X");
+    addElement(sqlext, 10, "SQLWARNA", "X");
+    addElement(sqlext, 10, "SQLSTATE", "X(5)");
+
+    return Collections.singletonList(variable);
+
+  }
+
+  private static void addElement(VariableNode parent, int level, String name, String pic) {
+    addElement(parent, level, name, pic, UsageFormat.UNDEFINED);
+  }
+
+  private static void addElement(VariableNode parent, int level, String name, String pic, UsageFormat usageFormat) {
+    parent.addChild(new ElementaryItemNode(LOCALITY, level, name, false, pic,
+            null, usageFormat, false, false, false));
+  }
+}

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/core/model/tree/logic/implicit/ImplicitVariablesProcessorTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/core/model/tree/logic/implicit/ImplicitVariablesProcessorTest.java
@@ -31,7 +31,7 @@ import org.eclipse.lsp.cobol.core.engine.processors.implicit.ImplicitVariablesPr
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 import static org.mockito.Mockito.*;
 
@@ -43,7 +43,7 @@ class ImplicitVariablesProcessorTest {
   private static final int CICS_INTRODUCED_REGISTERS_COUNT = 72;
   private static final AnalysisConfig ANALYSIS_CONFIG_CICS_TRANSLATE_DIABLED = new AnalysisConfig(
           new CopybookConfig(CopybookProcessingMode.ENABLED, SQLBackend.DB2_SERVER),
-          Arrays.asList(EmbeddedLanguage.values()),
+          Collections.singletonList(EmbeddedLanguage.CICS),
           ImmutableList.of(), false, ImmutableList.of(), ImmutableMap.of());
   private ProcessingContext processingContext;
   private VariableAccumulator variableAccumulator;
@@ -56,8 +56,10 @@ class ImplicitVariablesProcessorTest {
 
     when(processingContext.getVariableAccumulator()).thenReturn(variableAccumulator);
     processor =
-        new ImplicitVariablesProcessor(
-            AnalysisConfig.defaultConfig(CopybookProcessingMode.ENABLED));
+            new ImplicitVariablesProcessor(new AnalysisConfig(
+                    new CopybookConfig(CopybookProcessingMode.ENABLED, SQLBackend.DB2_SERVER),
+                    Collections.singletonList(EmbeddedLanguage.CICS),
+                    ImmutableList.of(), true, ImmutableList.of(), ImmutableMap.of()));
   }
 
   @Test

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlIncludeStatementForImplicitlyDefinedCpy.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlIncludeStatementForImplicitlyDefinedCpy.java
@@ -36,112 +36,151 @@ import static org.eclipse.lsp4j.DiagnosticSeverity.Error;
  */
 class TestSqlIncludeStatementForImplicitlyDefinedCpy {
   private static final String TEXT_BACKEND_DB2 =
-      "       IDENTIFICATION DIVISION.\n"
-          + "       PROGRAM-ID. HELLO-DB2.\n"
-          + "       DATA DIVISION.\n"
-          + "       WORKING-STORAGE SECTION.\n"
-          + "           EXEC SQL INCLUDE {~SQLCA} END-EXEC.\n"
-          + "           EXEC SQL INCLUDE {~SQLDA} END-EXEC.\n"
-          + "       PROCEDURE DIVISION.\n"
-          + "           MOVE 23 TO {$SQLCAID}  OF  {$SQLCA}.\n"
-          + "           MOVE 63 TO {$SQLCABC} OF  {$SQLCA}.\n"
-          + "           MOVE 00 TO {$SQLCODE} OF  {$SQLCA}.\n"
-          + "           MOVE 144 TO {$SQLN} OF  {$SQLDA}.\n"
-          + "           MOVE 200 TO {$SQLD} OF  {$SQLDA}.\n"
-          + "           IF {$SQLCODE} = ZERO  THEN  DISPLAY \"SUCCESS SQLCODE = \" {$SQLCODE}\n "
-          + "           ELSE DISPLAY \" FAIL SQLEXT = \"  {$SQLEXT}.\n"
-          + "           DISPLAY  {$SQLCABC} .\n"
-          + "           DISPLAY  {$SQLERRMC}.\n"
-          + "           DISPLAY  {$SQLN}.\n"
-          + "           DISPLAY  {$SQLD}.\n";
+          "       IDENTIFICATION DIVISION.\n"
+                  + "       PROGRAM-ID. HELLO-DB2.\n"
+                  + "       DATA DIVISION.\n"
+                  + "       WORKING-STORAGE SECTION.\n"
+                  + "           EXEC SQL INCLUDE {~SQLCA} END-EXEC.\n"
+                  + "           EXEC SQL INCLUDE {~SQLDA} END-EXEC.\n"
+                  + "       PROCEDURE DIVISION.\n"
+                  + "           MOVE 23 TO {$SQLCAID}  OF  {$SQLCA}.\n"
+                  + "           MOVE 63 TO {$SQLCABC} OF  {$SQLCA}.\n"
+                  + "           MOVE 00 TO {$SQLCODE} OF  {$SQLCA}.\n"
+                  + "           MOVE 144 TO {$SQLN} OF  {$SQLDA}.\n"
+                  + "           MOVE 200 TO {$SQLD} OF  {$SQLDA}.\n"
+                  + "           IF {$SQLCODE} = ZERO  THEN  DISPLAY \"SUCCESS SQLCODE = \" {$SQLCODE}\n "
+                  + "           ELSE DISPLAY \" FAIL SQLEXT = \"  {$SQLEXT}.\n"
+                  + "           DISPLAY  {$SQLCABC} .\n"
+                  + "           DISPLAY  {$SQLERRMC}.\n"
+                  + "           DISPLAY  {$SQLN}.\n"
+                  + "           DISPLAY  {$SQLD}.\n";
 
   private static final String TEXT_BACKEND_DATACOM =
-      "       IDENTIFICATION DIVISION.\n"
-          + "       PROGRAM-ID. HELLO-DB2.\n"
-          + "       DATA DIVISION.\n"
-          + "       WORKING-STORAGE SECTION.\n"
-          + "           EXEC SQL INCLUDE {~SQLCA} END-EXEC.\n"
-          + "           EXEC SQL INCLUDE {~SQLDA} END-EXEC.\n"
-          + "       PROCEDURE DIVISION.\n"
-          + "           MOVE 23 TO {$SQLCA-DB-VRS}  OF  {$SQLCA}.\n"
-          + "           MOVE 00 TO {$SQLCA-SQLCODE} OF  {$SQLCA}.\n"
-          + "           MOVE 44 TO {$SQLCA-ERROR-PGM} OF  {$SQLCA}.\n"
-          + "           MOVE 144 TO {$SQLN} OF  {$SQLDA}.\n"
-          + "           MOVE 200 TO {$SQLD} OF  {$SQLDA}.\n"
-          + "           IF {$SQLCA-SQLCODE} = ZERO  THEN \n"
-          + "               DISPLAY \"SUCCESS CODE = \" {$SQLCA-SQLCODE} \n"
-          + "           ELSE DISPLAY \" FAIL CODE = \"  {$SQLCA-ERROR-PGM}.\n"
-          + "           DISPLAY  {$SQLCA-DB-VRS} .\n"
-          + "           DISPLAY  {$SQLN}.\n"
-          + "           DISPLAY  {$SQLD}.\n";
+          "       IDENTIFICATION DIVISION.\n"
+                  + "       PROGRAM-ID. HELLO-DB2.\n"
+                  + "       DATA DIVISION.\n"
+                  + "       WORKING-STORAGE SECTION.\n"
+                  + "           EXEC SQL INCLUDE {~SQLCA} END-EXEC.\n"
+                  + "           EXEC SQL INCLUDE {~SQLDA} END-EXEC.\n"
+                  + "       PROCEDURE DIVISION.\n"
+                  + "           MOVE 23 TO {$SQLCA-DB-VRS}  OF  {$SQLCA}.\n"
+                  + "           MOVE 00 TO {$SQLCA-SQLCODE} OF  {$SQLCA}.\n"
+                  + "           MOVE 44 TO {$SQLCA-ERROR-PGM} OF  {$SQLCA}.\n"
+                  + "           MOVE 144 TO {$SQLN} OF  {$SQLDA}.\n"
+                  + "           MOVE 200 TO {$SQLD} OF  {$SQLDA}.\n"
+                  + "           IF {$SQLCA-SQLCODE} = ZERO  THEN \n"
+                  + "               DISPLAY \"SUCCESS CODE = \" {$SQLCA-SQLCODE} \n"
+                  + "           ELSE DISPLAY \" FAIL CODE = \"  {$SQLCA-ERROR-PGM}.\n"
+                  + "           DISPLAY  {$SQLCA-DB-VRS} .\n"
+                  + "           DISPLAY  {$SQLN}.\n"
+                  + "           DISPLAY  {$SQLD}.\n";
 
   private static final String TEXT_ERR_PRG =
-      "       IDENTIFICATION DIVISION.\n"
-          + "       PROGRAM-ID. HELLO-DB2.\n"
-          + "       DATA DIVISION.\n"
-          + "       WORKING-STORAGE SECTION.\n"
-          + "           EXEC SQL INCLUDE {~SQLCA} END-EXEC.\n"
-          + "           EXEC SQL INCLUDE {~SQLDA} END-EXEC.\n"
-          + "       PROCEDURE DIVISION.\n"
-          + "           MOVE 23 TO {$SQLCABC}  OF  {$SQLCA}.\n"
-          + "           MOVE 63 TO {$SQLCABC} OF  {$SQLCA}.\n"
-          + "           MOVE 200 TO {$SQLD} OF  {$SQLDA}.\n"
-          + "           IF {SQLCODE|err1} = ZERO  THEN  DISPLAY \"SUCCESS  \"\n "
-          + "           ELSE DISPLAY \" FAILED \"  {SQLEXT|err2}.\n"
-          + "           DISPLAY  {$SQLCABC} .\n"
-          + "           DISPLAY  {$SQLD}.\n";
+          "       IDENTIFICATION DIVISION.\n"
+                  + "       PROGRAM-ID. HELLO-DB2.\n"
+                  + "       DATA DIVISION.\n"
+                  + "       WORKING-STORAGE SECTION.\n"
+                  + "           EXEC SQL INCLUDE {~SQLCA} END-EXEC.\n"
+                  + "           EXEC SQL INCLUDE {~SQLDA} END-EXEC.\n"
+                  + "       PROCEDURE DIVISION.\n"
+                  + "           MOVE 23 TO {$SQLCABC}  OF  {$SQLCA}.\n"
+                  + "           MOVE 63 TO {$SQLCABC} OF  {$SQLCA}.\n"
+                  + "           MOVE 200 TO {$SQLD} OF  {$SQLDA}.\n"
+                  + "           IF {SQLCODE|err1} = ZERO  THEN  DISPLAY \"SUCCESS  \"\n "
+                  + "           ELSE DISPLAY \" FAILED \"  {SQLEXT|err2}.\n"
+                  + "           DISPLAY  {$SQLCABC} .\n"
+                  + "           DISPLAY  {$SQLD}.\n";
+
+  private static final String TEXT_BACKEND_DB2_IMPLICIT =
+          "       IDENTIFICATION DIVISION.\n"
+                  + "       PROGRAM-ID. HELLO-DB2.\n"
+                  + "       PROCEDURE DIVISION.\n"
+                  + "           IF {$SQLCODE} = ZERO  THEN  DISPLAY \"SUCCESS SQLCODE = \" {$SQLCODE}\n "
+                  + "           ELSE DISPLAY \" FAIL SQLEXT = \"  {$SQLEXT}.\n";
+
+  private static final String TEXT_BACKEND_DB2_2 =
+                    "       IDENTIFICATION DIVISION.\n"
+                  + "       PROGRAM-ID. HELLO-DB2.\n"
+                  + "       DATA DIVISION.\n"
+                  + "       WORKING-STORAGE SECTION.\n"
+                  + "       EXEC SQL\n"
+                  + "         INCLUDE {~SQLCA}\n"
+                  + "       END-EXEC.\n"
+                  + "       PROCEDURE DIVISION.\n"
+                  + "           IF {$SQLCODE} = ZERO  THEN  DISPLAY \"SUCCESS SQLCODE = \" {$SQLCODE}\n "
+                  + "           ELSE DISPLAY \" FAIL SQLEXT = \"  {$SQLEXT}.\n";
 
   private static final String ERR_MESSAGE = "Variable %s is not defined";
 
   @Test
   void test1() {
     UseCaseEngine.runTest(
-        TEXT_BACKEND_DB2,
-        ImmutableList.of(),
-        ImmutableMap.of(),
-        ImmutableList.of(),
-        AnalysisConfig.defaultConfig(CopybookProcessingMode.ENABLED));
+            TEXT_BACKEND_DB2,
+            ImmutableList.of(),
+            ImmutableMap.of(),
+            ImmutableList.of(),
+            AnalysisConfig.defaultConfig(CopybookProcessingMode.ENABLED));
   }
 
   @Test
   void test2() {
     UseCaseEngine.runTest(
-        TEXT_BACKEND_DATACOM,
-        ImmutableList.of(),
-        ImmutableMap.of(),
-        ImmutableList.of(),
-        new AnalysisConfig(
-            new CopybookConfig(CopybookProcessingMode.ENABLED, SQLBackend.DATACOM_SERVER),
+            TEXT_BACKEND_DATACOM,
             ImmutableList.of(),
-            ImmutableList.of(), true,
+            ImmutableMap.of(),
             ImmutableList.of(),
-            ImmutableMap.of()));
+            new AnalysisConfig(
+                    new CopybookConfig(CopybookProcessingMode.ENABLED, SQLBackend.DATACOM_SERVER),
+                    ImmutableList.of(),
+                    ImmutableList.of(), true,
+                    ImmutableList.of(),
+                    ImmutableMap.of()));
   }
 
   @Test
   void test3() {
     UseCaseEngine.runTest(
-        TEXT_ERR_PRG,
-        ImmutableList.of(),
-        ImmutableMap.of(
-            "err1",
-            new Diagnostic(
-                new Range(),
-                String.format(ERR_MESSAGE, "SQLCODE"),
-                Error,
-                ErrorSource.PARSING.getText()),
-            "err2",
-            new Diagnostic(
-                new Range(),
-                String.format(ERR_MESSAGE, "SQLEXT"),
-                Error,
-                ErrorSource.PARSING.getText())),
-        ImmutableList.of(),
-        new AnalysisConfig(
-            new CopybookConfig(CopybookProcessingMode.ENABLED, SQLBackend.DATACOM_SERVER),
+            TEXT_ERR_PRG,
             ImmutableList.of(),
-            ImmutableList.of(), true,
+            ImmutableMap.of(
+                    "err1",
+                    new Diagnostic(
+                            new Range(),
+                            String.format(ERR_MESSAGE, "SQLCODE"),
+                            Error,
+                            ErrorSource.PARSING.getText()),
+                    "err2",
+                    new Diagnostic(
+                            new Range(),
+                            String.format(ERR_MESSAGE, "SQLEXT"),
+                            Error,
+                            ErrorSource.PARSING.getText())),
             ImmutableList.of(),
-            ImmutableMap.of()));
+            new AnalysisConfig(
+                    new CopybookConfig(CopybookProcessingMode.ENABLED, SQLBackend.DATACOM_SERVER),
+                    ImmutableList.of(),
+                    ImmutableList.of(), true,
+                    ImmutableList.of(),
+                    ImmutableMap.of()));
+  }
+
+  @Test
+  void test4() {
+    UseCaseEngine.runTest(
+            TEXT_BACKEND_DB2_IMPLICIT,
+            ImmutableList.of(),
+            ImmutableMap.of(),
+            ImmutableList.of(),
+            AnalysisConfig.defaultConfig(CopybookProcessingMode.ENABLED));
+  }
+
+  @Test
+  void test5() {
+    UseCaseEngine.runTest(
+            TEXT_BACKEND_DB2_2,
+            ImmutableList.of(),
+            ImmutableMap.of(),
+            ImmutableList.of(),
+            AnalysisConfig.defaultConfig(CopybookProcessingMode.ENABLED));
   }
 }


### PR DESCRIPTION
## How Has This Been Tested?

```
       IDENTIFICATION DIVISION.
       PROGRAM-ID. HELLO-DB2.
       PROCEDURE DIVISION.
           IF SQLCODE = ZERO  THEN  DISPLAY "SUCCESS SQLCODE = " SQLCODE
           ELSE DISPLAY " FAIL SQLEXT = "  SQLEXT.
```

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
