### PR TITLE
fix: fix coloring for exec sql and cics

### DIFF
--- a/clients/daco-dialect-support/syntaxes/daco.injection.json
+++ b/clients/daco-dialect-support/syntaxes/daco.injection.json
@@ -1,6 +1,6 @@
 {
     "scopeName": "daco.injection",
-    "injectionSelector": "L:source.cobol",
+    "injectionSelector": "R:source.cobol",
     "patterns": [
       {
         "include": "#da-co-keywords"


### PR DESCRIPTION
fix coloring for exec sql and cics. DaCo dialect has an exec statement which disrupts the sql/cics coloring if applied before cobol coloring. Changing the order of injection should fix this.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] coloring of exec sql and exec cics should work when DaCo dialect is enabled for a program containing those blocks

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
