### PR TITLE
fix: do not trigger smart tab during completion

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -438,17 +438,12 @@
       {
         "key": "tab",
         "command": "cobol-lsp.smart-tab",
-        "when": "editorLangId == COBOL && !inSnippetMode && editorTextFocus && config.cobol-lsp.smart-tab"
+        "when": "editorLangId == cobol && !inSnippetMode && !config.editor.tabCompletion && editorTextFocus && config.cobol-lsp.smart-tab"
       },
       {
         "key": "shift+tab",
         "command": "cobol-lsp.smart-outdent",
-        "when": "editorLangId == cobol && !inSnippetMode && editorTextFocus && config.cobol-lsp.smart-tab"
-      },
-      {
-        "key": "shift+tab",
-        "command": "cobol-lsp.smart-outdent",
-        "when": "editorLangId == COBOL && !inSnippetMode && editorTextFocus && config.cobol-lsp.smart-tab"
+        "when": "editorLangId == cobol && !inSnippetMode && !config.editor.tabCompletion && editorTextFocus && config.cobol-lsp.smart-tab"
       },
       {
         "key": "ctrl+/",


### PR DESCRIPTION
Author: Vit Gottwald <vit.gottwald@broadcom.com>
## How Has This Been Tested?

1. Open a COBOL module
2. Add a new line and start typing `MOV`
3. Wait for a completion or trigger it by pressing CTRL+SPACE
4. Once the completion for MOVE shows up, press TAB/Shift+TAB

Expected result - the `MOVE` completion is inserted into the code.

Before this change - Smart Tab was invoked and moved the cursor. The completion was ignored.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
