### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/clients/cobol-lsp-vscode-extension/CHANGELOG.md
+++ b/clients/cobol-lsp-vscode-extension/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to the COBOL Language Support extension are documented in th
 
 #### Fixed
 - Miscellaneous bug fixes
+- Fix new tab for COBOL code in Explorer for Endevor
+
+#### Changed
+- Folding support added to conditional statements
 
 ## [2.1.0](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/compare/2.0.3...2.1.0) (2023-12-20)
 #### Fixed

--- a/clients/cobol-lsp-vscode-extension/CHANGELOG.md
+++ b/clients/cobol-lsp-vscode-extension/CHANGELOG.md
@@ -2,16 +2,24 @@
 All notable changes to the COBOL Language Support extension are documented in this file.
 
 ## [2.1.1](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/compare/2.1.0...2.1.1) (2024-01-30)
+#### Added
+- Support for CICS INQUIRE URIMAP statement
+
 #### Fixed
 - Miscellaneous bug fixes
 
 ## [2.1.0](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/compare/2.0.3...2.1.0) (2023-12-20)
 #### Fixed
+- Db2 grammar update
 - Miscellaneous bug fixes
+
+#### Changed
+- Include Db2 keywords in the SQL coloring
 
 ## [2.0.3](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/compare/2.0.2...2.0.3) (2023-09-20)
 
 #### Fixed
+- Db2 grammar update
 - Miscellaneous bug fixes
 
 ## [2.0.2](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/compare/2.0.1...2.0.2) (2023-08-15)


### PR DESCRIPTION
A bit more detail in the client changelog. I think we can mention (vaguely) whenever the CICS/Db2 parsers are updated and specify any new nonterminals added.