### PR TITLE
feat: support 'window/workDoneProgress/cancel' lsp event

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/CobolLanguageServer.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/CobolLanguageServer.java
@@ -20,9 +20,11 @@ import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.lsp.events.notifications.CancelProgressNotification;
 import org.eclipse.lsp.cobol.lsp.events.notifications.InitializedNotification;
 import org.eclipse.lsp.cobol.lsp.events.queries.InitializeQuery;
 import org.eclipse.lsp.cobol.lsp.events.queries.ShutdownQuery;
+import org.eclipse.lsp.cobol.lsp.handlers.server.CancelProgressHandler;
 import org.eclipse.lsp.cobol.lsp.handlers.server.ExitHandler;
 import org.eclipse.lsp.cobol.lsp.handlers.server.InitializeHandler;
 import org.eclipse.lsp.cobol.lsp.handlers.server.InitializedHandler;
@@ -48,6 +50,7 @@ public class CobolLanguageServer implements LanguageServer {
   private final ShutdownHandler shutdownHandler;
   private final InitializeHandler initializeHandler;
   private final InitializedHandler initializedHandler;
+  private final CancelProgressHandler cancelProgressHandler;
 
   @Inject
   @SuppressWarnings("squid:S107")
@@ -59,7 +62,8 @@ public class CobolLanguageServer implements LanguageServer {
           ShutdownHandler shutdownHandler,
           InitializeHandler initializeHandler,
           InitializedHandler initializedHandler,
-          LspEventConsumer lspEventConsumer) {
+          LspEventConsumer lspEventConsumer,
+          CancelProgressHandler cancelProgressHandler) {
     this.lspMessageBroker = lspMessageBroker;
     this.textService = textService;
     this.workspaceService = workspaceService;
@@ -68,6 +72,7 @@ public class CobolLanguageServer implements LanguageServer {
     this.initializeHandler = initializeHandler;
     this.initializedHandler = initializedHandler;
     this.lspEventConsumer = lspEventConsumer;
+    this.cancelProgressHandler = cancelProgressHandler;
   }
 
   @Override
@@ -112,5 +117,10 @@ public class CobolLanguageServer implements LanguageServer {
   public void exit() {
     // Kill the server (loop should be already stopped at this time)
     exitHandler.exit();
+  }
+
+  @Override
+  public void cancelProgress(WorkDoneProgressCancelParams params) {
+    lspMessageBroker.notify(new CancelProgressNotification(params.getToken().getLeft(), cancelProgressHandler));
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/notifications/CancelProgressNotification.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/notifications/CancelProgressNotification.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.lsp.events.notifications;
+
+import lombok.SneakyThrows;
+import org.eclipse.lsp.cobol.lsp.LspNotification;
+import org.eclipse.lsp.cobol.lsp.handlers.server.CancelProgressHandler;
+
+/** `window/workDoneProgress/cancel` language server event */
+public class CancelProgressNotification implements LspNotification {
+  private final String uri;
+  private final CancelProgressHandler cancelProgressHandler;
+
+  public CancelProgressNotification(String uri, CancelProgressHandler cancelProgressHandler) {
+    this.uri = uri;
+    this.cancelProgressHandler = cancelProgressHandler;
+  }
+
+  @SneakyThrows
+  @Override
+  public void execute() {
+    this.cancelProgressHandler.cancel(uri);
+  }
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/server/CancelProgressHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/server/CancelProgressHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.lsp.handlers.server;
+
+import com.google.inject.Inject;
+import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
+
+/** LSP `window/workDoneProgress/cancel` Handler */
+public class CancelProgressHandler {
+  private final AsyncAnalysisService asyncAnalysisService;
+
+  @Inject
+  public CancelProgressHandler(AsyncAnalysisService asyncAnalysisService) {
+    this.asyncAnalysisService = asyncAnalysisService;
+  }
+
+  /**
+   * Cancel analysis for the passed uri
+   * @param uri
+   * @throws InterruptedException
+   */
+  public void cancel(String uri) throws InterruptedException {
+    asyncAnalysisService.cancelAnalysis(uri);
+  }
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/communications/ServerCommunications.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/communications/ServerCommunications.java
@@ -140,6 +140,7 @@ public class ServerCommunications implements Communications {
 
   private void notifyWorkProgress(String uri) {
     WorkDoneProgressReport workDoneProgressReport = new WorkDoneProgressReport();
+    workDoneProgressReport.setCancellable(true);
     ProgressParams params = new ProgressParams(Either.forLeft(uri), Either.forLeft(workDoneProgressReport));
     getClient().notifyProgress(params);
   }
@@ -155,6 +156,7 @@ public class ServerCommunications implements Communications {
     workDoneProgressBegin.setTitle(messageService.getMessage(
             "Communications.syntaxAnalysisInProgressTitle",
             files.getNameFromURI(uri)));
+    workDoneProgressBegin.setCancellable(true);
     params.setValue(Either.forLeft(workDoneProgressBegin));
     getClient().notifyProgress(params);
   }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/events/notifications/CancelProgressNotificationTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/events/notifications/CancelProgressNotificationTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.lsp.events.notifications;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.lsp.cobol.lsp.handlers.server.CancelProgressHandler;
+import org.junit.jupiter.api.Test;
+
+/** Test {@link CancelProgressNotification} */
+class CancelProgressNotificationTest {
+  @Test
+  void test() throws InterruptedException {
+    CancelProgressHandler handler = mock(CancelProgressHandler.class);
+    CancelProgressNotification notification = new CancelProgressNotification("uri", handler);
+    notification.execute();
+    verify(handler).cancel("uri");
+  }
+}

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/handlers/server/CancelProgressHandlerTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/handlers/server/CancelProgressHandlerTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.lsp.handlers.server;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
+import org.junit.jupiter.api.Test;
+
+/** Test {@link CancelProgressHandler} */
+class CancelProgressHandlerTest {
+
+  @Test
+  void whenCancelIsCalled_properMethodIsInvoked() throws InterruptedException {
+    AsyncAnalysisService asyncAnalysisService = mock(AsyncAnalysisService.class);
+    CancelProgressHandler handler = new CancelProgressHandler(asyncAnalysisService);
+    handler.cancel("test-uri");
+    verify(asyncAnalysisService).cancelAnalysis("test-uri");
+  }
+}

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolLanguageServerTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolLanguageServerTest.java
@@ -32,7 +32,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import org.eclipse.lsp.cobol.common.dialects.CobolLanguageId;
 import org.eclipse.lsp.cobol.common.error.ErrorCodes;
 import org.eclipse.lsp.cobol.common.message.LocaleStore;
@@ -41,10 +40,7 @@ import org.eclipse.lsp.cobol.core.engine.dialects.DialectService;
 import org.eclipse.lsp.cobol.lsp.*;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
 import org.eclipse.lsp.cobol.lsp.events.queries.CodeActionQuery;
-import org.eclipse.lsp.cobol.lsp.handlers.server.ExitHandler;
-import org.eclipse.lsp.cobol.lsp.handlers.server.InitializeHandler;
-import org.eclipse.lsp.cobol.lsp.handlers.server.InitializedHandler;
-import org.eclipse.lsp.cobol.lsp.handlers.server.ShutdownHandler;
+import org.eclipse.lsp.cobol.lsp.handlers.server.*;
 import org.eclipse.lsp.cobol.lsp.handlers.text.CodeActionHandler;
 import org.eclipse.lsp.cobol.lsp.handlers.workspace.DidChangeConfigurationHandler;
 import org.eclipse.lsp.cobol.lsp.handlers.workspace.ExecuteCommandHandler;
@@ -87,6 +83,7 @@ class CobolLanguageServerTest {
 
   private DisposableLSPStateService stateService;
   private final UriDecodeService uriDecodeService = mock(UriDecodeService.class);
+  private final CancelProgressHandler cancelProgressHandler = mock(CancelProgressHandler.class);
 
   @BeforeEach
   void getStateService() {
@@ -130,7 +127,8 @@ class CobolLanguageServerTest {
                     new ShutdownHandler(stateService, lspMessageBroker),
                     mock(InitializeHandler.class),
                     initializedHandler,
-                    lspEventConsumer);
+                    lspEventConsumer,
+                    cancelProgressHandler);
 
 
     server.initialized(new InitializedParams());
@@ -208,7 +206,8 @@ class CobolLanguageServerTest {
                     new ShutdownHandler(stateService, lspMessageBroker),
                     new InitializeHandler(watchingService),
                     new InitializedHandler(watchingService, copybookNameService, keywords, settingsService, localeStore, analysisService, messageService, layoutStore),
-                    lspEventConsumer);
+                    lspEventConsumer,
+                    cancelProgressHandler);
 
     server.initialized(new InitializedParams());
     waitingQuery(lspMessageBroker).join();
@@ -253,7 +252,8 @@ class CobolLanguageServerTest {
                     new ShutdownHandler(stateService, lspMessageBroker),
                     new InitializeHandler(mock(WatcherServiceImpl.class)),
                     new InitializedHandler(mock(WatcherServiceImpl.class), null, null, null, null, null, null, null),
-                    lspEventConsumer);
+                    lspEventConsumer,
+                    cancelProgressHandler);
 
     try {
       InitializeResult result = server.initialize(initializeParams).get();
@@ -314,7 +314,8 @@ class CobolLanguageServerTest {
                     new ShutdownHandler(stateService, lspMessageBroker),
                     new InitializeHandler(null),
                     new InitializedHandler(null, null, null, null, null, null, null, null),
-                    lspEventConsumer);
+                    lspEventConsumer,
+                    cancelProgressHandler);
     assertEquals(1, stateService.getExitCode());
     server.shutdown();
     try {

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/delegates/communications/ServerCommunicationsTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/delegates/communications/ServerCommunicationsTest.java
@@ -126,11 +126,14 @@ class ServerCommunicationsTest {
     expectedNotifyBeginParams.setToken(uri);
     WorkDoneProgressBegin workDoneProgressBegin = new WorkDoneProgressBegin();
     workDoneProgressBegin.setTitle("TITLE");
+    workDoneProgressBegin.setCancellable(true);
     expectedNotifyBeginParams.setValue(Either.forLeft(workDoneProgressBegin));
 
     communications.notifyProgressBegin(uri);
     verify(client).notifyProgress(expectedNotifyBeginParams);
-    verify(client).notifyProgress(new ProgressParams(Either.forLeft(uri), Either.forLeft(new WorkDoneProgressReport())));
+    WorkDoneProgressReport expectedProgressReport = new WorkDoneProgressReport();
+    expectedProgressReport.setCancellable(true);
+    verify(client).notifyProgress(new ProgressParams(Either.forLeft(uri), Either.forLeft(expectedProgressReport)));
   }
 
   @Test


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Open a cobol program, while its analyzing, click the cancel button to cancel the analysis (as shown below) 
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/5d841a28-55e7-4b4e-908c-8da3da6eb3df)

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
