### PR TITLE
fix: update db2 insert grammar

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/Db2SqlParser.g4
@@ -732,13 +732,14 @@ dbs_include_sqlda: INCLUDE SQLDA;
 
 /*INSERT */
 dbs_insert: INSERT INTO (dbs_table_name | dbs_view_name) (LPARENCHAR dbs_column_name (dbs_comma_separator dbs_column_name)* RPARENCHAR)?
-            dbs_insert_include? (OVERRIDING USER VALUE)? (dbs_insert_values | dbs_insert_fullselect);
+            dbs_insert_include? (OVERRIDING USER VALUE)? dbs_insert_values;
 dbs_insert_include: INCLUDE LPARENCHAR dbs_column_name dbs_include_data_type (dbs_comma_separator dbs_column_name dbs_include_data_type)* RPARENCHAR;
 //?
 dbs_insert_data_type: (common_short_built_in_type | dbs_distinct_type);
 //dbs_insert_values: VALUES LPARENCHAR (dbs_insert_values_single | dbs_insert_values_multi) RPARENCHAR;
-dbs_insert_values: VALUES ((dbs_expression | DEFAULT | NULL) | LPARENCHAR dbs_insert_values_sgloop RPARENCHAR) | (FOR (dbs_host_variable | dbs_integer_constant) ROWS)? VALUES dbs_insert_values_multi;
-dbs_insert_values_sgloop: (dbs_expression | DEFAULT | NULL) (dbs_comma_separator (dbs_expression | DEFAULT | NULL) | NUMERICLITERAL)*;
+dbs_insert_values: (VALUES (dbs_insert_values_single | dbs_insert_values_multi)) | dbs_insert_fullselect;
+dbs_insert_values_single: (dbs_expression | DEFAULT | NULL) | LPARENCHAR dbs_insert_values_sgloop RPARENCHAR;
+dbs_insert_values_sgloop: (dbs_expressions | DEFAULT | NULL) (dbs_comma_separator (dbs_expressions | DEFAULT | NULL) | NUMERICLITERAL)*;
 dbs_insert_values_multi: (dbs_expression | dbs_host_variable_array | DEFAULT | NULL | LPARENCHAR dbs_insert_values_mloop RPARENCHAR)
                         (FOR (dbs_host_variable | T=dbs_integer_constant {validateDb2MaxInt($T.text);}) ROWS)?
                         (ATOMIC | NOT ATOMIC CONTINUE ON SQLEXCEPTION)?;
@@ -1340,7 +1341,7 @@ dbs_column_name | dbs_variable | dbs_special_register | dbs_scalar_fullselect | 
 
 dbs_time_zone_specific_expression : dbs_time_zone_expression ( AT LOCAL | AT TIME ZONE dbs_time_zone_expression);
 dbs_time_unit: (YEAR | YEARS | MONTH | MONTHS | DAY | DAYS | HOUR | HOURS | MINUTE | MINUTES | SECOND | SECONDS | MICROSECOND | MICROSECONDS );
-dbs_labeled_duration: (dbs_function_invocation | LPARENCHAR dbs_expression RPARENCHAR | dbs_constant |
+dbs_labeled_duration: (dbs_function_invocation | LPARENCHAR dbs_expressions RPARENCHAR | dbs_constant |
 dbs_column_name | dbs_variable) dbs_time_unit;
 
 dbs_XMLCAST_specification: XMLCAST LPARENCHAR (dbs_expression | NULL | dbs_parameter_marker) AS dbs_comment_parameter_type RPARENCHAR;

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlAllSetStatements.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlAllSetStatements.java
@@ -259,6 +259,22 @@ class TestSqlAllSetStatements {
   private static final String SET_SESSION_TIME_ZONE =
       TEXT + "             SET SESSION TIME ZONE = '-8:00';\n" + "           END-EXEC.";
 
+  public static final String SET_VRAIABLE_VALUE_EVALUATED_BY_FUNCTION_CALL =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. testpgm.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*WS-VARIABLES}.\n"
+          + "           05 {$*WS-TIMESTAMP}                PIC X(26).\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "       EXEC SQL\n"
+          + "                SET :{$WS-TIMESTAMP} =\n"
+          + "                             TIMESTAMP('1970-01-01-00.00.00.000000')\n"
+          + "                       + (:{$WS-TIMESTAMP} / 1000) SECOND\n"
+          + "                       + (INT(CURRENT TIMEZONE/10000)) HOURS\n"
+          + "           END-EXEC.\n"
+          + "       end program testpgm.";
+
   private static Stream<String> textsToTest() {
     return Stream.of(
         SET_CONNECTION,
@@ -307,7 +323,8 @@ class TestSqlAllSetStatements {
         SET_SCHEMA2,
         SET_SCHEMA3,
         SET_SCHEMA4,
-        SET_SESSION_TIME_ZONE);
+        SET_SESSION_TIME_ZONE,
+        SET_VRAIABLE_VALUE_EVALUATED_BY_FUNCTION_CALL);
   }
 
   @ParameterizedTest

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlInsertStatement.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlInsertStatement.java
@@ -105,18 +105,43 @@ class TestSqlInsertStatement {
           + "           END-EXEC.";
 
   private static final String INSERT8 =
-          TEXT
-                  + "           insert into all values(1,1);\n"
-                  + "           END-EXEC.";
+      TEXT + "           insert into all values(1,1);\n" + "           END-EXEC.";
 
   private static final String INSERT9 =
-          TEXT
-                  + "           insert into all(all,avg) \n"
-                  + "           select all all as all, avg from all;\n"
-                  + "           END-EXEC.";
+      TEXT
+          + "           insert into all(all,avg) \n"
+          + "           select all all as all, avg from all;\n"
+          + "           END-EXEC.";
+
+  public static final String INSERT10 =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. testpgm.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*WS-VARIABLES}.\n"
+          + "           05 {$*WS-TIMESTAMP}                PIC X(26).\n"
+          + "           05 {$*WS-originalIssueDate}        PIC S9(18) COMP.\n"
+          + "           05 {$*WS-FIELD1}                   PIC X(01).\n"
+          + "           05 {$*WS-EXPIRES-IN}               PIC S9(18)V COMP-3.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "                 EXEC SQL\n"
+          + "              INSERT INTO TABLE1\n"
+          + "              (\n"
+          + "                TBL1_FIELD1 \n"
+          + "               ,TBL1_TIMESTAMP\n"
+          + "              )\n"
+          + "              VALUES\n"
+          + "              (\n"
+          + "                :{$WS-FIELD1}\n"
+          + "               ,TIMESTAMP(:{$WS-TIMESTAMP}) +\n"
+          + "                          (:{$WS-EXPIRES-IN} SECONDS)\n"
+          + "              )\n"
+          + "           END-EXEC   .\n"
+          + "       end program testpgm.";
 
   private static Stream<String> textsToTest() {
-    return Stream.of(INSERT1, INSERT2, INSERT3, INSERT4, INSERT5, INSERT6, INSERT7, INSERT8, INSERT9);
+    return Stream.of(
+        INSERT1, INSERT2, INSERT3, INSERT4, INSERT5, INSERT6, INSERT7, INSERT8, INSERT9, INSERT10);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Following code should not have error diagnostics.
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. testpgm.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 WS-VARIABLES.
           05 WS-TIMESTAMP                PIC X(26).
           05 WS-originalIssueDate        PIC S9(18) COMP.
           05 WS-FIELD1                   PIC X(01).
           05 WS-EXPIRES-IN               PIC S9(18)V COMP-3.
       PROCEDURE DIVISION.
                 EXEC SQL
              INSERT INTO TABLE1
              (
                TBL1_FIELD1 
               ,TBL1_TIMESTAMP
              )
              VALUES
              (
                :WS-FIELD1
               ,TIMESTAMP(:WS-TIMESTAMP) +
                          (:WS-EXPIRES-IN SECONDS)
              )
           END-EXEC   .

        EXEC SQL
                SET :WS-TIMESTAMP =
                             TIMESTAMP('1970-01-01-00.00.00.000000')
                       + (:WS-originalIssueDate / 1000) SECOND
                       + (INT(CURRENT TIMEZONE/10000)) HOURS
           END-EXEC.
              
       end program testpgm.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
