### PR TITLE
chore: run sonar only on dev for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,6 @@ on:
     branches:
       - development
       - master
-  pull_request_target:
-    branches:
-      - development
-      - master
   push:
     branches:
       - development
@@ -102,6 +98,7 @@ jobs:
           npm ci
           npm run test
       - name: SonarQube Scan
+        if: github.ref == 'refs/heads/development'
         uses: kitabisa/sonarqube-action@v1.2.0
         with:
           projectBaseDir: ${{ github.workspace }}


### PR DESCRIPTION
Disable sonar on PRs for now. We need to figure out the configuration for fork PRs.  On the forked repository, there is no SONAR_TOKEN, so the job must run in our repo (pull_request_target), but we still want to debug run git actions on non-forked PRs.