### PR TITLE
fix: fix CICS coloring

### DIFF
--- a/clients/cobol-lsp-vscode-extension/syntaxes/CICS.tmLanguage.json
+++ b/clients/cobol-lsp-vscode-extension/syntaxes/CICS.tmLanguage.json
@@ -1,6 +1,6 @@
 {
   "scopeName": "meta.embedded.block.cics",
-  "injectionSelector": "L:cics.embedded.code",
+  "injectionSelector": ["R:cics.embedded.code", "L:string.quoted.cics.cobol"],
   "patterns": [
     {
       "include": "#cics-injection"


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Improved coloring for below code snippet
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/77ebc66b-97d2-4b76-b433-a5de9eb1ac60)
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/974ad621-b904-4283-af6f-4cfa6a22fb8f)

![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/1a6c32ec-c3af-4618-af3d-2f6f5550d5b2)



## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
