### PR TITLE
feat: Allow floating comments in DaCo COPY MAID statements

### DIFF
--- a/server/dialect-daco/src/main/java/org/eclipse/lsp/cobol/dialects/daco/DaCoMaidProcessor.java
+++ b/server/dialect-daco/src/main/java/org/eclipse/lsp/cobol/dialects/daco/DaCoMaidProcessor.java
@@ -70,7 +70,7 @@ public class DaCoMaidProcessor {
           Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
   private final Pattern copyMaidPattern =
       Pattern.compile(
-          "^(?<indent>\\s*)(?<level>\\d{1,2})?\\s*COPY\\s+MAID\\s+(?<layoutId>[a-zA-Z\\d]*-?[a-zA-Z\\d]{0,3})\\s*(?<layoutUsage>[a-zA-Z]{3,6})?\\s*\\.?$",
+          "^(?<indent>\\s*)(?<level>\\d{1,2})?\\s*COPY\\s+MAID\\s+(?<layoutId>[a-zA-Z\\d]*-?[a-zA-Z\\d]{0,3})\\s*(?<layoutUsage>[a-zA-Z]{3,6})?\\s*\\.?\\s*(?<floatingComment>\\s+\\*\\>\\s?.*)?$",
           Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
   private final CopybookService copybookService;
   private final ParseTreeListener treeListener;

--- a/server/dialect-daco/src/test/java/org/eclipse/lsp/cobol/dialects/daco/usecases/TestCopyMaidWithFloatingComment.java
+++ b/server/dialect-daco/src/test/java/org/eclipse/lsp/cobol/dialects/daco/usecases/TestCopyMaidWithFloatingComment.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 DAF Trucks NV.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * DAF Trucks NV – implementation of DaCo COBOL statements
+ * and DAF development standards
+ */
+package org.eclipse.lsp.cobol.dialects.daco.usecases;
+
+import org.eclipse.lsp.cobol.dialects.daco.DaCoDialect;
+import org.eclipse.lsp.cobol.dialects.daco.utils.DialectConfigs;
+import org.eclipse.lsp.cobol.test.CobolText;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+/** This test checks that COPY MAID statement is parsed correctly with a floating comment */
+public class TestCopyMaidWithFloatingComment {
+    private static final String TEXT =
+      "        IDENTIFICATION DIVISION.\n"
+          + "          PROGRAM-ID. PARTEST.\n"
+          + "        ENVIRONMENT DIVISION.\n"
+          + "        IDMS-CONTROL SECTION.\n"
+          + "            PROTOCOL. MODE ABC.\n"
+          + "            IDMS-RECORDS MANUAL\n"
+          + "          DATA DIVISION.\n"
+          + "          WORKING-STORAGE SECTION.\n"
+          + "          01 COPY MAID {~NAME!DaCo}. *>@@Hello, World!!@#$\n"
+          + "          PROCEDURE DIVISION.\n"
+          + "              DISPLAY {$ABC}.";
+
+  private static final String COPYBOOK = "         01 {$*ABC} PIC 9.";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(new CobolText("NAME", DaCoDialect.NAME, COPYBOOK)),
+        ImmutableMap.of(), ImmutableList.of(), DialectConfigs.getDaCoAnalysisConfig());
+  }
+}


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Usecase test: TestCopyMaidWithFloatingComment

## Checklist:
- [x] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
