### PR TITLE
fix: inline comments shouldn't be analysed while preprocessing

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/rewriter/CobolLineIndicatorProcessorImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/rewriter/CobolLineIndicatorProcessorImpl.java
@@ -38,7 +38,7 @@ public class CobolLineIndicatorProcessorImpl implements CobolLineReWriter {
   private static final String EMPTY_STRING = "";
   private static final String DOUBLE_QUOTE_LITERAL = "\"([^\"]|\"\"|'')*+\"";
   private static final String SINGLE_QUOTE_LITERAL = "'([^']|''|\"\")*+'";
-  private static final Pattern FLOATING_COMMENT_LINE =
+  public static final Pattern FLOATING_COMMENT_LINE =
       Pattern.compile("(?<validText>.*?)(?<floatingComment>\\*> .+)?");
 
   /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/transformer/ContinuationLineTransformation.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/transformer/ContinuationLineTransformation.java
@@ -32,11 +32,13 @@ import org.eclipse.lsp4j.Range;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.util.Optional.ofNullable;
 import static org.eclipse.lsp.cobol.common.error.ErrorSeverity.ERROR;
+import static org.eclipse.lsp.cobol.core.preprocessor.delegates.rewriter.CobolLineIndicatorProcessorImpl.FLOATING_COMMENT_LINE;
 
 /**
  * Process continuation lines. Any sentence, entry, clause, or phrase that requires more than one
@@ -60,7 +62,8 @@ public class ContinuationLineTransformation implements CobolLinesTransformation 
   }
 
   @Override
-  public ResultWithErrors<List<CobolLine>> transformLines(
+  public ResultWithErrors<List<CobolLine>>
+  transformLines(
       String documentURI, List<CobolLine> lines) {
     List<CobolLine> result = new ArrayList<>();
     List<SyntaxError> errors = new ArrayList<>();
@@ -212,7 +215,10 @@ public class ContinuationLineTransformation implements CobolLinesTransformation 
       return false;
     }
 
-    String cobolLineToCheck = cobolLine.getContentAreaA() + cobolLine.getContentAreaB();
+    Matcher floatingCommentMatcher = FLOATING_COMMENT_LINE.matcher(cobolLine.getContentArea());
+    String cobolLineToCheck = floatingCommentMatcher.matches()
+            ? floatingCommentMatcher.group("validText")
+            : cobolLine.getContentArea();
     String startChar = findQuoteOpeningChar(cobolLineToCheck);
 
     if (startChar == null) return false;

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestInlineCommentWithOnlyCommentTag.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestInlineCommentWithOnlyCommentTag.java
@@ -38,6 +38,16 @@ public class TestInlineCommentWithOnlyCommentTag {
           + "       77 {$*VARNAME} USAGE INDEX.\n"
           + "       PROCEDURE DIVISION.\n";
 
+  public static final String TEXT3 =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. MIN.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*ABC}  PIC X.                         \n"
+          + "       PROCEDURE DIVISION.                  \n"
+          + "           DISPLAY \"TEST IN PROGRESS\" *> COMMENT '\n"
+          + "           ADD 0 TO {$ABC}.\n";
+
   @Test
   void testNoErrorWhenCommentTagNotFollowedByText() {
     UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
@@ -46,5 +56,10 @@ public class TestInlineCommentWithOnlyCommentTag {
   @Test
   void testNoErrorWhenCommentTagisFollowedByTextWithoutSpace() {
     UseCaseEngine.runTest(TEXT2, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void testFloatingCommentDoNotFlagErrorWhenCommentsHaveUnBalancedQuotes() {
+    UseCaseEngine.runTest(TEXT3, ImmutableList.of(), ImmutableMap.of());
   }
 }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Following code shouldn't flag any error
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. MIN.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 ABC  PIC X.                         
       PROCEDURE DIVISION.                  
       DISPLAY "TEST IN PROGRESS" *> COMMENT '
	   ADD 0 TO ABC.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
