### PR TITLE
fix: fix wrong analysis for sql code inside a copybook

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlVariableReferenceInCopybook.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlVariableReferenceInCopybook.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.CobolText;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** Test the variable references within a SQL block present inside a copybook */
+public class TestSqlVariableReferenceInCopybook {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.                                         \n"
+          + "       PROGRAM-ID.    CCB008.                                           \n"
+          + "       DATA DIVISION.                                                   \n"
+          + "       WORKING-STORAGE SECTION.                                         \n"
+          + "       01 {$*AB} pic x.\n"
+          + "       PROCEDURE DIVISION.                                              \n"
+          + "           EXEC SQL                                                     \n"
+          + "              INCLUDE {~CCPP0008}                                          \n"
+          + "           END-EXEC.                                                    \n"
+          + "           DISPLAY {$AB}.";
+
+  public static final String COPYBOOK =
+      "                  EXEC SQL                                              \n"
+          + "                INSERT INTO CCA009                                      \n"
+          + "                               ( C_S_EVEN                               \n"
+          + "                                )                                       \n"
+          + "                        VALUES( :{$AB}  )                                   \n"
+          + "           END-EXEC.";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT, ImmutableList.of(new CobolText("CCPP0008", COPYBOOK)), ImmutableMap.of());
+  }
+}


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] For below program, test refences for variable AB shows 3 references including  one inside copybook CCB008

```cobol
       IDENTIFICATION DIVISION.                                         
       PROGRAM-ID.    CCB008.                                           
       DATA DIVISION.                                                   
       WORKING-STORAGE SECTION.                                         
       01 AB pic x.
       PROCEDURE DIVISION.                                              
           EXEC SQL                                                     
              INCLUDE CCPP0008                                          
           END-EXEC.                                                    
           DISPLAY AB.
``` 
```cobol
                  EXEC SQL                                              
                INSERT INTO CCA009                                      
                               ( C_S_EVEN                               
                                )                                       
                        VALUES( :AB  )                                   
           END-EXEC.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
