### PR TITLE
fix: fix: apply matching threshold while parsing different divisions …

### DIFF
--- a/server/parser/pom.xml
+++ b/server/parser/pom.xml
@@ -80,6 +80,12 @@
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons.text.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${google.guava.version}</version>

--- a/server/parser/src/main/java/org/eclipse/lsp/cobol/core/AstBuilder.java
+++ b/server/parser/src/main/java/org/eclipse/lsp/cobol/core/AstBuilder.java
@@ -16,7 +16,11 @@
  */
 package org.eclipse.lsp.cobol.core;
 
+import com.google.common.collect.ImmutableList;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.eclipse.lsp.cobol.core.hw.Diagnostic;
+
+import java.util.List;
 
 /**
  * A Cobol Parser Abstraction.
@@ -35,4 +39,12 @@ public interface AstBuilder {
    * @return Token stream.
    */
   CommonTokenStream getTokens();
+
+  /**
+   * Diagnostics while producing AST
+   * @return List of {@link Diagnostic} encountered while parsing
+   */
+  default List<Diagnostic> diagnostics() {
+    return ImmutableList.of();
+  }
 }

--- a/server/parser/src/main/java/org/eclipse/lsp/cobol/core/SplitParser.java
+++ b/server/parser/src/main/java/org/eclipse/lsp/cobol/core/SplitParser.java
@@ -26,6 +26,10 @@ import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.eclipse.lsp.cobol.common.utils.ThreadInterruptionUtil;
 import org.eclipse.lsp.cobol.core.cst.SourceUnit;
 import org.eclipse.lsp.cobol.core.hw.AntlrAdapter;
+import org.eclipse.lsp.cobol.core.hw.Diagnostic;
+import org.eclipse.lsp.cobol.core.hw.ParseResult;
+
+import java.util.List;
 
 /**
  * COBOL parser class.
@@ -33,12 +37,15 @@ import org.eclipse.lsp.cobol.core.hw.AntlrAdapter;
 public class SplitParser implements AstBuilder {
   @Getter
   private final CommonTokenStream tokens;
+  private final List<Diagnostic> diagnostics;
 
   org.eclipse.lsp.cobol.core.CobolParser.StartRuleContext root;
   public SplitParser(CharStream input, BaseErrorListener listener, DefaultErrorStrategy errorStrategy, ParseTreeListener treeListener) {
     org.eclipse.lsp.cobol.core.hw.CobolLexer lexer = new org.eclipse.lsp.cobol.core.hw.CobolLexer(
             input.getText(Interval.of(0, input.size())));
-    SourceUnit su = new org.eclipse.lsp.cobol.core.hw.CobolParser(lexer).parse().getSourceUnit();
+    ParseResult parseResult = new org.eclipse.lsp.cobol.core.hw.CobolParser(lexer).parse();
+    SourceUnit su = parseResult.getSourceUnit();
+    diagnostics = parseResult.getDiagnostics();
     AntlrAdapter antlrAdapter = new AntlrAdapter(listener, errorStrategy, treeListener);
     root = antlrAdapter.sourceUnitToStartRule(su);
     tokens = antlrAdapter.adaptTokens(su);
@@ -53,5 +60,10 @@ public class SplitParser implements AstBuilder {
   public CobolParser.StartRuleContext runParser() {
     ThreadInterruptionUtil.checkThreadInterrupted();
     return root;
+  }
+
+  @Override
+  public List<Diagnostic> diagnostics() {
+    return diagnostics;
   }
 }

--- a/server/parser/src/main/java/org/eclipse/lsp/cobol/core/hw/Diagnostic.java
+++ b/server/parser/src/main/java/org/eclipse/lsp/cobol/core/hw/Diagnostic.java
@@ -16,17 +16,14 @@
  */
 package org.eclipse.lsp.cobol.core.hw;
 
-import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Value;
-import org.eclipse.lsp.cobol.core.cst.SourceUnit;
+import lombok.Data;
+import org.eclipse.lsp4j.Range;
 
 /**
- * Parsing result container
+ * Diagnostic
  */
-@Value
-@AllArgsConstructor
-public class ParseResult {
-  SourceUnit sourceUnit;
-  List<Diagnostic> diagnostics;
+@Data
+public class Diagnostic {
+    private final Range range;
+    private final String message;
 }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -21,6 +21,7 @@
         <dialect.api.version>1.0.3</dialect.api.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <commons.text.version>1.10.0</commons.text.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
…of COBOL code

This implementation is based on the Jaro Winkler similarity algorithm from http://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Following code should give warning for mistyped Procedures keyword
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. COPY-FOLDING.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 CHECK pic x(9).
       01 evaluate-var pic x(9).
       PROCEDUREs DIVISION.
       sample1.
           display "under sample para".
       test1.
           IF CHECK > 4
           then next sentence
           else 
                DISPLAY "under else"
           END-IF.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
