### PR TITLE
fix: tolerate cics format time syntax when TIMESEP and TIME are not p…

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CICSParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CICSParser.g4
@@ -355,7 +355,7 @@ cics_formattime: FORMATTIME (ABSTIME cics_data_area | DATE cics_data_area | FULL
                  | MMDDYYYY cics_data_area | MONTHOFYEAR cics_data_area | cics_formattime_time | YEAR cics_data_area
                  | YYDDD cics_data_area | YYDDMM cics_data_area| YYMMDD cics_data_area | YYYYDDD cics_data_area | YYYYDDMM cics_data_area
                  | YYYYMMDD cics_data_area | DATESTRING cics_data_area | STRINGFORMAT cics_cvda | cics_handle_response)+;
-cics_formattime_time: TIME cics_data_area (TIMESEP (data_value | cics_data_area)?)?;
+cics_formattime_time: (TIME cics_data_area | (TIMESEP (data_value | cics_data_area)?))+;
 
 /** FREE (all of them) */
 cics_free: FREE (CONVID cics_name | SESSION cics_name | STATE cics_cvda | cics_handle_response)*;

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestExecCicsFormatTimeStatementsArgumentsOrder.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestExecCicsFormatTimeStatementsArgumentsOrder.java
@@ -43,11 +43,11 @@ class TestExecCicsFormatTimeStatementsArgumentsOrder {
           + "           END-EXEC.\n"
           + "           EXEC CICS FORMATTIME\n"
           + "                     ABSTIME({$WS-TIME})\n"
+          + "                     TIMESEP(':')\n"
           + "                     MMDDYY({$DATEO})\n"
           + "                     YYMMDD({$DATEO})\n"
           + "                     DATESEP('/')\n"
           + "                     TIME({$TIMEO})\n"
-          + "                     TIMESEP(':')\n"
           + "           END-EXEC.";
 
   @Test


### PR DESCRIPTION
…resent is a fixed order

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] check following syntax for exec cics
```cobol
FORMATTIME ABSTIME(LINE-SPACING)                    
                          TIMESEP(':')                            
                          DATESEP('/')                            
                          YYYYMMDD(WS0-D-CICS)                    
                          TIME(WS0-T-CICS) 
```  

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
