### PR TITLE
fix: handle tabs events by LS client

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/FetchCopybookCommandTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/FetchCopybookCommandTest.spec.ts
@@ -22,6 +22,15 @@ import { Utils } from "../../services/util/Utils";
 
 jest.mock("../../services/reporter/TelemetryService");
 jest.mock("../../services/copybook/CopybookDownloadService");
+jest.mock("vscode-languageclient/node", () => ({
+  LanguageClient: jest.fn(),
+  DidCloseTextDocumentNotification: {
+    type: jest.fn(),
+  },
+  DidOpenTextDocumentNotification: {
+    type: jest.fn(),
+  },
+}));
 Utils.getZoweExplorerAPI = jest.fn();
 
 const copybookDownloadService: CopybookDownloadService =

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/OpenSettingsCommandTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/OpenSettingsCommandTest.spec.ts
@@ -22,6 +22,15 @@ jest.mock("vscode", () => ({
     executeCommand: jest.fn(),
   },
 }));
+jest.mock("vscode-languageclient/node", () => ({
+  LanguageClient: jest.fn(),
+  DidCloseTextDocumentNotification: {
+    type: jest.fn(),
+  },
+  DidOpenTextDocumentNotification: {
+    type: jest.fn(),
+  },
+}));
 
 test("check gotoCopybookSettings calls telemetry services and vscode execute command with right parameters.", () => {
   expect(gotoCopybookSettings).toBeTruthy();

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
@@ -77,6 +77,9 @@ jest.mock("vscode", () => ({
     createOutputChannel: jest.fn().mockReturnValue({
       appendLine: jest.fn(),
     }),
+    tabGroups: {
+      onDidChangeTabs: jest.fn(),
+    },
   },
   workspace: {
     getConfiguration: jest.fn().mockReturnValue({
@@ -158,6 +161,9 @@ describe("Check plugin extension for cobol fails.", () => {
         addRequestHandler: jest.fn(),
         retrieveAnalysis: jest.fn(),
         start: jest.fn(),
+        listenToTabsChanges: {
+          bind: jest.fn(),
+        },
       };
     });
   });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -62,7 +62,15 @@ vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
   get: jest.fn().mockReturnValue(undefined),
 });
 (vscode.ProgressLocation as any) = { Notification: "notify" };
-
+jest.mock("vscode-languageclient/node", () => ({
+  LanguageClient: jest.fn(),
+  DidCloseTextDocumentNotification: {
+    type: jest.fn(),
+  },
+  DidOpenTextDocumentNotification: {
+    type: jest.fn(),
+  },
+}));
 Utils.getZoweExplorerAPI = jest.fn();
 const getContentMock = jest.fn();
 const getUSSContentsMock = jest.fn();

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookMessageHandlerTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookMessageHandlerTest.spec.ts
@@ -22,7 +22,15 @@ import { Utils } from "../../../services/util/Utils";
 vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
   get: jest.fn().mockReturnValue("testProfile"),
 });
-
+jest.mock("vscode-languageclient/node", () => ({
+  LanguageClient: jest.fn(),
+  DidCloseTextDocumentNotification: {
+    type: jest.fn(),
+  },
+  DidOpenTextDocumentNotification: {
+    type: jest.fn(),
+  },
+}));
 Utils.getZoweExplorerAPI = jest.fn();
 
 describe("Test the copybook message handler", () => {

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookResolveURITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookResolveURITest.spec.ts
@@ -46,7 +46,15 @@ jest.mock("vscode", () => ({
   },
   workspace: {},
 }));
-
+jest.mock("vscode-languageclient/node", () => ({
+  LanguageClient: jest.fn(),
+  DidCloseTextDocumentNotification: {
+    type: jest.fn(),
+  },
+  DidOpenTextDocumentNotification: {
+    type: jest.fn(),
+  },
+}));
 SettingsUtils.getWorkspaceFoldersPath = jest.fn().mockReturnValue([__dirname]);
 vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
   get: jest.fn().mockReturnValue(undefined),

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookURITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookURITest.spec.ts
@@ -17,7 +17,15 @@ import { CopybookURI } from "../../../services/copybook/CopybookURI";
 import { Utils } from "../../../services/util/Utils";
 
 Utils.getZoweExplorerAPI = jest.fn();
-
+jest.mock("vscode-languageclient/node", () => ({
+  LanguageClient: jest.fn(),
+  DidCloseTextDocumentNotification: {
+    type: jest.fn(),
+  },
+  DidOpenTextDocumentNotification: {
+    type: jest.fn(),
+  },
+}));
 describe("CopybooksPathGenerator tests", () => {
   const fsPath = "/projects";
   const profile = "profile";

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybooksCodeActionProviderTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybooksCodeActionProviderTest.spec.ts
@@ -17,6 +17,16 @@ import { CopybooksCodeActionProvider } from "../../../services/copybook/Copybook
 import { TelemetryService } from "../../../services/reporter/TelemetryService";
 import { Utils } from "../../../services/util/Utils";
 
+jest.mock("vscode-languageclient/node", () => ({
+  LanguageClient: jest.fn(),
+  DidCloseTextDocumentNotification: {
+    type: jest.fn(),
+  },
+  DidOpenTextDocumentNotification: {
+    type: jest.fn(),
+  },
+}));
+
 describe("Test Copybook code action provider", () => {
   const copybooksCodeAction = new CopybooksCodeActionProvider();
   const doc = { uri: { fsPath: "ws-path" }, fileName: "testFile" } as any;

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/reporter/TelemetryServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/reporter/TelemetryServiceTest.spec.ts
@@ -18,6 +18,16 @@ import { TelemetryReporterImpl } from "../../../services/reporter/TelemetryRepor
 import { TelemetryService } from "../../../services/reporter/TelemetryService";
 import { TelemetryEventMeasurements } from "../../../services/reporter/model/TelemetryEvent";
 
+jest.mock("vscode-languageclient/node", () => ({
+  LanguageClient: jest.fn(),
+  DidCloseTextDocumentNotification: {
+    type: jest.fn(),
+  },
+  DidOpenTextDocumentNotification: {
+    type: jest.fn(),
+  },
+}));
+
 const USERNAME: string = "usernameToAnonymize";
 const FAKE_ROOT_PATH: string = path.join(
   "C:",

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/ConfigurationWatcher.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/ConfigurationWatcher.spec.ts
@@ -16,7 +16,15 @@ import * as vscode from "vscode";
 import { SettingsService } from "../../../services/Settings";
 import { ConfigurationWatcher } from "../../../services/util/ConfigurationWatcher";
 jest.mock("../../../services/reporter/TelemetryService");
-
+jest.mock("vscode-languageclient/node", () => ({
+  LanguageClient: jest.fn(),
+  DidCloseTextDocumentNotification: {
+    type: jest.fn(),
+  },
+  DidOpenTextDocumentNotification: {
+    type: jest.fn(),
+  },
+}));
 jest.mock("vscode", () => ({
   commands: {
     executeCommand: jest.fn(),

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/ProfileUtilsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/ProfileUtilsTest.spec.ts
@@ -17,6 +17,16 @@ import * as vscode from "vscode";
 import { ProfileUtils } from "../../../services/util/ProfileUtils";
 import { Utils } from "../../../services/util/Utils";
 
+jest.mock("vscode-languageclient/node", () => ({
+  LanguageClient: jest.fn(),
+  DidCloseTextDocumentNotification: {
+    type: jest.fn(),
+  },
+  DidOpenTextDocumentNotification: {
+    type: jest.fn(),
+  },
+}));
+
 const getZoweExplorerMock = () => {
   return jest.fn().mockReturnValue({
     getExplorerExtenderApi: jest.fn().mockReturnValue({

--- a/clients/cobol-lsp-vscode-extension/src/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/extension.ts
@@ -90,6 +90,12 @@ export async function activate(
     ),
   );
 
+  context.subscriptions.push(
+    vscode.window.tabGroups.onDidChangeTabs(
+      languageClientService.listenToTabsChanges.bind(languageClientService),
+    ),
+  );
+
   configurationWatcher.watchConfigurationChanges();
 
   try {
@@ -126,9 +132,7 @@ export async function activate(
     "workspace/configuration",
     configHandler,
   );
-
   await languageClientService.start();
-
   // 'export' public api-surface
   return {
     v1: {

--- a/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
@@ -30,6 +30,7 @@ import { JavaCheck } from "./JavaCheck";
 import { NativeExecutableService } from "./nativeLanguageClient/nativeExecutableService";
 import { TelemetryService } from "./reporter/TelemetryService";
 import { SettingsService } from "./Settings";
+import { Utils } from "./util/Utils";
 
 const extensionId = "BroadcomMFD.cobol-language-support";
 
@@ -105,6 +106,15 @@ export class LanguageClientService {
     const languageClient = this.getLanguageClient();
     await languageClient.start();
     this.initHandlers();
+  }
+
+  public listenToTabsChanges(event: vscode.TabChangeEvent) {
+    if (this.languageClient) {
+      if (event.closed?.length > 0)
+        Utils.handleTabClose(event.closed, this.languageClient!);
+      if (event.opened?.length > 0)
+        Utils.handleTabsOpen(event.opened, this.languageClient!);
+    }
   }
 
   private initHandlers() {


### PR DESCRIPTION
handle tabs events by LS client. 
As per the discussion in the below 2 vscode issues, it seems LS should use tab API's to handle diagnostics. 

- https://github.com/microsoft/vscode-languageserver-node/issues/684
- https://github.com/microsoft/vscode/issues/201294

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Open a Cobol program using ZOWE explorer. Make sure that closing the dataset removes the related diagnostics and opening the file triggers analysis
- [x] Diagnostics of a file opened in multiple tabs, disappears only when all tabs are closed.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
