### PR TITLE
fix: fix joined query grammar

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestDb2JoinedTablesQuery.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestDb2JoinedTablesQuery.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** Test Joined table query for DB2 */
+public class TestDb2JoinedTablesQuery {
+  public static final String TEXT =
+      "       Identification Division.\n"
+          + "       Program-id. HELLO-WORLD.\n"
+          + "\n"
+          + "       Data Division.\n"
+          + "       Working-Storage Section.\n"
+          + "\n"
+          + "       Procedure Division.\n"
+          + "\n"
+          + "           EXEC SQL \n"
+          + "           declare dummy-cu cursor for \n"
+          + "           select 'Y' from table t1\n"
+          + "           inner join table t2 ON t1.key = t2.KEY\n"
+          + "           inner join table t3 ON t3.key = t1.key\n"
+          + "           END-EXEC.\n"
+          + "\n"
+          + "       End program HELLO-WORLD.\n";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+}


### PR DESCRIPTION
Ref https://www.ibm.com/docs/en/db2-for-zos/13?topic=clause-joined-table

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Following code should work
```cobol
       Identification Division.
       Program-id. HELLO-WORLD.

       Data Division.
       Working-Storage Section.

       Procedure Division.

           EXEC SQL 
           declare dummy-cu cursor for 
           select 'Y' from table t1
           inner join table t2 ON t1.key = t2.KEY
           inner join table t3 ON t3.key = t1.key
           END-EXEC.

       End program HELLO-WORLD.

``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
