### PR TITLE
feature: include statements in the folding range

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/FoldingRangeHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/FoldingRangeHandler.java
@@ -16,9 +16,10 @@ package org.eclipse.lsp.cobol.lsp.handlers.text;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp.cobol.lsp.AsyncAnalysisService;
 import org.eclipse.lsp.cobol.lsp.LspEvent;
 import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
@@ -26,7 +27,6 @@ import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.service.DocumentModelService;
 import org.eclipse.lsp.cobol.service.DocumentServiceHelper;
 import org.eclipse.lsp.cobol.service.UriDecodeService;
-import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeRequestParams;
 
@@ -55,11 +55,11 @@ public class FoldingRangeHandler {
    */
   public List<FoldingRange> foldingRange(FoldingRangeRequestParams params) {
     String uri = uriDecodeService.decode(params.getTextDocument().getUri());
-    List<DocumentSymbol> symbols =
-            documentService.isDocumentSynced(uri)
-                    ? documentService.get(uri).getOutlineResult()
-                    : Collections.emptyList();
-    return DocumentServiceHelper.getFoldingRangeFromDocumentSymbol(symbols);
+    Node rootNode =
+        documentService.isDocumentSynced(uri)
+            ? documentService.get(uri).getAnalysisResult().getRootNode()
+            : null;
+    return new ArrayList<>(DocumentServiceHelper.getFoldingRange(rootNode, uri));
   }
 
   /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/DocumentServiceHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/DocumentServiceHelper.java
@@ -14,49 +14,68 @@
  */
 package org.eclipse.lsp.cobol.service;
 
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.lsp.cobol.common.model.NodeType.*;
+import static org.eclipse.lsp.cobol.common.model.tree.Node.hasType;
+
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lsp.cobol.common.AnalysisResult;
+import org.eclipse.lsp.cobol.common.model.NodeType;
 import org.eclipse.lsp.cobol.common.model.tree.CopyNode;
-import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp4j.FoldingRange;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static java.util.stream.Collectors.toList;
-import static org.eclipse.lsp.cobol.common.model.NodeType.COPY;
-import static org.eclipse.lsp.cobol.common.model.tree.Node.hasType;
-
-/**
- * FoldingRange helper
- */
+/** FoldingRange helper */
 @UtilityClass
 public class DocumentServiceHelper {
 
+  private static final ImmutableList<NodeType> NODES_FOR_FOLDING =
+      ImmutableList.of(
+          DIVISION,
+          EVALUATE,
+          FILE_CONTROL_ENTRY,
+          IF,
+          IF_ELSE,
+          PARAGRAPH,
+          PERFORM,
+          PROCEDURE_SECTION,
+          PROGRAM,
+          SECTION,
+          VARIABLE);
+
   /**
    * Creates folding ranges for given document symbol table
-   * @param documentSymbols - document symbol table
-   * @return list of folding ranges
+   *
+   * @param rootNode root node
+   * @param uri
+   * @return Set of folding ranges
    */
-  public List<FoldingRange> getFoldingRangeFromDocumentSymbol(List<DocumentSymbol> documentSymbols) {
-    if (documentSymbols == null) {
-      return ImmutableList.of();
-    }
-    List<FoldingRange> foldingRanges = new ArrayList<>();
-    for (DocumentSymbol documentSymbol : documentSymbols) {
-      foldingRanges.add(
-          new FoldingRange(
-              documentSymbol.getSelectionRange().getStart().getLine(),
-              documentSymbol.getSelectionRange().getEnd().getLine()));
-      foldingRanges.addAll(getFoldingRangeFromDocumentSymbol(documentSymbol.getChildren()));
-    }
-    return foldingRanges;
+  public static Set<FoldingRange> getFoldingRange(Node rootNode, String uri) {
+    if (Objects.isNull(rootNode)) return ImmutableSet.of();
+    return rootNode
+        .getDepthFirstStream()
+        .filter(node -> node.getLocality().getUri().equals(uri))
+        .filter(node -> NODES_FOR_FOLDING.contains(node.getNodeType()))
+        .filter(
+            node ->
+                node.getLocality().getRange().getStart().getLine()
+                    != node.getLocality().getRange().getEnd().getLine())
+        .map(
+            node ->
+                new FoldingRange(
+                    node.getLocality().getRange().getStart().getLine(),
+                    node.getLocality().getRange().getEnd().getLine()))
+        .collect(Collectors.toSet());
   }
 
   /**
    * Extracts copybook uris from analysis result
+   *
    * @param result - analysis result
    * @return - list of copybook uris
    */
@@ -70,5 +89,4 @@ public class DocumentServiceHelper {
         .filter(def -> !StringUtils.isEmpty(def))
         .collect(toList());
   }
-
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/DocumentServiceHelperTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/DocumentServiceHelperTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+import org.eclipse.lsp.cobol.common.model.Locality;
+import org.eclipse.lsp.cobol.common.model.tree.ExitNode;
+import org.eclipse.lsp.cobol.common.model.tree.IfNode;
+import org.eclipse.lsp.cobol.common.model.tree.Node;
+import org.eclipse.lsp.cobol.common.model.tree.RootNode;
+import org.eclipse.lsp4j.FoldingRange;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/** Tests {@link DocumentServiceHelper} */
+class DocumentServiceHelperTest {
+  private static final Locality LOCALITY = Locality.builder().build();
+  public static final String DOCUMENT_URI = "file:///c:/workspace/document.cbl";
+
+  @Test
+  void getFoldingRange_whenRootNodelIsNull() {
+    Set<FoldingRange> foldingRange = DocumentServiceHelper.getFoldingRange(null, DOCUMENT_URI);
+    assertEquals(0, foldingRange.size());
+  }
+
+  @Test
+  void getFoldingRange_whenRootNodeIsPresent() {
+    Set<FoldingRange> foldingRange =
+        DocumentServiceHelper.getFoldingRange(getRootNode(), DOCUMENT_URI);
+    assertEquals(1, foldingRange.size());
+  }
+
+  @Test
+  void getFoldingRange_whenRootNodeIsPresent2() {
+    Node rootNode = getRootNode();
+    rootNode.addChild(
+        new ExitNode(
+            Locality.builder()
+                .range(new Range(new Position(3, 7), new Position(9, 7)))
+                .uri(DOCUMENT_URI)
+                .build()));
+    Set<FoldingRange> foldingRange = DocumentServiceHelper.getFoldingRange(rootNode, DOCUMENT_URI);
+    assertEquals(1, foldingRange.size());
+  }
+
+  @Test
+  void getFoldingRange_whenNoConditionalNodePresent() {
+    Node rootNode = new RootNode(LOCALITY);
+    rootNode.addChild(
+        new ExitNode(
+            Locality.builder().range(new Range(new Position(1, 0), new Position(3, 0))).build()));
+    Set<FoldingRange> foldingRange = DocumentServiceHelper.getFoldingRange(rootNode, DOCUMENT_URI);
+    assertEquals(0, foldingRange.size());
+  }
+
+  private static Node getRootNode() {
+    Node rootNode = new RootNode(LOCALITY);
+    Node ifNode =
+        new IfNode(
+            Locality.builder()
+                .range(new Range(new Position(1, 0), new Position(3, 0)))
+                .uri(DOCUMENT_URI)
+                .build());
+    rootNode.addChild(ifNode);
+    return rootNode;
+  }
+}


### PR DESCRIPTION
include IF, IF-ELSE, PERFORM and EVALUATE statements in the folding range

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Open a program with if , if else or evaluate statement. Expect a folding option for these statements as shown in the below screen shot

![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/7a2b8849-36a2-4542-890e-9792584e351f)


## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
