### PR TITLE
fix: update divide statement syntax

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestDivideStatement.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestDivideStatement.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.common.error.ErrorSource;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/** Test cobol divide statement */
+public class TestDivideStatement {
+
+  public static final String TEXT =
+      "       Identification Division.\n"
+          + "       Program-id. HELLO-WORLD.\n"
+          + "\n"
+          + "       Data Division.\n"
+          + "       Working-Storage Section.\n"
+          + "       01 {$*USER-NUM1} PIC 9(9).\n"
+          + "       01 {$*USER-NUM2} PIC 9(9).\n"
+          + "       01 {$*USER-INFO}.\n"
+          + "           05 {$*USER-INDEX} PIC 9(6).\n"
+          + "           05 {$*USER-PHONE} PIC 9(6).\n"
+          + "       Procedure Division.\n"
+          + "           DIVIDE {$USER-NUM1} BY {$USER-NUM2} GIVING {$USER-INDEX}.\n"
+          + "           DIVIDE {$USER-NUM1} BY {$USER-NUM2}{.|1}\n"
+          + "           DIVIDE {$USER-NUM1} INTO {$USER-NUM2} \n"
+          + "           GIVING {$USER-INDEX} ROUNDED REMAINDER {$USER-PHONE}.\n"
+          + "       End program HELLO-WORLD.\n";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                new Range(),
+                "Syntax error on '.' expected {GIVING, IN, OF, '('}",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText())));
+  }
+}

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -1297,11 +1297,15 @@ divideIntoStatement
    ;
 
 divideIntoGivingStatement
-   : INTO (literal | generalIdentifier) divideGivingPhrase?
+   : INTO (literal | generalIdentifier) divideGivingPhrase divideRemainderPhrase?
+   ;
+
+divideRemainderPhrase
+   : REMAINDER generalIdentifier
    ;
 
 divideByGivingStatement
-   : BY (literal | generalIdentifier) divideGivingPhrase?
+   : BY (literal | generalIdentifier) divideGivingPhrase
    ;
 
 divideGivingPhrase


### PR DESCRIPTION
update divide statement syntax as per https://www.ibm.com/docs/en/cobol-zos/6.4?topic=statements-divide-statement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] DIVIDE A BY B  requires GIVING.  Flag error when giving is not found
```cobol
DIVIDE USER-NUM1 BY USER-NUM2 GIVING USER-INDEX.  *> valid
           DIVIDE USER-NUM1 BY USER-NUM2. *> not valid
           DIVIDE USER-NUM1 INTO USER-NUM2 
           GIVING USER-INDEX ROUNDED REMAINDER USER-PHONE. *> valid
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
