### PR TITLE
fix: fix definition and references uri for virtual documents

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DefinitionHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DefinitionHandler.java
@@ -59,7 +59,8 @@ public class DefinitionHandler {
    */
   public Either<List<? extends Location>, List<? extends LocationLink>> definition(DefinitionParams params) throws ExecutionException, InterruptedException {
     CobolDocumentModel doc = documentModelService.get(uriDecodeService.decode(params.getTextDocument().getUri()));
-    return Either.forLeft(occurrences.findDefinitions(doc, params));
+    List<Location> definitions = occurrences.findDefinitions(doc, params);
+    return Either.forLeft(HandlerUtility.mapToOriginalLocation(definitions, uriDecodeService));
   }
 
   /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/HandlerUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/HandlerUtility.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.lsp.handlers.text;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.experimental.UtilityClass;
+import org.eclipse.lsp.cobol.service.UriDecodeService;
+import org.eclipse.lsp4j.Location;
+
+/**
+ * Class with utility methods for {@link org.eclipse.lsp.cobol.lsp.LspEvent} handlers
+ */
+@UtilityClass
+public class HandlerUtility {
+    /**
+     * Maps the provided location to the original location which triggered the request.
+     * @param decodedLocations locations with decoded uri's
+     * @param service {@link UriDecodeService}
+     * @return mapped locations
+     */
+    List<Location> mapToOriginalLocation(List<Location> decodedLocations, UriDecodeService service) {
+        return decodedLocations.stream().map(loc -> {
+            loc.setUri(service.getOriginalUri(loc.getUri()));
+            return loc;
+        }).collect(Collectors.toList());
+    }
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/ReferencesHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/ReferencesHandler.java
@@ -54,7 +54,8 @@ public class ReferencesHandler {
    */
   public List<? extends Location> references(ReferenceParams params) throws ExecutionException, InterruptedException {
     String uri = uriDecodeService.decode(params.getTextDocument().getUri());
-    return occurrences.findReferences(documentModelService.get(uri), params, params.getContext());
+    List<Location> references = occurrences.findReferences(documentModelService.get(uri), params, params.getContext());
+    return HandlerUtility.mapToOriginalLocation(references, uriDecodeService);
   }
 
   /**


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] 1. edit cobol files using Explorer for Endevor. 
       2. Trigger to to definition on any variable. No new files should be opened for definition, if definition lies in the same program.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
