### PR TITLE
feat: remove optional dot for file description entry clauses

### DIFF
--- a/server/dialect-idms/src/test/java/org/eclipse/lsp/cobol/dialects/idms/usecases/TestIdmsCopy.java
+++ b/server/dialect-idms/src/test/java/org/eclipse/lsp/cobol/dialects/idms/usecases/TestIdmsCopy.java
@@ -14,18 +14,18 @@
  */
 package org.eclipse.lsp.cobol.dialects.idms.usecases;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.eclipse.lsp.cobol.common.model.NodeType;
-import org.eclipse.lsp.cobol.dialects.idms.IdmsDialect;
-import org.eclipse.lsp.cobol.common.model.tree.variable.ElementaryItemNode;
-import org.eclipse.lsp.cobol.test.CobolText;
 import org.eclipse.lsp.cobol.common.AnalysisResult;
+import org.eclipse.lsp.cobol.common.model.NodeType;
+import org.eclipse.lsp.cobol.common.model.tree.variable.ElementaryItemNode;
+import org.eclipse.lsp.cobol.dialects.idms.IdmsDialect;
 import org.eclipse.lsp.cobol.dialects.idms.utils.DialectConfigs;
+import org.eclipse.lsp.cobol.test.CobolText;
 import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * These test for COPY IDMS statements in FILE SECTION, WS/LINKAGE SECTIONS AND PROCEDURE DIVISION
@@ -123,7 +123,7 @@ class TestIdmsCopy {
       "       01  {$*MRB-ABCMAP}.\n" + "            03  {$*MRB-ABCMAP-ID}          PIC X(8).\n";
 
   private static final String CB_NAME5 = "FL002";
-  private static final String CB5 = "       FD {$*EMP-FILE}.\n" + "       RECORD CONTAINS 80.\n";
+  private static final String CB5 = "       FD {$*EMP-FILE}\n" + "       RECORD CONTAINS 80.\n";
   private static final String CB6 =
       "       05  {$*SKILL}.\n"
           + "         10  {$*SKILL-ID-0455}           PIC 9(4).\n";

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestFDRecordContainsClause.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestFDRecordContainsClause.java
@@ -17,12 +17,15 @@ package org.eclipse.lsp.cobol.usecases;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.common.error.ErrorSource;
 import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests record contains clause2 for file description entry
- * ref- <a
+ * Tests record contains clause2 for file description entry ref- <a
  * href="https://www.ibm.com/docs/en/cobol-zos/6.3?topic=division-data-file-description-entries">
  * division-data-file-description-entries</a>
  */
@@ -62,6 +65,14 @@ public class TestFDRecordContainsClause {
           + "002800     DATA RECORD IS {$AAAAAAAAAA}.                                   00002800\n"
           + "       01 {$*AAAAAAAAAA} PIC 9(2).\n";
 
+  public static final String TEXT5 =
+      BASE
+          + "           record contains 0 CHARACTERS.\n"
+          + "           {BLOCK|1} CONTAINS 0 RECORDS\n"
+          + "           LABEL RECORDS are OMITTED.\n"
+          + "       01 CARD_ABC_FIELD.\n"
+          + "           05 A-FIELD pic x(9).";
+
   @Test
   void test() {
     UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
@@ -80,5 +91,19 @@ public class TestFDRecordContainsClause {
   @Test
   void test4() {
     UseCaseEngine.runTest(TEXT4, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void testDotAreNotAllowedBetweenFDEntryClauses() {
+    UseCaseEngine.runTest(
+        TEXT5,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                new Range(),
+                "Syntax error on 'BLOCK'",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText())));
   }
 }

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolDataDivisionParser.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolDataDivisionParser.g4
@@ -37,7 +37,7 @@ fileDescriptionEntry
    ;
 
 fileDescriptionEntryClauses
-   : (FD | SD) cobolWord (DOT_FS? fileDescriptionEntryClause)* DOT_FS
+   : (FD | SD) cobolWord  fileDescriptionEntryClause* DOT_FS
    ;
 
 fileDescriptionEntryClause

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -417,7 +417,7 @@ fileDescriptionEntry
    ;
 
 fileDescriptionEntryClauses
-   : (FD | SD) cobolWord (DOT_FS? fileDescriptionEntryClause)* dot_fs   ;
+   : (FD | SD) cobolWord fileDescriptionEntryClause* dot_fs   ;
 
 fileDescriptionEntryClause
    : externalClause | globalClause | blockContainsClause | recordContainsClause | labelRecordsClause | valueOfClause | dataRecordsClause | linageClause | codeSetClause | reportClause | recordingModeClause


### PR DESCRIPTION
as per the doc - https://www.ibm.com/docs/en/cobol-zos/6.4?topic=division-data-file-description-entries the file description entires can not have optional dots in between.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Following issue should be resolved
![image](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/69206564/512881b0-5dc5-4407-b03a-43d2bb5b7400)

**wrong code**
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. test23.
       ENVIRONMENT DIVISION.
       CONFIGURATION SECTION.
       SPECIAL-NAMES.
       INPUT-OUTPUT SECTION.
       FILE-CONTROL.
           select CARD_ABC ASSIGN to abc.
       DATA DIVISION.
        FILE SECTION.
         FD CARD_ABC
           record contains 0 CHARACTERS.
           BLOCK CONTAINS 0 RECORDS
           LABEL RECORDS are OMITTED.
       01 CARD_ABC_FIELD.
           05 A-FIELD pic x(9).
        WORKING-STORAGE SECTION.
        LINKAGE SECTION.
       PROCEDURE DIVISION.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
