### PR TITLE
fix: propagate preprocess error in copybook to the cobol source

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookServiceTest.java
@@ -20,6 +20,7 @@ import org.eclipse.lsp.cobol.common.copybook.*;
 import org.eclipse.lsp.cobol.common.error.ErrorSeverity;
 import org.eclipse.lsp.cobol.common.error.SyntaxError;
 import org.eclipse.lsp.cobol.common.mapping.ExtendedText;
+import org.eclipse.lsp.cobol.common.mapping.OriginalLocation;
 import org.eclipse.lsp.cobol.core.preprocessor.TextPreprocessor;
 import org.eclipse.lsp.cobol.common.utils.PredefinedCopybooks;
 import org.eclipse.lsp.cobol.domain.databus.api.DataBusBroker;
@@ -467,6 +468,7 @@ class CopybookServiceTest {
     CopybookService copybookService = createCopybookService();
     String copybookContent = "SOME TEXT";
     SyntaxError expectedSyntaxError = SyntaxError.syntaxError()
+            .location(new OriginalLocation(null, VALID_CPY_NAME))
             .suggestion("some suggestion")
             .severity(ErrorSeverity.ERROR)
             .build();

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestPreprocessErrorInCopybookIsPropagatedToMainProgram.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestPreprocessErrorInCopybookIsPropagatedToMainProgram.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.common.error.ErrorSource;
+import org.eclipse.lsp.cobol.test.CobolText;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.lsp4j.DiagnosticSeverity.Error;
+
+/** Tests that the pre-process error from a copybook is propagated to the source cobol prohram. */
+public class TestPreprocessErrorInCopybookIsPropagatedToMainProgram {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST12.\n"
+          + "       DATA DIVISION.\n"
+          + "        WORKING-STORAGE SECTION.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "        {_copy {~test9}.|error1_}";
+  public static final String COPYBOOK_CONTENT =
+      "                                                                                {extra|error2}";
+  private static final String COPYBOOK_ID = "TEST9";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(new CobolText(COPYBOOK_ID, COPYBOOK_CONTENT)),
+        ImmutableMap.of(
+            "error1",
+            new Diagnostic(
+                new Range(), "Errors inside the copybook", Error, ErrorSource.COPYBOOK.getText()),
+            "error2",
+            new Diagnostic(
+                new Range(),
+                "Source text cannot go past column 80",
+                Error,
+                ErrorSource.PREPROCESSING.getText())));
+  }
+}


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Steps to reproduce:
- Open a Cobol program which has a Copybook.
- Navigate to copybook.
- At the end of the line add SPACES 
- Now it shows error in the copybook:  Source text cannot go past column 80.
**Expected Result:** It should also show error in Cobol program as well

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
