### PR TITLE
fix: expect analysisResult could be null

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/references/ElementOccurrences.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/references/ElementOccurrences.java
@@ -15,6 +15,10 @@
 package org.eclipse.lsp.cobol.service.delegates.references;
 
 import com.google.common.collect.Streams;
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.common.AnalysisResult;
@@ -23,11 +27,6 @@ import org.eclipse.lsp.cobol.core.engine.symbols.SymbolsRepository;
 import org.eclipse.lsp.cobol.service.CobolDocumentModel;
 import org.eclipse.lsp.cobol.service.utils.UriHelper;
 import org.eclipse.lsp4j.*;
-
-import java.util.*;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * This occurrences provider resolves the requests for the semantic elements based on its positions.
@@ -64,7 +63,7 @@ public class ElementOccurrences implements Occurrences {
 
   @Override
   public @NonNull List<DocumentHighlight> findHighlights(
-      @NonNull AnalysisResult analysisResult, @NonNull TextDocumentPositionParams position) {
+      AnalysisResult analysisResult, @NonNull TextDocumentPositionParams position) {
     Optional<DefinedAndUsedStructure> element = SymbolsRepository.findElementByPosition(UriHelper.decode(position.getTextDocument().getUri()),
             analysisResult, position.getPosition());
     return element.map(context -> Streams.concat(context.getUsages().stream(), context.getDefinitions().stream())

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/references/Occurrences.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/references/Occurrences.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.lsp.cobol.service.delegates.references;
 
+import java.util.List;
 import lombok.NonNull;
 import org.eclipse.lsp.cobol.common.AnalysisResult;
 import org.eclipse.lsp.cobol.service.CobolDocumentModel;
@@ -22,8 +23,6 @@ import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.ReferenceContext;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
-
-import java.util.List;
 
 /**
  * This class is a service delegate to resolve the location requests of document elements, i.e Go to
@@ -72,5 +71,5 @@ public interface Occurrences {
    */
   @NonNull
   List<DocumentHighlight> findHighlights(
-          @NonNull AnalysisResult analysisResult, @NonNull TextDocumentPositionParams position);
+          AnalysisResult analysisResult, @NonNull TextDocumentPositionParams position);
 }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Try to find reference of a variable while its being analyzed.
<details><summary>Details</summary>
<p>

_[Error - 11:59:50 AM] Request textDocument/documentHighlight failed.
  Message: Internal error.
  Code: -32603 
java.util.concurrent.CompletionException: java.lang.IllegalArgumentException: analysisResult is marked non-null but is null
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292)
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308)
	at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:661)
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:646)
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:488)
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1990)
	at org.eclipse.lsp.cobol.lsp.LspMessageDispatcher.loop(LspMessageDispatcher.java:72)
	at org.eclipse.lsp.cobol.lsp.LspMessageDispatcher.lambda$startEventLoop$1(LspMessageDispatcher.java:46)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)_

</p>
</details> 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
