### PR TITLE
fix: fix wrong diagnostic location for embedded code present inside a…

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/analysis/EmbeddedCodeListener.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/analysis/EmbeddedCodeListener.java
@@ -22,17 +22,22 @@ import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 import org.eclipse.lsp.cobol.common.EmbeddedLanguage;
 import org.eclipse.lsp.cobol.common.error.SyntaxError;
-import org.eclipse.lsp.cobol.common.message.MessageService;
 import org.eclipse.lsp.cobol.common.mapping.ExtendedDocument;
+import org.eclipse.lsp.cobol.common.message.MessageService;
+import org.eclipse.lsp.cobol.common.model.Locality;
 import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp.cobol.common.utils.RangeUtils;
 import org.eclipse.lsp.cobol.core.*;
+import org.eclipse.lsp.cobol.core.semantics.CopybooksRepository;
 import org.eclipse.lsp.cobol.core.strategy.CobolErrorStrategy;
 import org.eclipse.lsp.cobol.core.visitor.ParserListener;
 import org.eclipse.lsp.cobol.core.visitor.VisitorHelper;
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
@@ -52,6 +57,7 @@ public class EmbeddedCodeListener extends CobolParserBaseListener {
   private final String programUri;
   private final List<EmbeddedLanguage> features;
   private final ExtendedDocument extendedDocument;
+  private final CopybooksRepository copybooksRepository;
 
   @Getter private final List<Node> resultNodes = new LinkedList<>();
   @Getter private final List<SyntaxError> errors = new LinkedList<>();
@@ -91,16 +97,49 @@ public class EmbeddedCodeListener extends CobolParserBaseListener {
     CommonTokenStream tokens = applyCicsLexer(context);
     CICSParser parser = createCicsParser(tokens);
 
-    Position position = getOriginalPosition(context);
+    Location originalLocation = getOriginalLocation(context);
 
     ParserRuleContext tree = parser.allCicsRules();
     ParseTreeVisitor<List<Node>> visitor = instanceVisitor(createPosition(context.getStart()), EmbeddedLanguage.CICS);
     resultNodes.addAll(visitor.visit(tree));
 
-    errorListener.getErrors().forEach(e -> e.getLocation().getLocation().setRange(
-        RangeUtils.shiftRangeWithPosition(position, e.getLocation().getLocation().getRange())));
+    errors.addAll(fetchError(originalLocation));
+  }
 
-    errors.addAll(errorListener.getErrors());
+  private List<SyntaxError> fetchError(Location originalLocation) {
+    List<SyntaxError> errorList = new ArrayList<>();
+    errorListener.getErrors().forEach(e -> {
+      if (embeddedCodePresentInMainSource(originalLocation)) {
+        e.getLocation().getLocation().setRange(
+                getAdjustedRange(originalLocation, e));
+        errorList.add(e);
+      } else {
+        errorList.add(getSyntaxErrorForCopybook(originalLocation, e));
+      }
+    });
+    return Collections.unmodifiableList(errorList);
+  }
+
+  private Range getAdjustedRange(Location originalLocation, SyntaxError e) {
+    return RangeUtils.shiftRangeWithPosition(originalLocation.getRange().getStart(), e.getLocation().getLocation().getRange());
+  }
+
+  private SyntaxError getSyntaxErrorForCopybook(Location originalLocation, SyntaxError e) {
+    return SyntaxError.syntaxError()
+            .errorSource(e.getErrorSource())
+            .location(
+                    Locality.builder()
+                            .uri(originalLocation.getUri())
+                            .range(getAdjustedRange(originalLocation, e))
+                            .copybookId(copybooksRepository.getCopybookIdByUri(originalLocation.getUri()))
+                            .build().toOriginalLocation())
+            .suggestion(e.getSuggestion())
+            .severity(e.getSeverity())
+            .build();
+  }
+
+  private boolean embeddedCodePresentInMainSource(Location originalLocation) {
+    return extendedDocument.getCurrentText().getUri().equals(originalLocation.getUri());
   }
 
   private Position createPosition(Token token) {
@@ -115,21 +154,18 @@ public class EmbeddedCodeListener extends CobolParserBaseListener {
     SqlCodeContext sqlCode = context.sqlCode();
     if (sqlCode == null) return;
     CommonTokenStream tokens = applyDb2Lexer(sqlCode);
-    Position position = getOriginalPosition(sqlCode);
+    Location originalLocation = getOriginalLocation(sqlCode);
 
     ParserRuleContext tree = grammarStartRule.apply(createDb2SqlParser(tokens));
     ParseTreeVisitor<List<Node>> visitor = instanceVisitor(createPosition(sqlCode.getStart()), EmbeddedLanguage.SQL);
     resultNodes.addAll(visitor.visit(tree));
 
-    errorListener.getErrors().forEach(e -> e.getLocation().getLocation().setRange(
-        RangeUtils.shiftRangeWithPosition(position, e.getLocation().getLocation().getRange())));
-    errors.addAll(errorListener.getErrors());
+    errors.addAll(fetchError(originalLocation));
   }
 
-  private Position getOriginalPosition(ParserRuleContext parserRuleContext) {
+  private Location getOriginalLocation(ParserRuleContext parserRuleContext) {
     return extendedDocument.mapLocation(
-            new Range(createPosition(parserRuleContext.getStart()), createPosition(parserRuleContext.getStop())))
-            .getRange().getStart();
+            new Range(createPosition(parserRuleContext.getStart()), createPosition(parserRuleContext.getStop())));
   }
 
   private CommonTokenStream applyDb2Lexer(ParserRuleContext context) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/analysis/EmbeddedCodeService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/analysis/EmbeddedCodeService.java
@@ -25,6 +25,7 @@ import org.eclipse.lsp.cobol.common.message.MessageService;
 import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp.cobol.common.utils.ThreadInterruptionUtil;
 import org.eclipse.lsp.cobol.core.CobolParser;
+import org.eclipse.lsp.cobol.core.semantics.CopybooksRepository;
 import org.eclipse.lsp.cobol.core.visitor.ParserListener;
 
 import java.util.List;
@@ -49,17 +50,19 @@ public class EmbeddedCodeService {
    * @param treeListener a Parse Tree Listener
    * @param programUri a program uri
    * @param features is a list of language features such as CICS or SQL
+   * @param copybooksRepository  - copybook repository
    * @return a list of embedded code nodes with errors
    */
   public ResultWithErrors<List<Node>> generateNodes(
-      ExtendedDocument extendedDocument,
-      ParserListener listener,
-      CobolParser.StartRuleContext tree,
-      ParseTreeListener treeListener,
-      String programUri,
-      List<EmbeddedLanguage> features) {
+          ExtendedDocument extendedDocument,
+          ParserListener listener,
+          CobolParser.StartRuleContext tree,
+          ParseTreeListener treeListener,
+          String programUri,
+          List<EmbeddedLanguage> features,
+          CopybooksRepository copybooksRepository) {
     ThreadInterruptionUtil.checkThreadInterrupted();
-    EmbeddedCodeListener embeddedLanguagesListener = new EmbeddedCodeListener(messageService, treeListener, listener, programUri, features, extendedDocument);
+    EmbeddedCodeListener embeddedLanguagesListener = new EmbeddedCodeListener(messageService, treeListener, listener, programUri, features, extendedDocument, copybooksRepository);
     new ParseTreeWalker().walk(embeddedLanguagesListener, tree);
     return new ResultWithErrors<>(embeddedLanguagesListener.getResultNodes(), embeddedLanguagesListener.getErrors());
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/EmbeddedCodeStage.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/pipeline/stages/EmbeddedCodeStage.java
@@ -39,7 +39,7 @@ public class EmbeddedCodeStage implements Stage<Pair<ParserStageResult, List<Nod
   public PipelineResult<Pair<ParserStageResult, List<Node>>> run(AnalysisContext context, PipelineResult<ParserStageResult> prevPipelineResult) {
     // Parse embedded code
     List<Node> embeddedNodes = embeddedCodeService.generateNodes(context.getExtendedDocument(), new ParserListener(context.getExtendedDocument(), context.getCopybooksRepository()),
-            prevPipelineResult.getData().getTree(), treeListener, context.getExtendedDocument().getUri(), context.getConfig().getFeatures())
+            prevPipelineResult.getData().getTree(), treeListener, context.getExtendedDocument().getUri(), context.getConfig().getFeatures(), context.getCopybooksRepository())
         .unwrap(context.getAccumulatedErrors()::addAll);
 
     context.getExtendedDocument().commitTransformations();

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/core/engine/CobolLanguageEngineTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/core/engine/CobolLanguageEngineTest.java
@@ -121,7 +121,7 @@ class CobolLanguageEngineTest {
     when(preprocessor.cleanUpCode(URI, TEXT))
         .thenReturn(new ResultWithErrors<>(new ExtendedText(TEXT, URI), ImmutableList.of()));
 
-    when(embeddedCodeService.generateNodes(any(), any(), any(), any(), anyString(), anyList()))
+    when(embeddedCodeService.generateNodes(any(), any(), any(), any(), anyString(), anyList(), any()))
         .thenReturn(new ResultWithErrors<>(ImmutableList.of(), ImmutableList.of()));
 
     when(grammarPreprocessor.preprocess(any())).thenReturn(new ResultWithErrors<>(new CopybooksRepository(), ImmutableList.of()));

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestIssueWithEmbeddedCodePresentInCopybook.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestIssueWithEmbeddedCodePresentInCopybook.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.common.error.ErrorSource;
+import org.eclipse.lsp.cobol.test.CobolText;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test the error generated for an embedded code present inside a copybook is properly reflected.
+ */
+public class TestIssueWithEmbeddedCodePresentInCopybook {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST12.\n"
+          + "       DATA DIVISION.\n"
+          + "        WORKING-STORAGE SECTION.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "        {_copy {~test9}.|1_}";
+
+  public static final String COPYBOOK_CONTENT =
+      "XDEBUG     EXEC CICS FORMATTIME ABSTIME({WS0-ABSTIME|2})                   \n"
+          + "XDEBUG                          {TIMESEP1|3}(':')                    \n"
+          + "XDEBUG                          DATESEP('/')                         \n"
+          + "XDEBUG                          YYYYMMDD(WS0-D-CICS)                 \n"
+          + "XDEBUG                          TIME(WS0-T-CICS)                     \n"
+          + "XDEBUG     END-EXEC.   \n"
+          + "           EXEC SQL \n"
+          + "           declare scur cursor for select a,b,c from tabD where a = 8\n"
+          + "           order by c for {fetch|4} only;\n"
+          + "            END-EXEC.\n";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(new CobolText("TEST9", COPYBOOK_CONTENT)),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                new Range(),
+                "Errors inside the copybook",
+                DiagnosticSeverity.Error,
+                ErrorSource.COPYBOOK.getText()),
+            "2",
+            new Diagnostic(
+                new Range(),
+                "Variable WS0-ABSTIME is not defined",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText()),
+            "3",
+            new Diagnostic(
+                new Range(),
+                "Syntax error on 'TIMESEP1' expected {FUNCTION, IN, LINAGE-COUNTER, OF, '(', ')', '01-49', "
+                    + "'66', '77', '88', INTEGERLITERAL, NUMERICLITERAL, NONNUMERICLITERAL, IDENTIFIER}",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText()),
+            "4",
+            new Diagnostic(
+                new Range(),
+                "No viable alternative at input for fetch",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText())));
+  }
+}


### PR DESCRIPTION
… copybook

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test by introducing error in an embedded code present inside a copybook. Assert diagnostics are present at the correct location.
example file:
 
test.cbl
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. TEST12.
       DATA DIVISION.
        WORKING-STORAGE SECTION.
       PROCEDURE DIVISION.
        copy test9.
``` 

test9.cpy
```cobol
XDEBUG     EXEC CICS FORMATTIME ABSTIME(WS0-ABSTIME)                    00256500
XDEBUG                          TIMESEP(':')                            00256600
XDEBUG                          DATESEP('/')                            00256700
XDEBUG                          YYYYMMDD(WS0-D-CICS)                    00256800
XDEBUG                          TIME(WS0-T-CICS)                        00256900
XDEBUG     END-EXEC.   		
           copy test10.			

``` 


test10.cpy
```cobol
           EXEC SQL 
           declare scur cursor for select a,b,c from tabD where a = 8
           order by c dor fetch only;
            END-EXEC.
``` 
## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
