### PR TITLE
fix: update db2 select grammar as per doc

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/Db2SqlParser.g4
@@ -881,15 +881,19 @@ dbs_savepoint: SAVEPOINT dbs_savepoint_name UNIQUE? ON ROLLBACK RETAIN (CURSORS 
 
 
 dbs_select: dbs_select_unpack_function_invocation | (WITH common_table_expression_loop)? dbs_fullselect
-            (dbs_select_update
+            ( dbs_select_update
              | dbs_select_readOnly
              | dbs_select_optimize
              | dbs_select_statement_isolation_clause
-             | (QUERYNO dbs_integer)
-             | (SKIPCHAR LOCKED DATA))*;
+             | dbs_concurrent_access_resolution_clause
+             | dbs_offset_clause
+             | dbs_fetch_clause
+             | dbs_lock_req_clause )*;
 dbs_select_update: FOR UPDATE (OF dbs_column_name (dbs_comma_separator dbs_column_name)*)? ;
-dbs_select_readOnly: FOR READ ONLY;
+dbs_select_readOnly: FOR (READ | FETCH) ONLY;
 dbs_select_optimize:OPTIMIZE FOR dbs_integer (ROWS | ROW);
+dbs_concurrent_access_resolution_clause: (WAIT FOR OUTCOME) | (SKIPCHAR LOCKED DATA) ;
+dbs_lock_req_clause: USE AND KEEP (SHARE| UPDATE | EXCLUSIVE) LOCKS;
 /*Queries Subselects (all)*/
 dbs_select_unpack_function_invocation: UNPACK LPARENCHAR dbs_expression RPARENCHAR DOT_FS ASTERISKCHAR AS LPARENCHAR dbs_field_name db2sql_data_types (dbs_comma_separator dbs_field_name db2sql_data_types)* RPARENCHAR;
 dbs_select_row_fullselect: (NONNUMERICLITERAL | NUMERICLITERAL)+ ;

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlSelectStatement.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlSelectStatement.java
@@ -139,9 +139,16 @@ class TestSqlSelectStatement {
           + "            FROM SYSIBM.SYSDUMMY1                                       00095700\n"
           + "           END-EXEC.                                                    00095800";
 
+  private static final String SELECT14 =
+          TEXT
+                  + "            DECLARE C1 CURSOR FOR \n"
+                  + "             SELECT * FROM RMTTAB\n"
+                  + "               FOR FETCH ONLY \n"
+                  + "           END-EXEC.\n";
+
   private static Stream<String> textsToTest() {
     return Stream.of(SELECT, SELECT2, SELECT3, SELECT4, SELECT5, SELECT6, SELECT7, SELECT8, SELECT9, SELECT10,
-            SELECT11, SELECT12, SELECT13);
+            SELECT11, SELECT12, SELECT13, SELECT14);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
update db2 select grammar as per https://www.ibm.com/docs/en/db2/11.5?topic=queries-select-statement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test following syntax works
```cobol
DECLARE Testcur CURSOR    FOR SELECT A                                      
                    ,B                            
                    ,C                        
                    ,D                        
                    ,E                     
                FROM TABAA                             
               WHERE C1 = "TEST"                  
               AND   C2  = "TEST-A"            
               ORDER BY B                         
                       ,C                     
                       ,D                     
               FOR FETCH ONLY 
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
