### PR TITLE
fix: fix right insertion of dialect copy node

### DIFF
--- a/server/dialect-daco/src/test/java/org/eclipse/lsp/cobol/dialects/daco/usecases/TestDacoCopynodeInsertion.java
+++ b/server/dialect-daco/src/test/java/org/eclipse/lsp/cobol/dialects/daco/usecases/TestDacoCopynodeInsertion.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.dialects.daco.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.dialects.daco.DaCoDialect;
+import org.eclipse.lsp.cobol.dialects.daco.utils.DialectConfigs;
+import org.eclipse.lsp.cobol.dialects.idms.IdmsDialect;
+import org.eclipse.lsp.cobol.test.CobolText;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** Tests right insertion of {@link org.eclipse.lsp.cobol.dialects.daco.nodes.DaCoCopyNode} */
+public class TestDacoCopynodeInsertion {
+  public static final String TEXT =
+      "000200 IDENTIFICATION DIVISION.\n"
+          + "000300 PROGRAM-ID.    TEST12.\n"
+          + "006700 ENVIRONMENT  DIVISION.\n"
+          + "006800 IDMS-CONTROL SECTION.\n"
+          + "006900 PROTOCOL.    MODE IS IDMS-DC-NONAUTO DEBUG\n"
+          + "007000              IDMS-RECORDS MANUAL.\n"
+          + "007100 CONFIGURATION    SECTION.\n"
+          + "007200 OBJECT-COMPUTER. IBM-370.\n"
+          + "007300 DATA   DIVISION.\n"
+          + "007400 WORKING-STORAGE SECTION.\n"
+          + "007500 01  {$*WS-AREA}.\n"
+          + "053500     03 {$*AREA-XWE}.                                                \n"
+          + "053600       05 COPY MAID {~TESTCPY!DaCo} KMK.                                \n"
+          + "055300 01  COPY IDMS {~SUBSCHEMA-NAMES!IDMS}.";
+
+  public static final String COPYBOOK_CONTENT =
+      "     1 01  {$*TEST-X`TEST-XWE}.          \n"
+          + "     2     03 {$*TEST1-X`TEST1-XWE}                 PIC X(4)    VALUE SPACE.";
+
+  private static final String SUBSCHEMA_NAMES =
+      "      *   * This copybook remains empty,\n"
+          + "      *   * because the content is of no interest while editing COBOL\n"
+          + "       01  FILLER                      PIC X(0).\n";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(
+            new CobolText("TESTCPY", DaCoDialect.NAME, COPYBOOK_CONTENT),
+            new CobolText("SUBSCHEMA-NAMES", IdmsDialect.NAME, SUBSCHEMA_NAMES, "url", true)),
+        ImmutableMap.of(),
+        ImmutableList.of(),
+        DialectConfigs.getDaCoAnalysisConfig());
+  }
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/processors/SectionNodeProcessorHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/processors/SectionNodeProcessorHelper.java
@@ -106,6 +106,7 @@ public class SectionNodeProcessorHelper {
   private List<VariableDefinitionNode> unwrapVariables(Node node) {
     List<VariableDefinitionNode> variables = new ArrayList<>();
     List<CopyNode> copybooks = new LinkedList<>();
+    String nodeUri = node.getLocality().getUri();
 
     node.getChildren()
         .forEach(
@@ -127,24 +128,25 @@ public class SectionNodeProcessorHelper {
             .map(CopyNode.class::cast)
             .collect(Collectors.toList());
 
-//   Below could be problematic if a copybook is referenced at multiple places in a cobol doc.
-//    As the uri of copybooks would match with all variable definition and would result in a wrong node tree structure.
-//
-//    allCopybooks.stream()
-//        .filter(c -> c.getUri() != null)
-//        .forEach(
-//            c ->
-//                new ArrayList<>(variables)
-//                    .stream()
-//                        .filter(Objects::nonNull)
-//                        .filter(v -> v.getLocality() != null)
-//                        .filter(v -> v.getLocality().getUri() != null)
-//                        .filter(v -> v.getLocality().getUri().equals(c.getUri()))
-//                        .forEach(
-//                            v -> {
-//                              variables.remove(v);
-//                              c.addChild(v);
-//                            }));
+    //   Below could be problematic if a copybook is referenced at multiple places in a cobol doc.
+    //    As the uri of copybooks would match with all variable definition and would result in a
+    // wrong node tree structure.
+    //
+    //    allCopybooks.stream()
+    //        .filter(c -> c.getUri() != null)
+    //        .forEach(
+    //            c ->
+    //                new ArrayList<>(variables)
+    //                    .stream()
+    //                        .filter(Objects::nonNull)
+    //                        .filter(v -> v.getLocality() != null)
+    //                        .filter(v -> v.getLocality().getUri() != null)
+    //                        .filter(v -> v.getLocality().getUri().equals(c.getUri()))
+    //                        .forEach(
+    //                            v -> {
+    //                              variables.remove(v);
+    //                              c.addChild(v);
+    //                            }));
 
     allCopybooks.forEach(
         copyNode -> {
@@ -156,7 +158,11 @@ public class SectionNodeProcessorHelper {
             if (variable.getLocality().getUri().equals(uri) && variableLine > copybookLine) {
               break;
             }
-            index.incrementAndGet();
+            // index of variable node insertion from copybooks,
+            // should happen  after variable located at same uri as copybook
+            if (variable.getLocality().getUri().equals(uri)) {
+              index.incrementAndGet();
+            }
           }
 
           copyNode


### PR DESCRIPTION
fix right insertion of dialect copy node. Dialect which insert copynode when followed by other copynode from dialect should be placed at right location

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test no regression introduced when working with dialects which introduce copy nodes. 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
