### PR TITLE
enable copybook download error/info messages for user triggered download

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -136,12 +136,16 @@ export class CopybookDownloadService implements vscode.Disposable {
   ) {
     return members.find(
       (ele) =>
-        ele
-          .substring(
-            0,
-            ele.lastIndexOf(".") !== -1 ? ele.lastIndexOf(".") : ele.length,
-          )
-          .toUpperCase() === copybookName.toUpperCase(),
+        CopybookDownloadService.getFilenameWithoutExtension(
+          ele,
+        ).toUpperCase() === copybookName.toUpperCase(),
+    );
+  }
+
+  private static getFilenameWithoutExtension(ele: string) {
+    return ele.substring(
+      0,
+      ele.lastIndexOf(".") !== -1 ? ele.lastIndexOf(".") : ele.length,
     );
   }
 
@@ -327,7 +331,9 @@ export class CopybookDownloadService implements vscode.Disposable {
     errors: Set<string>,
     cp: CopybookProfile,
   ) {
-    errors.delete(cp.getCopybook());
+    errors.delete(
+      CopybookDownloadService.getFilenameWithoutExtension(cp.getCopybook()),
+    );
     this.completedDownload++;
     const downloadPercent = Math.round(
       (this.completedDownload / this.totalDownload) * 100,

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/AsyncAnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/AsyncAnalysisService.java
@@ -21,6 +21,7 @@ import java.util.concurrent.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.common.SubroutineService;
+import org.eclipse.lsp.cobol.common.copybook.CopybookProcessingMode;
 import org.eclipse.lsp.cobol.common.copybook.CopybookService;
 import org.eclipse.lsp.cobol.service.AnalysisService;
 import org.eclipse.lsp.cobol.service.CobolDocumentModel;
@@ -117,7 +118,7 @@ public class AsyncAnalysisService {
 
       try {
         communications.notifyProgressBegin(uri);
-        analysisService.analyzeDocument(uri, text, open);
+        analysisService.analyzeDocument(uri, text, open, getProcessingMode(force));
         CobolDocumentModel documentModel = documentModelService.get(uri);
         analysisResults.remove(id).complete(documentModel);
         return documentModel;
@@ -133,6 +134,13 @@ public class AsyncAnalysisService {
       Optional.ofNullable(analysisResults.get(makeId(uri, prevId))).ifPresent(cf -> cf.cancel(true));
     }
     return value;
+  }
+
+  private CopybookProcessingMode getProcessingMode(boolean force) {
+    if (force) {
+      return CopybookProcessingMode.ENABLED_VERBOSE;
+    }
+    return null;
   }
 
   private void handleRelatedDocuments(String uri, String text, boolean isNew, boolean force) {


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. Provide wrong/empty Zowe explorer profile and try to analyze a program which need the copybook to be downloaded.
2. Analysis finishes with missing copybook
3. Try to resolve missing copybook through code actions
4. Expect a pop-up with proper warning message.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
