### PR TITLE
fix: allow whenever in data division

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/Db2SqlParser.g4
@@ -24,7 +24,7 @@ procedureDivisionRules: ((dbs_allocate | dbs_alter | dbs_associate | dbs_call | 
           dbs_label | dbs_lock | dbs_merge | dbs_open | dbs_prepare | dbs_refresh | dbs_release | dbs_rename |
           dbs_revoke | dbs_rollback | dbs_savepoint | dbs_select | dbs_set | dbs_signal | dbs_transfer | dbs_truncate |
           dbs_update | dbs_values | dbs_whenever) dbs_semicolon_end?)+ EOF;
-rulesAllowedInDataDivision: ((dbs_declare_cursor | dbs_declare_table | dbs_include) dbs_semicolon_end?)+;
+rulesAllowedInDataDivision: ((dbs_declare_cursor | dbs_whenever | dbs_declare_table | dbs_include) dbs_semicolon_end?)+;
 rulesAllowedInWorkingStorageAndLinkageSection: ((dbs_begin | dbs_end | dbs_include_sqlca | dbs_include_sqlda) dbs_semicolon_end?)+;
 
 //used in working-storage section of cobol program

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlExecInDataSection.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlExecInDataSection.java
@@ -23,6 +23,14 @@ import org.junit.jupiter.api.Test;
  * Test EXEC SQL in data definition section
  */
 class TestSqlExecInDataSection {
+  private static final String TEXT_WHENEVER = "       IDENTIFICATION DIVISION.\n"
+          +          "       PROGRAM-ID. WE.\n"
+          +          "       ENVIRONMENT DIVISION.\n"
+          +          "       DATA DIVISION.\n"
+          +          "       WORKING-STORAGE SECTION.\n"
+          +          "           EXEC SQL \n"
+          +          "               WHENEVER SQLERROR GO TO 1000-ABEND-RTN \n" // FIXME 1000-ABEND-RTN should cause an error
+          +          "           END-EXEC.";
   private static final String TEXT = "       IDENTIFICATION DIVISION.\n"
           + "       PROGRAM-ID. SQLISSUE.\n"
           + "       ENVIRONMENT DIVISION.\n"
@@ -40,5 +48,9 @@ class TestSqlExecInDataSection {
   @Test
   void test() {
     UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+  @Test
+  void testWhenever() {
+    UseCaseEngine.runTest(TEXT_WHENEVER, ImmutableList.of(), ImmutableMap.of());
   }
 }


### PR DESCRIPTION
## How Has This Been Tested?

```COBOL
       IDENTIFICATION DIVISION.
       PROGRAM-ID. CASE1.
       ENVIRONMENT DIVISION.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
           EXEC SQL 
               WHENEVER SQLERROR GO TO 1000-ABEND-RTN 
           END-EXEC.
```
## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
