### PR TITLE
fix: do not invalidate cache in between a running analysis

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/AsyncAnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/AsyncAnalysisService.java
@@ -178,12 +178,23 @@ public class AsyncAnalysisService {
   /**
    * Trigger reanalyse of opened programs.
    */
-  public void reanalyseOpenedPrograms() {
+  public void reanalyseOpenedPrograms() throws InterruptedException {
+    List<CobolDocumentModel> openDocuments = documentModelService.getAllOpened()
+            .stream().filter(d -> !analysisService.isCopybook(d.getUri(), d.getText())).collect(Collectors.toList());
+    boolean analysisInProgress;
+    do {
+      analysisInProgress = openDocuments.stream()
+              .filter(model -> model.getLastAnalysisResult() != null)
+              .map(model -> makeId(model.getUri(), analysisResultsRevisions.get(model.getUri())))
+              .anyMatch(id -> !analysisResults.get(id).isDone());
+      LOG.debug(" re-analysis is waiting for prev analysis to finish");
+      TimeUnit.MILLISECONDS.sleep(100);
+    } while (analysisInProgress);
+
     copybookService.invalidateCache();
     subroutineService.invalidateCache();
     LOG.info("Cache invalidated");
-    documentModelService.getAllOpened()
-            .stream().filter(d -> !analysisService.isCopybook(d.getUri(), d.getText()))
+    openDocuments
             .forEach(doc -> scheduleAnalysis(doc.getUri(), doc.getText(), analysisResultsRevisions.get(doc.getUri()), false, true));
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DirtyCacheHandlerService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DirtyCacheHandlerService.java
@@ -42,7 +42,7 @@ public class DirtyCacheHandlerService {
   private LspEvent<Object> getLspEvent() {
     return new LspEvent<Object>() {
       @Override
-      public Object execute() {
+      public Object execute() throws InterruptedException {
         cacheIsDirty.compareAndSet(true, false);
         asyncAnalysisService.reanalyseOpenedPrograms();
         return null;

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/workspace/DidChangeWatchedFilesHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/workspace/DidChangeWatchedFilesHandler.java
@@ -15,6 +15,7 @@
 package org.eclipse.lsp.cobol.lsp.handlers.workspace;
 
 import com.google.inject.Inject;
+import java.util.List;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.lsp.AsyncAnalysisService;
@@ -22,8 +23,6 @@ import org.eclipse.lsp.cobol.lsp.DisposableLSPStateService;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookNameService;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.FileEvent;
-
-import java.util.List;
 
 /**
  * LSP DidChangeWatchedFiles Handler
@@ -47,7 +46,7 @@ public class DidChangeWatchedFilesHandler {
    *
    * @param params DidChangeWatchedFilesParams
    */
-  public void didChangeWatchedFiles(@NonNull DidChangeWatchedFilesParams params) {
+  public void didChangeWatchedFiles(@NonNull DidChangeWatchedFilesParams params) throws InterruptedException {
     if (disposableLSPStateService.isServerShutdown()) return;
     if (isRelevant(params.getChanges())) {
       copybookNameService.collectLocalCopybookNames();


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] This is little tricky to reproduce. 
1. Make sure that a db2 dialect is enabled and SQLCA copybook is included in a cobol source.
2. Edit the source, creating random changes. 
3. Prev behavior - Some times, this may lead to SQLCA copybook not found. 
    Expected - predefined and downloaded copybooks errors are not found,

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
