### PR TITLE
Use last analysis result to generate completion lists

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolDocumentModel.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolDocumentModel.java
@@ -34,17 +34,29 @@ import java.util.concurrent.CopyOnWriteArrayList;
 @Slf4j
 public class CobolDocumentModel {
   private static final String DELIMITER = "[ .\\[\\]()<>,*\"']+";
-  @Getter private final List<Line> lines = new CopyOnWriteArrayList<>();
-  @Getter private String text;
-  @Getter private final String uri;
-  @Getter @Setter private boolean opened = true;
-  @Getter @Setter private AnalysisResult analysisResult;
-  @Getter @Setter private List<DocumentSymbol> outlineResult;
+  @Getter
+  private final List<Line> lines = new CopyOnWriteArrayList<>();
+  @Getter
+  private String text;
+  @Getter
+  private final String uri;
+  @Getter
+  @Setter
+  private boolean opened = true;
+  @Getter
+  private AnalysisResult analysisResult;
+  /** Store last successfully completed analysis result, mostly for generation completion lists proposes */
+  @Getter
+  private AnalysisResult lastAnalysisResult;
+  @Getter
+  @Setter
+  private List<DocumentSymbol> outlineResult;
 
   public CobolDocumentModel(String uri, String text, AnalysisResult analysisResult) {
     this.uri = uri;
     this.text = text;
     this.analysisResult = analysisResult;
+    this.lastAnalysisResult = analysisResult;
     parse(text);
   }
 
@@ -58,6 +70,16 @@ public class CobolDocumentModel {
     return (analysisResult != null && outlineResult != null);
   }
 
+  /**
+   * Set new analysis result and update the last valid result
+   * @param analysisResult an analysis result
+   */
+  public void setAnalysisResult(AnalysisResult analysisResult) {
+    this.analysisResult = analysisResult;
+    if (analysisResult != null) {
+      lastAnalysisResult = analysisResult;
+    }
+  }
 
   Line getLine(int number) {
     return lines.stream().filter(line -> line.getNumber() == number).findFirst().orElse(null);
@@ -79,6 +101,7 @@ public class CobolDocumentModel {
 
   /**
    * Update CobolDocumentModel with a new text
+   *
    * @param text - the new document text
    */
   public void update(String text) {
@@ -146,10 +169,12 @@ public class CobolDocumentModel {
 
   private boolean isPositionAtDelimiter(Position position, Line route) {
     return position.getCharacter() > 1
-        && DELIMITER.contains(String.valueOf(route.getText().charAt(position.getCharacter() - 1)));
+            && DELIMITER.contains(String.valueOf(route.getText().charAt(position.getCharacter() - 1)));
   }
 
-  /** A value object to store program lines */
+  /**
+   * A value object to store program lines
+   */
   @Value
   public static class Line {
     int number;

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/completions/Completion.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/completions/Completion.java
@@ -20,7 +20,6 @@ import org.eclipse.lsp4j.CompletionItem;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.Objects;
 
 /**
  * Completion provider that allows to resolve autocomplete requests with specific items based on
@@ -32,13 +31,13 @@ public interface Completion {
   /**
    * Provide a list of completion items of specific kind
    *
-   * @param token - token to filter the suggestions
+   * @param token    - token to filter the suggestions
    * @param document - object that contains text and analysis output
    * @return collection of strings to be converted into completion items
    */
   @NonNull
   Collection<CompletionItem> getCompletionItems(
-      @NonNull String token, @Nullable CobolDocumentModel document);
+          @NonNull String token, @Nullable CobolDocumentModel document);
 
   /**
    * Checks if the supplied document is ready for collection based on weather document is analysis.
@@ -47,6 +46,6 @@ public interface Completion {
    * @return True if document is ready, false otherwise.
    */
   default boolean isDocumentReadyForSemanticCollection(CobolDocumentModel document) {
-    return !(Objects.isNull(document) || Objects.isNull(document.getAnalysisResult()));
+    return document != null && document.getLastAnalysisResult() != null;
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/completions/CopybookCompletion.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/completions/CopybookCompletion.java
@@ -39,7 +39,7 @@ public class CopybookCompletion implements Completion {
       @NonNull String token, @Nullable CobolDocumentModel document) {
     if (!isDocumentReadyForSemanticCollection(document)) return emptyList();
     return document
-        .getAnalysisResult()
+        .getLastAnalysisResult()
         .getRootNode()
         .getDepthFirstStream()
         .filter(hasType(COPY))

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/completions/ParagraphCompletion.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/completions/ParagraphCompletion.java
@@ -49,7 +49,7 @@ public class ParagraphCompletion implements Completion {
       @NonNull String token, @Nullable CobolDocumentModel document) {
     if (!isDocumentReadyForSemanticCollection(document)) return emptyList();
     return document
-        .getAnalysisResult()
+        .getLastAnalysisResult()
         .getRootNode()
         .getDepthFirstStream()
         .filter(hasType(PROGRAM))

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/completions/SectionCompletion.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/completions/SectionCompletion.java
@@ -49,7 +49,7 @@ public class SectionCompletion implements Completion {
       @NonNull String token, @Nullable CobolDocumentModel document) {
     if (!isDocumentReadyForSemanticCollection(document)) return emptyList();
     return document
-        .getAnalysisResult()
+        .getLastAnalysisResult()
         .getRootNode()
         .getDepthFirstStream()
         .filter(hasType(PROGRAM))

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/completions/VariableCompletion.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/completions/VariableCompletion.java
@@ -57,7 +57,7 @@ public class VariableCompletion implements Completion {
       @NonNull String token, @Nullable CobolDocumentModel document) {
     if (!isDocumentReadyForSemanticCollection(document)) return emptyList();
     return document
-        .getAnalysisResult()
+        .getLastAnalysisResult()
         .getRootNode()
         .getDepthFirstStream()
         .filter(hasType(PROGRAM))


### PR DESCRIPTION
## How Has This Been Tested?

1. Opem big COBOL program (long time to analyze)
2. Wait until the first analysis is done
3. Start to a variable name

Expected:
An autocompletion list with variable names will appear even if the reanalysis is not finished.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
