### PR TITLE
Update package.json

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -41,35 +41,43 @@
     "commands": [
       {
         "command": "cobol-lsp.cpy-manager.fetch-copybook",
-        "title": "Fetch copybook"
+        "category": "COBOL",
+        "title": "Fetch Copybook"
       },
       {
         "command": "cobol-lsp.cpy-manager.goto-settings",
-        "title": "Open Copybook location settings"
+        "category": "COBOL",
+        "title": "Open Copybook Location Settings"
       },
       {
         "command": "cobol-lsp.serverRuntime.goto-settings",
-        "title": "Open serverRuntime settings"
+        "category": "COBOL",
+        "title": "Open Server Runtime Settings"
       },
       {
         "command": "cobol-lsp.dialects.goto-settings",
-        "title": "Open Dialects settings"
+        "category": "COBOL",
+        "title": "Open Dialect Settings"
       },
       {
         "command": "cobol-lsp.commentLine.toggle",
+        "category": "COBOL",
         "title": "Toggle COBOL Line Comment"
       },
       {
         "command": "cobol-lsp.commentLine.comment",
-        "title": "Add Cobol Line Comment"
+        "category": "COBOL",
+        "title": "Add COBOL Line Comment"
       },
       {
         "command": "cobol-lsp.commentLine.uncomment",
+        "category": "COBOL",
         "title": "Remove COBOL Line Comment"
       },
       {
         "command": "cobol-lsp.clear.downloaded.copybooks",
-        "title": "Clear downloaded copybooks"
+        "category": "COBOL",
+        "title": "Clear Downloaded Copybooks"
       },
       {
         "command": "cobol-lsp.snippets.insertSnippets",


### PR DESCRIPTION
Some changes to F1 pallet command text:
- Added "COBOL" category (except to the snippets one, which can remain in snippets)
- Consistent formatting using Title Case
- Some small copyedits

I am doing the same on COBOL Control Flow. This is to bring this extension in line with HLASM Language Support and for easier documentation of the pallet commands in the Code4z techdocs, as well as just for clarity.

BTW, I'm not sure what the difference is between "add/remove COBOL line comment" and "toggle COBOL line comment", they seem redundant to me. The only difference I can tell is that the "add COBOL line comment" one will try and comment out a line that's already a comment, which won't do anything as far as I know, whereas the toggle/remove will remove the comment.