### PR TITLE
fix: tolerate unexpected comma char in string statement

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/ParserListener.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/ParserListener.java
@@ -14,6 +14,9 @@
  */
 package org.eclipse.lsp.cobol.core.visitor;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,14 +29,11 @@ import org.eclipse.lsp.cobol.common.error.ErrorSource;
 import org.eclipse.lsp.cobol.common.error.SyntaxError;
 import org.eclipse.lsp.cobol.common.mapping.ExtendedDocument;
 import org.eclipse.lsp.cobol.common.model.Locality;
+import org.eclipse.lsp.cobol.core.WarningRecognitionException;
 import org.eclipse.lsp.cobol.core.semantics.CopybooksRepository;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 /** This error listener registers syntax errors found by the COBOL parser. */
 @Slf4j
@@ -72,10 +72,18 @@ public class ParserListener extends BaseErrorListener {
                     .copybookId(copybooksRepository.getCopybookIdByUri(location.getUri()))
                     .build().toOriginalLocation())
             .suggestion(msg)
-            .severity(ErrorSeverity.ERROR)
+            .severity(getErrorSeverity(e))
             .build();
     LOG.debug("Syntax error by ParserListener " + error.toString());
     errors.add(error);
+  }
+
+  private static ErrorSeverity getErrorSeverity(RecognitionException e) {
+    ErrorSeverity severity = ErrorSeverity.ERROR;
+    if (e instanceof WarningRecognitionException) {
+      severity = ErrorSeverity.WARNING;
+    }
+    return severity;
   }
 
   private int getOffendingSymbolSize(Object offendingSymbol) {

--- a/server/engine/src/main/resources/resourceBundles/messages_en.properties
+++ b/server/engine/src/main/resources/resourceBundles/messages_en.properties
@@ -132,3 +132,4 @@ db2Parser.validation.section=this DB2 statement is allowed only in LINKAGE SECTI
 db2Parser.validation.procedureDiv=this DB2 statement is allowed only in PROCEDURE DIVISION
 db2Parser.validation.declareVar=Db2 variable declaration is only allowed in DATA DIVISION
 db2Parser.validation.allStatement=this DB2 statement is allowed only in DATA DIVISION or PROCEDURE DIVISION
+cobolParser.expectSpace=a blank is missing after ','

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestStringStatementWithInvalidCommaCharIsTolerated.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestStringStatementWithInvalidCommaCharIsTolerated.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.common.error.ErrorSource;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/** Tolerate string statement with comma character */
+public class TestStringStatementWithInvalidCommaCharIsTolerated {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID.   TEST23.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       CONFIGURATION SECTION.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*WS-VARIABLES}.\n"
+          + "          05 {$*WS-REFRESH-TOKEN-LENGTH}     PIC S9(4)V  COMP-3.\n"
+          + "          05 {$*WS-REFRESH-TOKEN}            PIC X(1500).\n"
+          + "          05 {$*SW-DUMMY}                    PIC X(01) VALUE 'N'.\n"
+          + "             88 {$*SW-DUMMY-Y}                         VALUE 'Y'.\n"
+          + "             88 {$*SW-DUMMY-N}                         VALUE 'N'.\n"
+          + "          05 {$*WS-REQUEST-BODY}             PIC X(2000) VALUE SPACES.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           EVALUATE TRUE\n"
+          + "              WHEN {$SW-DUMMY-Y}\n"
+          + "                 STRING 'refresh_token='   DELIMITED BY SIZE\n"
+          + "                       {,|1}{$WS-REFRESH-TOKEN}(1:{$WS-REFRESH-TOKEN-LENGTH})\n"
+          + "                                           DELIMITED BY SIZE\n"
+          + "                       , '&'                DELIMITED BY SIZE\n"
+          + "                       , 'grant_type='      DELIMITED BY SIZE\n"
+          + "                       {,|2}'refresh_token'    DELIMITED BY SIZE\n"
+          + "                    INTO {$WS-REQUEST-BODY}\n"
+          + "                 END-STRING.";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                new Range(),
+                "a blank is missing after ','",
+                DiagnosticSeverity.Warning,
+                ErrorSource.PARSING.getText()),
+            "2",
+            new Diagnostic(
+                new Range(),
+                "a blank is missing after ','",
+                DiagnosticSeverity.Warning,
+                ErrorSource.PARSING.getText())));
+  }
+}

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -1772,6 +1772,7 @@ stringStatement
 
 stringSendingPhrase
    : stringSending (COMMACHAR? stringSending)*? (stringDelimitedByPhrase | stringForPhrase)
+   | {notifyWarning("cobolParser.expectSpace");} COMMACHAR stringSending (COMMACHAR? stringSending)*? (stringDelimitedByPhrase | stringForPhrase)
    ;
 
 stringSending

--- a/server/parser/src/main/java/org/eclipse/lsp/cobol/core/MessageServiceParser.java
+++ b/server/parser/src/main/java/org/eclipse/lsp/cobol/core/MessageServiceParser.java
@@ -17,12 +17,11 @@
 
 package org.eclipse.lsp.cobol.core;
 
-import org.antlr.v4.runtime.Parser;
 import com.google.common.annotations.VisibleForTesting;
+import java.util.regex.Pattern;
+import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.TokenStream;
 import org.eclipse.lsp.cobol.common.message.MessageServiceProvider;
-
-import java.util.regex.Pattern;
 
 /**
  * Provide the support of message externalization for Parser.
@@ -52,6 +51,22 @@ public abstract class MessageServiceParser extends Parser {
   public void notifyError(String messageId, String... parameters) {
     String message = getMessageForParser(messageId, parameters);
     notifyListeners(message);
+  }
+
+  /**
+   * Extend the functionality of {@link org.eclipse.lsp.cobol.common.message.MessageService} for
+   * {@link CobolParser}
+   *
+   * <p>Example: notifyWarning("db2SqlParser.validValueMsg", input, value); would notify errorListener
+   * with the externalized messages.
+   *
+   * @param messageId Unique ID for each message in externalized message file.
+   * @param parameters Arguments referenced by the format specifiers in the format string in
+   *     externalized message file.
+   */
+  public void notifyWarning(String messageId, String... parameters) {
+    String message = getMessageForParser(messageId, parameters);
+    notifyErrorListeners(getCurrentToken(), message, new WarningRecognitionException());
   }
 
   /**

--- a/server/parser/src/main/java/org/eclipse/lsp/cobol/core/WarningRecognitionException.java
+++ b/server/parser/src/main/java/org/eclipse/lsp/cobol/core/WarningRecognitionException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core;
+
+import org.antlr.v4.runtime.IntStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+
+/** Help {@link org.antlr.v4.runtime.ANTLRErrorListener} to identify a warning error */
+public class WarningRecognitionException extends RecognitionException {
+  public WarningRecognitionException(
+      Recognizer<?, ?> recognizer, IntStream input, ParserRuleContext ctx) {
+    super(recognizer, input, ctx);
+  }
+
+  public WarningRecognitionException() {
+    super(null, null, null);
+  }
+}


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] below code should give warning messages for the unexpected comma char in the string statement
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID.   TEST23.
       ENVIRONMENT DIVISION.
       CONFIGURATION SECTION.
       INPUT-OUTPUT SECTION.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 WS-VARIABLES.
          05 WS-REFRESH-TOKEN-LENGTH     PIC S9(4)V  COMP-3.
          05 WS-REFRESH-TOKEN            PIC X(1500).
          05 SW-DUMMY                    PIC X(01) VALUE 'N'.
             88 SW-DUMMY-Y                         VALUE 'Y'.
             88 SW-DUMMY-N                         VALUE 'N'.
          05 WS-REQUEST-BODY             PIC X(2000) VALUE SPACES.
       PROCEDURE DIVISION.
           EVALUATE TRUE
              WHEN SW-DUMMY-Y
                 STRING 'refresh_token='   DELIMITED BY SIZE
                       ,WS-REFRESH-TOKEN(1:WS-REFRESH-TOKEN-LENGTH)
                                           DELIMITED BY SIZE
                       , '&'                DELIMITED BY SIZE
                       , 'grant_type='      DELIMITED BY SIZE
                       ,'refresh_token'    DELIMITED BY SIZE
                    INTO WS-REQUEST-BODY
                 END-STRING.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
