### PR TITLE
fix: add data type check for file status variable

### DIFF
--- a/server/engine/src/main/resources/resourceBundles/messages_en.properties
+++ b/server/engine/src/main/resources/resourceBundles/messages_en.properties
@@ -118,6 +118,7 @@ xmlParse.encoding.phrase=The ENCODING phrase can be specified only when the XMLP
 xmlParse.ccid.nationalItem=A national item codepage must be 1200
 fileStatus.charLimit=data-name %s was not defined as a two-character item
 fileStatus.allowedSection=%s was not defined in the 'WORKING-STORAGE SECTION', 'LOCAL-STORAGE SECTION' or 'LINKAGE SECTION'
+fileStatus.allowedDataType=data-name %s was not defined as a category alphanumeric data item, a category national data item or as a category numeric data item with either "USAGE DISPLAY" or "USAGE NATIONAL"
 readFileOperation.notOpened=READ statement can only reference a file opened for INPUT or I-O
 writeFileOperation.notOpened=WRITE statement can only reference a file opened for OUTPUT or I-O or EXTEND
 rewriteFileOperation.notOpened=REWRITE statement can only reference a file opened for I-O

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSemanticsForFileStatus.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSemanticsForFileStatus.java
@@ -63,6 +63,44 @@ public class TestSemanticsForFileStatus {
           + "\n"
           + "       PROCEDURE DIVISION.\n";
 
+  public static final String NEGATIVE_TEST_NOT_ALPHANUMERIC =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID.    TEST12.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       FILE-CONTROL.\n"
+          + "           SELECT {$FILE-IN}  file STATUS is {$DS|1} ASSIGN TO UT-S-YYCUSMST .\n"
+          + "       DATA DIVISION.\n"
+          + "       FILE SECTION.\n"
+          + "       FD  {$*FILE-IN} IS EXTERNAL\n"
+          + "           RECORD CONTAINS 450 CHARACTERS\n"
+          + "           DATA RECORDS ARE {$WREHOUSE-RECORD}.\n"
+          + "       01  {$*WREHOUSE-RECORD}                         PIC X(450).\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*DS} PIC V9(2).\n"
+          + "\n"
+          + "       PROCEDURE DIVISION.";
+
+  public static final String POSITIVE_TEST_ALPHANUMERIC =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID.    TEST12.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       FILE-CONTROL.\n"
+          + "           SELECT {$FILE-IN}  file STATUS is {$DS} ASSIGN TO UT-S-YYCUSMST .\n"
+          + "       DATA DIVISION.\n"
+          + "       FILE SECTION.\n"
+          + "       FD  {$*FILE-IN} IS EXTERNAL\n"
+          + "           RECORD CONTAINS 450 CHARACTERS\n"
+          + "           DATA RECORDS ARE {$WREHOUSE-RECORD}.\n"
+          + "       01  {$*WREHOUSE-RECORD}                         PIC X(450).\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*DS}  .\n"
+          + "           05 {$*XY} PIC V9(01) .\n"
+          + "           05 {$*YZ} pic x.\n"
+          + "\n"
+          + "       PROCEDURE DIVISION.";
+
   @Test
   void positiveText() {
     UseCaseEngine.runTest(POSITIVE_TEXT, ImmutableList.of(), ImmutableMap.of());
@@ -86,5 +124,26 @@ public class TestSemanticsForFileStatus {
                 "DS was not defined in the 'WORKING-STORAGE SECTION', 'LOCAL-STORAGE SECTION' or 'LINKAGE SECTION'",
                 DiagnosticSeverity.Error,
                 ErrorSource.PARSING.getText())));
+  }
+
+  @Test
+  void negativeTestForInvalidDataType() {
+    UseCaseEngine.runTest(
+        NEGATIVE_TEST_NOT_ALPHANUMERIC,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                new Range(),
+                "data-name DS was not defined as a category alphanumeric data item, "
+                    + "a category national data item or as a category numeric data item with "
+                    + "either \"USAGE DISPLAY\" or \"USAGE NATIONAL\"",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText())));
+  }
+
+  @Test
+  void positiveTestForInvalidDataType() {
+    UseCaseEngine.runTest(POSITIVE_TEST_ALPHANUMERIC, ImmutableList.of(), ImmutableMap.of());
   }
 }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Following code should work
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID.    TEST12.
       ENVIRONMENT DIVISION.
       INPUT-OUTPUT SECTION.
       FILE-CONTROL.
           SELECT FILE-IN  file STATUS is DS ASSIGN TO UT-S-YYCUSMST .
       DATA DIVISION.
       FILE SECTION.
       FD  FILE-IN IS EXTERNAL
           RECORD CONTAINS 450 CHARACTERS
           DATA RECORDS ARE WREHOUSE-RECORD.
       01  WREHOUSE-RECORD                        PIC X(450).
       WORKING-STORAGE SECTION.
	   	01 DS  .
           05 XY PIC V9(01)  USAGE NATIONAL.
           05 YZ pic x.
       PROCEDURE DIVISION.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
