### PR TITLE
fix: EXP-COBOL not selected by default

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -107,13 +107,6 @@
       },
       {
         "id": "expcobol",
-        "extensions": [
-          ".cbl",
-          ".cob",
-          ".cobol",
-          ".cpy",
-          ".copy"
-        ],
         "aliases": [
           "EXP-COBOL"
         ],


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Installed the extension and opened a COBOL program. The language ID is properly selected as "COBOL" as opposed to EXP-COBOL

## Checklist:
- [x] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
