### PR TITLE
fix: do not trigger smart tab during completion

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -433,7 +433,7 @@
       {
         "key": "tab",
         "command": "cobol-lsp.smart-tab",
-        "when": "editorLangId == cobol && !inSnippetMode && editorTextFocus && config.cobol-lsp.smart-tab"
+        "when": "editorLangId == cobol && !inSnippetMode && !config.editor.tabCompletion && editorTextFocus && config.cobol-lsp.smart-tab"
       },
       {
         "key": "tab",


### PR DESCRIPTION
## How Has This Been Tested?

1. Open a COBOL module
2. Add a new line and start typing `MOV`
3. Wait for a completion or trigger it by pressing CTRL+SPACE
4. Once the completion for MOVE shows up, press TAB

Expected result - the `MOVE` completion is inserted into the code.

Before this change - Smart Tab was invoked and moved the cursor. The completion was ignored.

- [ ] Test A
- [ ] Test B

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
