### PR TITLE
fix: allow db2 declare statement in the working storage and linkage s…

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
@@ -40,7 +40,7 @@ procedureDivisionRules: ((dbs_allocate | dbs_alter | dbs_associate | dbs_call | 
           dbs_revoke | dbs_rollback | dbs_savepoint | dbs_select | dbs_set | dbs_signal | dbs_transfer | dbs_truncate |
           dbs_update | dbs_values) dbs_semicolon_end?)+;
 
-rulesAllowedInDataDivisionAndProcedureDivision: ((dbs_declare_cursor | dbs_whenever | dbs_declare_table | dbs_include) dbs_semicolon_end?)+;
+rulesAllowedInDataDivisionAndProcedureDivision: ((dbs_declare_cursor | dbs_whenever | dbs_declare_table | dbs_include | DECLARE dbs_declare_statement) dbs_semicolon_end?)+;
 
 rulesAllowedInWorkingStorageAndLinkageSection: ((dbs_begin | dbs_end | dbs_include_sqlca | dbs_include_sqlda) dbs_semicolon_end?)+;
 
@@ -552,7 +552,7 @@ dbs_create_view: VIEW dbs_view_name column_loop? AS tbl_expr_loop?  dbs_fullsele
 tbl_expr_loop: WITH dbs_select_statement_common_table_expression dbs_comma_separator dbs_select_statement_common_table_expression*;
 
 /*DECLARE (all) */
-dbs_declare: DECLARE (dbs_declare_global | dbs_declare_statement);
+dbs_declare: DECLARE dbs_declare_global;
 
 dbs_declare_cursor: DECLARE dbs_cursor_name ((NO|ASENSITIVE|INSENSITIVE|SENSITIVE (DYNAMIC|STATIC)?) SCROLL)? CURSOR ((WITH|WITHOUT) HOLD |
                     (WITHOUT RETURN|WITH RETURN TO (CALLER|CLIENT)) | (WITH|WITHOUT) ROWSET POSITIONING)* /*random ordering req*/
@@ -1799,4 +1799,4 @@ dbs_integer_max: INTEGERLITERAL  {validateValue($INTEGERLITERAL.text, "214748364
 dbs_char_a: NONNUMERICLITERAL  {validateValue($NONNUMERICLITERAL.text, "A");};
 dbs_char_n: NONNUMERICLITERAL  {validateValue($NONNUMERICLITERAL.text, "N");};
 dbs_char_r: NONNUMERICLITERAL  {validateValue($NONNUMERICLITERAL.text, "R");};
-/////// End Variables /////////////
+/////

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlAllDeclareStatements.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlAllDeclareStatements.java
@@ -17,12 +17,11 @@ package org.eclipse.lsp.cobol.usecases;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.stream.Stream;
 import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
 
 /**
  * This PARAMETERIZED test checks if all below sql DECLARE statements works correctly.
@@ -107,13 +106,36 @@ class TestSqlAllDeclareStatements {
           + "             DECLARE :{$AMBER} VARIABLE CCSID UNICODE;\n"
           + "           END-EXEC.";
 
+  public static final String DECLARE_STATEMENT_IN_WORKING_STORAGE =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. HELLO-SQL.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "           EXEC SQL\n"
+          + "              declare asasa statement\n"
+          + "             END-EXEC.\n"
+          + "       PROCEDURE DIVISION.";
+
+  public static final String DECLARE_STATEMENT_IN_LINKAGE_SECTION =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. HELLO-SQL.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       LINKAGE SECTION.\n"
+          + "           EXEC SQL\n"
+          + "              declare asasa statement\n"
+          + "             END-EXEC.\n"
+          + "       PROCEDURE DIVISION.";
+
   private static Stream<String> textsToTest() {
     return Stream.of(
         DECLARE_CURSOR,
         DECLARE_GLOBAL_TEMP_TABLE,
         DECLARE_TABLE,
         DECLARE_STATEMENT,
-        DECLARE_VARIABLE);
+        DECLARE_VARIABLE,
+        DECLARE_STATEMENT_IN_WORKING_STORAGE,
+        DECLARE_STATEMENT_IN_LINKAGE_SECTION);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
…ection

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] below code do not throw any error
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. HELLO-SQL.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
           EXEC SQL
              declare asasa statement
             END-EXEC.
       PROCEDURE DIVISION.
            EXEC SQL
              declare asasa statement
             END-EXEC.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
