### PR TITLE
fix: fix folding when IfNode has a copynode child

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/DocumentServiceHelperTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/DocumentServiceHelperTest.java
@@ -18,14 +18,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Set;
 import org.eclipse.lsp.cobol.common.model.Locality;
-import org.eclipse.lsp.cobol.common.model.tree.EvaluateNode;
-import org.eclipse.lsp.cobol.common.model.tree.EvaluateWhenNode;
-import org.eclipse.lsp.cobol.common.model.tree.ExitNode;
-import org.eclipse.lsp.cobol.common.model.tree.IfNode;
-import org.eclipse.lsp.cobol.common.model.tree.Node;
-import org.eclipse.lsp.cobol.common.model.tree.RootNode;
+import org.eclipse.lsp.cobol.common.model.tree.*;
 import org.eclipse.lsp.cobol.common.model.tree.variable.QualifiedReferenceNode;
 import org.eclipse.lsp4j.FoldingRange;
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Disabled;
@@ -91,12 +87,31 @@ class DocumentServiceHelperTest {
     ifNode.addChild(new QualifiedReferenceNode(Locality.builder()
             .range(new Range(new Position(3, 0), new Position(4, 10)))
             .uri(DOCUMENT_URI).build()));
+    CopyNode copyNode = new CopyNode(
+            Locality.builder()
+                    .range(new Range(new Position(5, 0), new Position(5, 10)))
+                    .uri(DOCUMENT_URI)
+                    .build(),
+            new Location(),
+            "",
+            "");
+    PerformNode performNode = new PerformNode(Locality.builder()
+            .range(new Range(new Position(0, 0), new Position(12, 10)))
+            .uri("file:///c:/workspace/copy.cpy")
+            .build());
+    copyNode.addChild(performNode);
+    ifNode.addChild(performNode);
+    ifNode.addChild(copyNode);
     evaluateWhenNode.addChild(ifNode);
     evaluateNode.addChild(evaluateWhenNode);
     evaluateNode.addChild(evaluateWhenNode2);
     rootNode.addChild(evaluateNode);
     Set<FoldingRange> foldingRange = DocumentServiceHelper.getFoldingRange(rootNode, DOCUMENT_URI);
     assertEquals(4, foldingRange.size());
+    assertTrue(foldingRange.contains(new FoldingRange(5, 6))); // evaluateWhenNode2
+    assertTrue(foldingRange.contains(new FoldingRange(0, 10))); // evaluateNode
+    assertTrue(foldingRange.contains(new FoldingRange(3, 5))); // if node
+    assertTrue(foldingRange.contains(new FoldingRange(2, 4))); // evaluateWhenNode
   }
 
   private static Node getRootNode() {


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Folding for below code should work for if block and evaluate block
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. COPY-FOLDING.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 CHECK pic x(9).
       01 evaluate-var pic x(9).
       PROCEDURE DIVISION.
       sample1.
           display "under sample para".
       test1.
           if check not ZERO
               display "under if condition."
               display "asas"
               copy testio.
           END-IF.
       test2.
           EVALUATE evaluate-var
               WHEN 'add'
                   DISPLAY 'ADD'
               WHEN 'update'
                   DISPLAY 'UPDATE'
                    if evaluate-var
                        perform XXX 
                        THRU YYYY
                        go to common-return
                    ELSE
                        perform zzz 
                        THRU uuuu
                        go to common-return
                END-IF

               WHEN OTHER
                   PERFORM SAMPLE1
           END-EVALUATE.

       common-return.
           display "exit".
       zzz.
       xxx.
       yyyy.
       uuuu.

``` 

copybook 
```cobol
            perform sample1        
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
