### PR TITLE
fix: trigger watch file action only for copybooks and opened programs

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/CobolWorkspaceServiceImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/CobolWorkspaceServiceImpl.java
@@ -110,6 +110,10 @@ public class CobolWorkspaceServiceImpl extends LspEventConsumer implements Works
               path = path.getParent();
             }
             String uriString = uriDecodeService.decode(path.toUri().toString());
+            if (sourceUnitGraph.isFileOpened(uriString)) {
+              // opened files are taken care by textChange events
+              return;
+            }
             boolean isDirectory = Files.isDirectory(path);
             if (!isDirectory) {
               triggerAnalysisForChangedFile(uriString);

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
@@ -210,7 +210,14 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
    */
   public void reanalyseCopybooksAssociatedPrograms(List<String> uris, String copybookUri, String copybookContent, SourceUnitGraph.EventSource eventSource) {
     documentModelService.removeDocumentDiagnostics(copybookUri);
-    for (String uri : uris) {
+    Optional.ofNullable(documentModelService.get(copybookUri)).ifPresent(model -> model.update(copybookContent));
+    List<String> openedUris =
+        documentModelService.getAllOpened().stream()
+            .filter(model -> uris.contains(model.getUri()))
+            .filter(model -> !analysisService.isCopybook(model.getUri(), model.getText()))
+            .map(CobolDocumentModel::getUri)
+            .collect(Collectors.toList());
+    for (String uri : openedUris) {
       //TODO: update cache directly from workspace document graph
       if (copybookService instanceof CopybookServiceImpl) {
         CopybookServiceImpl copybookServiceImpl = (CopybookServiceImpl) copybookService;

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisServiceTest.java
@@ -14,6 +14,13 @@
  */
 package org.eclipse.lsp.cobol.lsp.analysis;
 
+import static org.mockito.Mockito.*;
+
+import com.google.common.collect.ImmutableList;
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eclipse.lsp.cobol.common.SubroutineService;
 import org.eclipse.lsp.cobol.lsp.SourceUnitGraph;
 import org.eclipse.lsp.cobol.service.AnalysisService;
@@ -26,13 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.mockito.Mockito.*;
 
 /**
  *  Test {@link AsyncAnalysisService}
@@ -83,7 +83,11 @@ class AsyncAnalysisServiceTest {
         List<String> uris = Stream.of("URI1", "URI2").collect(Collectors.toList());
         SourceUnitGraph.EventSource eventSource = mock(SourceUnitGraph.EventSource.class);
         CobolDocumentModel cobolDocumentModel = mock(CobolDocumentModel.class);
+        when(cobolDocumentModel.getUri()).thenReturn("URI1");
+        when(cobolDocumentModel.getText()).thenReturn("code");
+        when(documentModelService.getAllOpened()).thenReturn(ImmutableList.of(cobolDocumentModel));
         when(documentModelService.get(any())).thenReturn(cobolDocumentModel);
+        when(analysisService.isCopybook(anyString(), anyString())).thenReturn(false);
         when(analysisResultsRevisionsMock.get(cobolDocumentModel.getUri())).thenReturn(1);
         asyncAnalysisService.reanalyseCopybooksAssociatedPrograms(uris, "copybookUri", "copybookContent", eventSource);
 


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Change in a copybook should trigger analysis only for related Cobol programs

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
