### PR TITLE
fix: allow LEADING / TRAILING as a function argument #2139

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestTrimFunctionSupport.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestTrimFunctionSupport.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** Test intrinsic function's trim support */
+public class TestTrimFunctionSupport {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID.  TRIM.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01  {$*TRIM-OUT-VAL}                     PIC X(80).\n"
+          + "       LINKAGE SECTION.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "       {@*MAIN} SECTION.\n"
+          + "           MOVE FUNCTION TRIM('TEST123   ', TRAILING)\n"
+          + "             TO {$TRIM-OUT-VAL}\n"
+          + "           MOVE FUNCTION TRIM('   TEST123', LEADING)\n"
+          + "             TO {$TRIM-OUT-VAL}\n"
+          + "           GOBACK.";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+}

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -2230,6 +2230,7 @@ length
 
 argument
    : arithmeticExpression
+   | TRAILING | LEADING
    ;
 
 // qualified data name ----------------------------------


### PR DESCRIPTION
allow LEADING / TRAILING as a function argument

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Below code should not throw any diagnostics
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID.  TRIM.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       
       01  TRIM-OUT-VAL                     PIC X(80).
       
       LINKAGE SECTION.
       
       PROCEDURE DIVISION.
       MAIN SECTION.
           MOVE FUNCTION TRIM('TEST123   ', TRAILING)
             TO TRIM-OUT-VAL
           MOVE FUNCTION TRIM('   TEST123', LEADING)
             TO TRIM-OUT-VAL
           GOBACK.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
