### PR TITLE
[approach 2] fix: trigger analysis when copybook content is changed

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
@@ -79,6 +79,7 @@ suite("Integration Test Suite", function () {
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     for (const d of diagnostics) {
       if (d.range.start.line === 22) {
+        console.log("== check dia ==", d);
         assert.strictEqual(d.message, "Source text cannot go past column 80");
         helper.assertRangeIsEqual(d.range, range(pos(22, 80), pos(22, 131)));
         return;

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/CobolLanguageServer.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/CobolLanguageServer.java
@@ -16,6 +16,8 @@ package org.eclipse.lsp.cobol.lsp;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.lsp.handlers.server.ExitHandler;
@@ -26,9 +28,6 @@ import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
-
-import javax.annotation.Nullable;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * This class sets up the initial state of the services and applies other initialization activities,

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/CobolTextDocumentService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/CobolTextDocumentService.java
@@ -17,6 +17,9 @@ package org.eclipse.lsp.cobol.lsp;
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -28,10 +31,6 @@ import org.eclipse.lsp.cobol.service.delegates.communications.Communications;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * This class is a set of end-points to apply text operations for COBOL documents. All the requests

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/LspMessageDispatcher.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/LspMessageDispatcher.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 public class LspMessageDispatcher {
   private static final LspEvent<Void> POISON_PILL = () -> null;
-
   private final BlockingDeque<LspEvent<?>> eventQueue = new LinkedBlockingDeque<>();
   private final Map<LspEvent<?>, CompletableFuture<?>> eventResults = Collections.synchronizedMap(new HashMap<>());
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/server/InitializedHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/server/InitializedHandler.java
@@ -14,7 +14,10 @@
  */
 package org.eclipse.lsp.cobol.lsp.handlers.server;
 
+import static org.eclipse.lsp.cobol.service.settings.SettingsParametersEnum.*;
+
 import com.google.inject.Inject;
+import javax.annotation.Nullable;
 import org.eclipse.lsp.cobol.common.message.LocaleStore;
 import org.eclipse.lsp.cobol.common.message.MessageService;
 import org.eclipse.lsp.cobol.common.utils.LogLevelUtils;
@@ -24,10 +27,6 @@ import org.eclipse.lsp.cobol.service.copybooks.CopybookNameService;
 import org.eclipse.lsp.cobol.service.delegates.completions.Keywords;
 import org.eclipse.lsp.cobol.service.settings.SettingsService;
 import org.eclipse.lsp4j.InitializedParams;
-
-import javax.annotation.Nullable;
-
-import static org.eclipse.lsp.cobol.service.settings.SettingsParametersEnum.*;
 
 /**
  * LSP Initialized Handler

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/AnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/AnalysisService.java
@@ -14,9 +14,14 @@
  */
 package org.eclipse.lsp.cobol.service;
 
+import static java.lang.String.format;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.common.AnalysisConfig;
@@ -27,13 +32,6 @@ import org.eclipse.lsp.cobol.common.copybook.CopybookService;
 import org.eclipse.lsp.cobol.common.utils.ThreadInterruptionUtil;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookIdentificationService;
 import org.eclipse.lsp.cobol.service.settings.ConfigurationService;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-
-import static java.lang.String.format;
 
 /** Provides async document analysis functionality */
 @Slf4j
@@ -100,10 +98,7 @@ public class AnalysisService {
    * @param isNew Is document just opened, or it's reanalyse request.
    */
   public void analyzeDocument(String uri, String text, boolean isNew) {
-    contentCache.store(uri, text);
-    if (!isNew) {
-      documentService.updateDocument(uri, text);
-    }
+    updateCache(uri, text, isNew);
 
     String logPrefix = isNew ? "[analyzeDocument] Document " : "[reanalyzeDocument] Document ";
     LOG.debug(logPrefix + uri + " opened");
@@ -111,22 +106,20 @@ public class AnalysisService {
     if (!isCopybook(uri, text)) {
       LOG.debug(logPrefix + uri + " treated as a program, start analyzing");
       analyzeDocumentWithCopybooks(uri, text);
-      return;
     }
+  }
 
-    LOG.debug(logPrefix + uri + " treated as a copy");
-    if (isNew) {
-      return;
+  /**
+   * Update cache
+   * @param uri - document uri
+   * @param text - document text
+   * @param isNew - Is document just opened, or it's reanalyse request
+   */
+  public void updateCache(String uri, String text, boolean isNew) {
+    contentCache.store(uri, text);
+    if (!isNew) {
+      documentService.updateDocument(uri, text);
     }
-
-    Set<String> affectedOpenedPrograms =
-        documentService.findAffectedDocumentsForCopybook(
-            uri, d -> !isCopybook(d.getUri(), d.getText()));
-
-    documentService.getAll(affectedOpenedPrograms).stream()
-        .filter(d -> !isCopybook(d.getUri(), d.getText()))
-        .forEach(doc -> analyzeDocumentWithCopybooks(doc.getUri(), doc.getText()));
-
   }
 
   /**

--- a/server/engine/src/main/resources/resourceBundles/messages_en.properties
+++ b/server/engine/src/main/resources/resourceBundles/messages_en.properties
@@ -132,4 +132,4 @@ db2Parser.validation.section=this DB2 statement is allowed only in LINKAGE SECTI
 db2Parser.validation.procedureDiv=this DB2 statement is allowed only in PROCEDURE DIVISION
 db2Parser.validation.declareVar=Db2 variable declaration is only allowed in DATA DIVISION
 db2Parser.validation.allStatement=this DB2 statement is allowed only in DATA DIVISION or PROCEDURE DIVISION
-cobolParser.expectSpace=a blank is missing after ','
+cobolParser.expectSpace=A blank is missing after ','

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/ClientServerIntegrationTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/ClientServerIntegrationTest.java
@@ -14,34 +14,33 @@
  */
 package org.eclipse.lsp.cobol.service;
 
-import com.google.common.collect.ImmutableList;
-import com.google.inject.AbstractModule;
-import com.google.inject.Guice;
-import com.google.inject.Inject;
-import com.google.inject.Injector;
-import org.eclipse.lsp.cobol.ClientServerTestModule;
-import org.eclipse.lsp.cobol.ConfigurableTest;
-import org.eclipse.lsp.cobol.domain.modules.DatabusModule;
-import org.eclipse.lsp.cobol.lsp.CobolTextDocumentService;
-import org.eclipse.lsp.cobol.lsp.DisposableLSPStateService;
-import org.eclipse.lsp.cobol.common.LanguageEngineFacade;
-import org.eclipse.lsp.cobol.lsp.LspMessageDispatcher;
-import org.eclipse.lsp.cobol.service.mocks.MockLanguageClient;
-import org.eclipse.lsp4j.*;
-import org.eclipse.lsp4j.services.TextDocumentService;
-import org.junit.jupiter.api.*;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.function.Predicate;
-
 import static org.eclipse.lsp.cobol.test.engine.UseCaseUtils.DOCUMENT_URI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+import org.eclipse.lsp.cobol.ClientServerTestModule;
+import org.eclipse.lsp.cobol.ConfigurableTest;
+import org.eclipse.lsp.cobol.common.LanguageEngineFacade;
+import org.eclipse.lsp.cobol.domain.modules.DatabusModule;
+import org.eclipse.lsp.cobol.lsp.CobolTextDocumentService;
+import org.eclipse.lsp.cobol.lsp.DisposableLSPStateService;
+import org.eclipse.lsp.cobol.lsp.LspMessageDispatcher;
+import org.eclipse.lsp.cobol.service.mocks.MockLanguageClient;
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.junit.jupiter.api.*;
 
 /**
  * Test the LSP specification for shutdown request

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolLanguageServerTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolLanguageServerTest.java
@@ -15,9 +15,21 @@
 
 package org.eclipse.lsp.cobol.service;
 
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.eclipse.lsp.cobol.service.settings.SettingsParametersEnum.*;
+import static org.eclipse.lsp4j.DiagnosticTag.Unnecessary;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonPrimitive;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.eclipse.lsp.cobol.common.error.ErrorCodes;
 import org.eclipse.lsp.cobol.common.message.LocaleStore;
 import org.eclipse.lsp.cobol.common.message.MessageService;
@@ -56,19 +68,6 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static java.util.Collections.singletonList;
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.eclipse.lsp.cobol.service.settings.SettingsParametersEnum.*;
-import static org.eclipse.lsp4j.DiagnosticTag.Unnecessary;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * This test asserts functions of the {@link CobolLanguageServer}, such as initialization.

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolTextDocumentServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolTextDocumentServiceTest.java
@@ -14,6 +14,9 @@
  */
 package org.eclipse.lsp.cobol.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 import com.google.gson.JsonObject;
 import org.eclipse.lsp.cobol.cfg.CFASTBuilder;
 import org.eclipse.lsp.cobol.common.SubroutineService;
@@ -39,11 +42,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.concurrent.ExecutionException;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 /**
  * This test checks the entry points of the {@link TextDocumentService} implementation.
@@ -224,7 +222,7 @@ class CobolTextDocumentServiceTest {
   }
 
   @Test
-  void testFormatting() throws ExecutionException, InterruptedException {
+  void testFormatting() {
     DocumentFormattingParams params = mock(DocumentFormattingParams.class);
     TextDocumentIdentifier textDocumentIdentifier = mock(TextDocumentIdentifier.class);
     when(textDocumentIdentifier.getUri()).thenReturn(URI);

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestStringStatementWithInvalidCommaCharIsTolerated.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestStringStatementWithInvalidCommaCharIsTolerated.java
@@ -61,13 +61,13 @@ public class TestStringStatementWithInvalidCommaCharIsTolerated {
             "1",
             new Diagnostic(
                 new Range(),
-                "a blank is missing after ','",
+                "A blank is missing after ','",
                 DiagnosticSeverity.Warning,
                 ErrorSource.PARSING.getText()),
             "2",
             new Diagnostic(
                 new Range(),
-                "a blank is missing after ','",
+                "A blank is missing after ','",
                 DiagnosticSeverity.Warning,
                 ErrorSource.PARSING.getText())));
   }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A

1. open .cbl
2. select copybook and 'go to definition'
3. in the copybook tab make some error which cause some variable in main program not to be defined
4. close the copybook without saving - it means the error is not saved and should disappear
5. Unexpected output  -->the error in main program persists
    Expected output --> error disappears 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
