### PR TITLE
fix: floating comment quotes

### DIFF
--- a/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
+++ b/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
@@ -55,7 +55,7 @@
       }
     },
     "comment-floating": {
-      "match": "\\s\\*>\\s.*",
+      "match": "\\s\\*>\\s*.*",
       "name": "comment.line.cobol.floating"
     },
     "number-constant": {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/rewriter/CobolLineIndicatorProcessorImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/rewriter/CobolLineIndicatorProcessorImpl.java
@@ -38,8 +38,8 @@ public class CobolLineIndicatorProcessorImpl implements CobolLineReWriter {
   private static final String EMPTY_STRING = "";
   private static final String DOUBLE_QUOTE_LITERAL = "\"([^\"]|\"\"|'')*+\"";
   private static final String SINGLE_QUOTE_LITERAL = "'([^']|''|\"\")*+'";
-  private static final Pattern FLOATING_COMMENT_LINE =
-      Pattern.compile("(?<validText>.*?)(?<floatingComment>\\*> .+)?");
+  public static final Pattern FLOATING_COMMENT_LINE =
+      Pattern.compile("(?<validText>.*?)(?<floatingComment>\\*>\\s*.+)?");
 
   /**
    * Normalizes the lines by stripping the sequence number and line indicator, and interpreting the

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestInlineCommentWithOnlyCommentTag.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestInlineCommentWithOnlyCommentTag.java
@@ -38,6 +38,19 @@ public class TestInlineCommentWithOnlyCommentTag {
           + "       77 {$*VARNAME} USAGE INDEX.\n"
           + "       PROCEDURE DIVISION.\n";
 
+  public static final String TEXT3 =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TESTREPL.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01  {$*PARENT} PIC 9.\n"
+          + "       01  {$*CHILD1} PIC 9.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "       MAINLINE.\n"
+          + "           MOVE 0 TO   {$CHILD1}   *>\"\"\" '.\n"
+          + "           display \"Testing in progress\"\n"
+          + "           GOBACK.";
+
   @Test
   void testNoErrorWhenCommentTagNotFollowedByText() {
     UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
@@ -46,5 +59,10 @@ public class TestInlineCommentWithOnlyCommentTag {
   @Test
   void testNoErrorWhenCommentTagisFollowedByTextWithoutSpace() {
     UseCaseEngine.runTest(TEXT2, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void testNoErrorWhenCommentTagisFollowedByUnBalancedQuotes() {
+    UseCaseEngine.runTest(TEXT3, ImmutableList.of(), ImmutableMap.of());
   }
 }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Following code should work
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. TESTREPL.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01  PARENT PIC 9.
       01  CHILD1 PIC 9.
       PROCEDURE DIVISION.
       MAINLINE.
           MOVE 0 TO   CHILD1   *>""" '.
           display "what the fuck"
           GOBACK.

``` 

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
