### PR TITLE
test: fix CFASTBuilderTest to match the exact result json

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/extendedapi/CFASTBuilderTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/extendedapi/CFASTBuilderTest.java
@@ -16,6 +16,7 @@ package org.eclipse.lsp.cobol.extendedapi;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.common.EmbeddedLanguage;
 import org.eclipse.lsp.cobol.cfg.CFASTBuilder;
@@ -39,7 +40,11 @@ import java.util.stream.Stream;
 /** Test for @link({@link CFASTBuilderImpl}. */
 @Slf4j
 class CFASTBuilderTest {
-  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+  private static final Gson GSON =
+      new GsonBuilder()
+          .setPrettyPrinting()
+          .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+          .create();
 
   static Stream<Arguments> casesToTest() throws IOException {
     return Files.list(Paths.get("src", "test", "resources", "cfast"))
@@ -58,7 +63,12 @@ class CFASTBuilderTest {
   @MethodSource("casesToTest")
   void cfastBuilderTest(String src, String jsonTree, String caseName) {
     AnalysisResult analysisResult =
-        UseCaseUtils.analyze(UseCase.builder().documentUri("fake/path").features(Arrays.asList(EmbeddedLanguage.values())).text(src).build());
+        UseCaseUtils.analyze(
+            UseCase.builder()
+                .documentUri("fake/path")
+                .features(Arrays.asList(EmbeddedLanguage.values()))
+                .text(src)
+                .build());
     CFASTBuilder builder = new CFASTBuilderImpl();
     Assertions.assertEquals(
         GSON.toJson(GSON.fromJson(jsonTree, List.class)),

--- a/server/engine/src/test/resources/cfast/case46.result.json
+++ b/server/engine/src/test/resources/cfast/case46.result.json
@@ -70,12 +70,12 @@
         "location": {
           "uri": "fake/path",
           "start": {
-            "line": 33.0,
-            "character": 8.0
+            "line": 33,
+            "character": 8
           },
           "end": {
-            "line": 34.0,
-            "character": 17.0
+            "line": 34,
+            "character": 17
           }
         },
         "type": "paragraph",

--- a/server/engine/src/test/resources/cfast/case7.result.json
+++ b/server/engine/src/test/resources/cfast/case7.result.json
@@ -4,12 +4,12 @@
     "location": {
       "uri": "fake/path",
       "start": {
-        "line": 15.0,
-        "character": 8.0
+        "line": 15,
+        "character": 8
       },
       "end": {
-        "line": 19.0,
-        "character": 18.0
+        "line": 19,
+        "character": 18
       }
     },
     "type": "program",
@@ -27,12 +27,12 @@
         "location": {
           "uri": "fake/path",
           "start": {
-            "line": 18.0,
-            "character": 8.0
+            "line": 18,
+            "character": 8
           },
           "end": {
-            "line": 19.0,
-            "character": 18.0
+            "line": 19,
+            "character": 18
           }
         },
         "type": "paragraph",

--- a/server/engine/src/test/resources/cfast/case8.result.json
+++ b/server/engine/src/test/resources/cfast/case8.result.json
@@ -4,12 +4,12 @@
     "location": {
       "uri": "fake/path",
       "start": {
-        "line": 15.0,
-        "character": 8.0
+        "line": 15,
+        "character": 8
       },
       "end": {
-        "line": 19.0,
-        "character": 18.0
+        "line": 19,
+        "character": 18
       }
     },
     "type": "program",
@@ -27,12 +27,12 @@
         "location": {
           "uri": "fake/path",
           "start": {
-            "line": 18.0,
-            "character": 8.0
+            "line": 18,
+            "character": 8
           },
           "end": {
-            "line": 19.0,
-            "character": 18.0
+            "line": 19,
+            "character": 18
           }
         },
         "type": "paragraph",

--- a/server/engine/src/test/resources/cfast/case_perform_thru.result.json
+++ b/server/engine/src/test/resources/cfast/case_perform_thru.result.json
@@ -4,12 +4,12 @@
     "location": {
       "uri": "fake/path",
       "start": {
-        "line": 15.0,
-        "character": 8.0
+        "line": 15,
+        "character": 8
       },
       "end": {
-        "line": 24.0,
-        "character": 25.0
+        "line": 24,
+        "character": 25
       }
     },
     "type": "program",
@@ -27,12 +27,12 @@
         "location": {
           "uri": "fake/path",
           "start": {
-            "line": 17.0,
-            "character": 8.0
+            "line": 17,
+            "character": 8
           },
           "end": {
-            "line": 21.0,
-            "character": 25.0
+            "line": 21,
+            "character": 25
           }
         },
         "type": "section",
@@ -43,12 +43,12 @@
             "location": {
               "uri": "fake/path",
               "start": {
-                "line": 18.0,
-                "character": 8.0
+                "line": 18,
+                "character": 8
               },
               "end": {
-                "line": 19.0,
-                "character": 25.0
+                "line": 19,
+                "character": 25
               }
             },
             "type": "paragraph"
@@ -59,12 +59,12 @@
             "location": {
               "uri": "fake/path",
               "start": {
-                "line": 20.0,
-                "character": 8.0
+                "line": 20,
+                "character": 8
               },
               "end": {
-                "line": 21.0,
-                "character": 25.0
+                "line": 21,
+                "character": 25
               }
             },
             "type": "paragraph"
@@ -77,12 +77,12 @@
         "location": {
           "uri": "fake/path",
           "start": {
-            "line": 22.0,
-            "character": 8.0
+            "line": 22,
+            "character": 8
           },
           "end": {
-            "line": 24.0,
-            "character": 25.0
+            "line": 24,
+            "character": 25
           }
         },
         "type": "section",
@@ -93,12 +93,12 @@
             "location": {
               "uri": "fake/path",
               "start": {
-                "line": 23.0,
-                "character": 8.0
+                "line": 23,
+                "character": 8
               },
               "end": {
-                "line": 24.0,
-                "character": 25.0
+                "line": 24,
+                "character": 25
               }
             },
             "type": "paragraph"


### PR DESCRIPTION
fix CFASTBuilderTest to match the exact result json. A detailed discussion could be found at https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/pull/2094


## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated tests  that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
