### PR TITLE
feat: Db2 binary host variable support

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
@@ -24,9 +24,17 @@ execRule: EXEC SQL sqlCode END_EXEC
          | {notifyError("cobolParser.missingEndExec");} EXEC SQL sqlCode DOT_FS? EOF
          | {notifyError("cobolParser.missingEndExec");} EXEC SQL;
 
-nonExecRule: result_set_locator_host_variable;
+nonExecRule: host_variable_rule;
+
+host_variable_rule: (result_set_locator_host_variable | binary_host_variable);
 
 result_set_locator_host_variable: dbs_level_01 entry_name  (USAGE IS?)? SQL TYPE IS RESULT_SET_LOCATOR VARYING;
+
+binary_host_variable: dbs_level_01 entry_name host_variable_usage binary_host_variable_type;
+binary_host_variable_type: ((BINARY | VARBINARY) LPARENCHAR INTEGERLITERAL RPARENCHAR ) | BINARY VARYING;
+
+host_variable_usage: (USAGE IS?)? SQL TYPE IS;
+
 entry_name : (FILLER |dbs_host_names);
 sqlCode
    : ~END_EXEC*?

--- a/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
@@ -33,8 +33,8 @@ result_set_locator_host_variable: dbs_level_01 entry_name  (USAGE IS?)? SQL TYPE
 binary_host_variable: dbs_level_01 entry_name host_variable_usage binary_host_variable_type;
 binary_host_variable_type: BINARY LPARENCHAR binary_host_variable_binary_size RPARENCHAR | VARBINARY LPARENCHAR binary_host_variable_varbinary_size RPARENCHAR  | BINARY VARYING;
 
-binary_host_variable_binary_size: dbs_integerliteral_expanded {validateIntegerRange($dbs_integerliteral_expanded.text, 1, 255);};
-binary_host_variable_varbinary_size: dbs_integerliteral_expanded {validateIntegerRange($dbs_integerliteral_expanded.text, 1, 32704);};
+binary_host_variable_binary_size: T=dbs_integerliteral_expanded {validateIntegerRange($T.start, $T.text, 1, 255);};
+binary_host_variable_varbinary_size: T=dbs_integerliteral_expanded {validateIntegerRange($T.start, $T.text, 1, 32704);};
 
 host_variable_usage: (USAGE IS?)? SQL TYPE IS;
 

--- a/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
@@ -31,7 +31,10 @@ host_variable_rule: (result_set_locator_host_variable | binary_host_variable);
 result_set_locator_host_variable: dbs_level_01 entry_name  (USAGE IS?)? SQL TYPE IS RESULT_SET_LOCATOR VARYING;
 
 binary_host_variable: dbs_level_01 entry_name host_variable_usage binary_host_variable_type;
-binary_host_variable_type: ((BINARY | VARBINARY) LPARENCHAR INTEGERLITERAL RPARENCHAR ) | BINARY VARYING;
+binary_host_variable_type: BINARY LPARENCHAR binary_host_variable_binary_size RPARENCHAR | VARBINARY LPARENCHAR binary_host_variable_varbinary_size RPARENCHAR  | BINARY VARYING;
+
+binary_host_variable_binary_size: dbs_positive_integerliteral {validateTextInRange($dbs_positive_integerliteral.text, 0, 256);};
+binary_host_variable_varbinary_size: dbs_positive_integerliteral {validateTextInRange($dbs_positive_integerliteral.text, 0, 32705);};
 
 host_variable_usage: (USAGE IS?)? SQL TYPE IS;
 
@@ -1790,6 +1793,9 @@ dbs_pieceSize : IDENTIFIER {validateTokenWithRegex($IDENTIFIER.text, "\\d+[MmGgK
 dbs_sql_identifier: NONNUMERICLITERAL | IDENTIFIER | FILENAME | FILENAME (DOT_FS IDENTIFIER)* | DSNDB04 | TRANSACTION | RECORDS | dbs_special_name;
 dbs_comma_separator: (COMMASEPARATORDB2 | COMMACHAR);
 dbs_semicolon_end: SEMICOLON_FS | SEMICOLONSEPARATORSQL;
+
+dbs_positive_integerliteral: (dbs_integerliteral_expanded | {notifyError("parsers.positiveIntOnly");} MINUSCHAR dbs_integerliteral_expanded);
+dbs_integerliteral_expanded: (INTEGERLITERAL|SINGLEDIGITLITERAL|SINGLEDIGIT_1);
 
 dbs_integer0: T=dbs_integer  {validateValue($T.text, "0");};
 dbs_integer1: T=dbs_integer  {validateValue($T.text, "1");};

--- a/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
@@ -33,8 +33,8 @@ result_set_locator_host_variable: dbs_level_01 entry_name  (USAGE IS?)? SQL TYPE
 binary_host_variable: dbs_level_01 entry_name host_variable_usage binary_host_variable_type;
 binary_host_variable_type: BINARY LPARENCHAR binary_host_variable_binary_size RPARENCHAR | VARBINARY LPARENCHAR binary_host_variable_varbinary_size RPARENCHAR  | BINARY VARYING;
 
-binary_host_variable_binary_size: dbs_positive_integerliteral {validateTextInRange($dbs_positive_integerliteral.text, 0, 256);};
-binary_host_variable_varbinary_size: dbs_positive_integerliteral {validateTextInRange($dbs_positive_integerliteral.text, 0, 32705);};
+binary_host_variable_binary_size: dbs_integerliteral_expanded {validateTextInRange($dbs_integerliteral_expanded.text, 0, 256);};
+binary_host_variable_varbinary_size: dbs_integerliteral_expanded {validateTextInRange($dbs_integerliteral_expanded.text, 0, 32705);};
 
 host_variable_usage: (USAGE IS?)? SQL TYPE IS;
 
@@ -1794,8 +1794,7 @@ dbs_sql_identifier: NONNUMERICLITERAL | IDENTIFIER | FILENAME | FILENAME (DOT_FS
 dbs_comma_separator: (COMMASEPARATORDB2 | COMMACHAR);
 dbs_semicolon_end: SEMICOLON_FS | SEMICOLONSEPARATORSQL;
 
-dbs_positive_integerliteral: (dbs_integerliteral_expanded | {notifyError("parsers.positiveIntOnly");} MINUSCHAR dbs_integerliteral_expanded);
-dbs_integerliteral_expanded: (INTEGERLITERAL|SINGLEDIGITLITERAL|SINGLEDIGIT_1);
+dbs_integerliteral_expanded: MINUSCHAR? (INTEGERLITERAL|SINGLEDIGITLITERAL|SINGLEDIGIT_1);
 
 dbs_integer0: T=dbs_integer  {validateValue($T.text, "0");};
 dbs_integer1: T=dbs_integer  {validateValue($T.text, "1");};

--- a/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
@@ -31,7 +31,7 @@ host_variable_rule: (result_set_locator_host_variable | binary_host_variable);
 result_set_locator_host_variable: dbs_level_01 entry_name  (USAGE IS?)? SQL TYPE IS RESULT_SET_LOCATOR VARYING;
 
 binary_host_variable: dbs_level_01 entry_name host_variable_usage binary_host_variable_type;
-binary_host_variable_type: BINARY LPARENCHAR binary_host_variable_binary_size RPARENCHAR | VARBINARY LPARENCHAR binary_host_variable_varbinary_size RPARENCHAR  | BINARY VARYING;
+binary_host_variable_type: BINARY LPARENCHAR binary_host_variable_binary_size RPARENCHAR | (VARBINARY | BINARY VARYING) LPARENCHAR binary_host_variable_varbinary_size RPARENCHAR;
 
 binary_host_variable_binary_size: T=dbs_integerliteral_expanded {validateIntegerRange($T.start, $T.text, 1, 255);};
 binary_host_variable_varbinary_size: T=dbs_integerliteral_expanded {validateIntegerRange($T.start, $T.text, 1, 32704);};

--- a/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
@@ -33,8 +33,8 @@ result_set_locator_host_variable: dbs_level_01 entry_name  (USAGE IS?)? SQL TYPE
 binary_host_variable: dbs_level_01 entry_name host_variable_usage binary_host_variable_type;
 binary_host_variable_type: BINARY LPARENCHAR binary_host_variable_binary_size RPARENCHAR | VARBINARY LPARENCHAR binary_host_variable_varbinary_size RPARENCHAR  | BINARY VARYING;
 
-binary_host_variable_binary_size: dbs_integerliteral_expanded {validateTextInRange($dbs_integerliteral_expanded.text, 0, 256);};
-binary_host_variable_varbinary_size: dbs_integerliteral_expanded {validateTextInRange($dbs_integerliteral_expanded.text, 0, 32705);};
+binary_host_variable_binary_size: dbs_integerliteral_expanded {validateIntegerRange($dbs_integerliteral_expanded.text, 1, 255);};
+binary_host_variable_varbinary_size: dbs_integerliteral_expanded {validateIntegerRange($dbs_integerliteral_expanded.text, 1, 32704);};
 
 host_variable_usage: (USAGE IS?)? SQL TYPE IS;
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlVisitor.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlVisitor.java
@@ -112,6 +112,33 @@ class Db2SqlVisitor extends Db2SqlParserBaseVisitor<List<Node>> {
     return ImmutableList.of(variableDefinitionNode);
   }
 
+   @Override
+   public List<Node> visitBinary_host_variable(Db2SqlParser.Binary_host_variableContext ctx) {
+      addReplacementContext(ctx);
+      Locality statementLocality = getLocality(this.context.getExtendedDocument().mapLocation(constructRange(ctx)));
+
+      Db2WorkingAndLinkageSectionNode semanticsNode = new Db2WorkingAndLinkageSectionNode(statementLocality);
+
+     VariableDefinitionNode variableDefinitionNode =
+             VariableDefinitionNode.builder()
+                     .level(Integer.parseInt(ctx.dbs_level_01().getText()))
+                     .levelLocality(
+                             getLocality(
+                                     this.context.getExtendedDocument().mapLocation(constructRange(ctx.entry_name()))))
+                     .statementLocality(statementLocality)
+                     .variableNameAndLocality(
+                             new VariableNameAndLocality(
+                                     VisitorHelper.getName(ctx.entry_name()),
+                                     getLocality(
+                                             this.context
+                                                     .getExtendedDocument()
+                                                     .mapLocation(constructRange(ctx.entry_name())))))
+                     .usageClauses(ImmutableList.of(UsageFormat.DISPLAY))
+                     .build();
+     variableDefinitionNode.addChild(semanticsNode);
+     return ImmutableList.of(variableDefinitionNode);
+   }
+
   private Locality getLocality(Location location) {
     Locality.LocalityBuilder builder =
         Locality.builder().uri(location.getUri()).range(location.getRange());

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/MessageServiceParser.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/MessageServiceParser.java
@@ -97,6 +97,20 @@ public abstract class MessageServiceParser extends Parser {
   }
 
   /**
+   * Validate integer value against range and throw an error if it is incorrect
+   *
+   * @param input integer to check
+   * @param minValue allowed integer value
+   * @param maxValue allowed integer value
+   */
+  protected void validateIntegerRange(String input, Integer minValue, Integer maxValue) {
+    Integer intInputValue = tryParseInt(input);
+    if (intInputValue != null && !(intInputValue >= minValue && intInputValue <= maxValue)) {
+      notifyError("parsers.intRangeValue", minValue.toString(), maxValue.toString());
+    }
+  }
+
+  /**
    * Validate that the subschema name is 16 or 18
    *
    * @param input string to check
@@ -220,5 +234,15 @@ public abstract class MessageServiceParser extends Parser {
     return ((MessageServiceProvider) this.getErrorHandler())
         .getMessageService()
         .getMessage(messageKey, (Object[]) parameters);
+  }
+
+  private Integer tryParseInt(String input) {
+    Integer parsedValue;
+    try {
+      parsedValue = Integer.parseInt(input);
+    } catch (Exception ex) {
+      parsedValue = null;
+    }
+    return parsedValue;
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/MessageServiceParser.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/MessageServiceParser.java
@@ -53,6 +53,18 @@ public abstract class MessageServiceParser extends Parser {
     notifyListeners(message);
   }
 
+  /**
+   * Extend the functionality of notifyError to include the offending token along with the message.
+   * @param offendingToken Token where the error occurs
+   * @param messageId Unique ID for each message in externalized message file.
+   * @param parameters Arguments referenced by the format specifiers in the format string in
+   *    externalized message file.
+   */
+  public void notifyError(Token offendingToken, String messageId, String... parameters) {
+    String message = getMessageForParser(messageId, parameters);
+    notifyErrorListeners(offendingToken, message, null);
+  }
+
   @Override
   public void notifyErrorListeners(Token offendingToken, String msg, RecognitionException e) {
     _syntaxErrors++;
@@ -107,6 +119,21 @@ public abstract class MessageServiceParser extends Parser {
     Integer intInputValue = tryParseInt(input);
     if (intInputValue != null && !(intInputValue >= minValue && intInputValue <= maxValue)) {
       notifyError("parsers.intRangeValue", minValue.toString(), maxValue.toString());
+    }
+  }
+
+  /**
+   * Validate integer value against range and throw an error if it is incorrect
+   *
+   * @param start start token
+   * @param input integer to check
+   * @param minValue allowed integer value
+   * @param maxValue allowed integer value
+   */
+  protected void validateIntegerRange(Token start, String input, Integer minValue, Integer maxValue) {
+    Integer intInputValue = tryParseInt(input);
+    if (intInputValue != null && !(intInputValue >= minValue && intInputValue <= maxValue)) {
+      notifyError(start, "parsers.intRangeValue", minValue.toString(), maxValue.toString());
     }
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/MessageServiceParser.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/MessageServiceParser.java
@@ -263,13 +263,11 @@ public abstract class MessageServiceParser extends Parser {
         .getMessage(messageKey, (Object[]) parameters);
   }
 
-  private Integer tryParseInt(String input) {
-    Integer parsedValue;
+ private Integer tryParseInt(String input) {
     try {
-      parsedValue = Integer.parseInt(input);
-    } catch (Exception ex) {
-      parsedValue = null;
+        return Integer.parseInt(input);
+    } catch (NumberFormatException ex) {
+        return null;
     }
-    return parsedValue;
-  }
+}
 }

--- a/server/engine/src/main/resources/resourceBundles/messages_en.properties
+++ b/server/engine/src/main/resources/resourceBundles/messages_en.properties
@@ -32,6 +32,7 @@ db2SqlParser.maxIntValue=%s not allowed. Allowed range is 1 to 32767
 db2SqlParser.pieceSize=%s not allowed. Size must be in KB, MB or GB
 db2SqlParser.size=%s not allowed. Size must be in GB
 parsers.validValueMsg=%s not allowed. It must be %s
+parsers.positiveIntOnly=Negative values are not allowed. Must be a positive integer.
 parsers.maxLength=%s cannot exceed %s characters
 parsers.exactLength=Exact length of %s must be %s characters
 parsers.intRangeValue =Allowed range is %s to %s

--- a/server/engine/src/main/resources/resourceBundles/messages_en.properties
+++ b/server/engine/src/main/resources/resourceBundles/messages_en.properties
@@ -32,7 +32,6 @@ db2SqlParser.maxIntValue=%s not allowed. Allowed range is 1 to 32767
 db2SqlParser.pieceSize=%s not allowed. Size must be in KB, MB or GB
 db2SqlParser.size=%s not allowed. Size must be in GB
 parsers.validValueMsg=%s not allowed. It must be %s
-parsers.positiveIntOnly=Negative values are not allowed. Must be a positive integer.
 parsers.maxLength=%s cannot exceed %s characters
 parsers.exactLength=Exact length of %s must be %s characters
 parsers.intRangeValue =Allowed range is %s to %s

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlHostVariable.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlHostVariable.java
@@ -57,7 +57,7 @@ public class TestSqlHostVariable {
                   + "        Program-Id. 'TEST1'.\n"
                   + "        Data Division.\n"
                   + "         Working-Storage Section.\n"
-                  + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS BINARY(256{)|1}.\n"
+                  + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS BINARY({256|1}).\n"
                   + "        PROCEDURE DIVISION.\n";
 
   public static final String BINARY_TEXT2 =
@@ -65,7 +65,7 @@ public class TestSqlHostVariable {
           + "        Program-Id. 'TEST1'.\n"
           + "        Data Division.\n"
           + "         Working-Storage Section.\n"
-          + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS BINARY(-1{)|1}.\n"
+          + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS BINARY({-|1}1).\n"
           + "        PROCEDURE DIVISION.\n";
 
   public static final String BINARY_TEXT3 =
@@ -73,7 +73,7 @@ public class TestSqlHostVariable {
           + "        Program-Id. 'TEST1'.\n"
           + "        Data Division.\n"
           + "         Working-Storage Section.\n"
-          + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS VARBINARY(32705{)|1}.\n"
+          + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS VARBINARY({32705|1}).\n"
           + "        PROCEDURE DIVISION.\n";
 
   public static final String BINARY_TEXT4 =
@@ -81,7 +81,7 @@ public class TestSqlHostVariable {
           + "        Program-Id. 'TEST1'.\n"
           + "        Data Division.\n"
           + "         Working-Storage Section.\n"
-          + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS VARBINARY(-1234{)|1}.\n"
+          + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS VARBINARY({-|1}1234).\n"
           + "        PROCEDURE DIVISION.\n";
 
   @Test

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlHostVariable.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlHostVariable.java
@@ -52,6 +52,38 @@ public class TestSqlHostVariable {
           + "        PROCEDURE DIVISION.\n"
           + "         {_01 VAR-NAME USAGE IS SQL TYPE IS RESULT-SET-LOCATOR VARYING|1_}.";
 
+  public static final String BINARY_TEXT1 =
+          "        Identification Division.\n"
+                  + "        Program-Id. 'TEST1'.\n"
+                  + "        Data Division.\n"
+                  + "         Working-Storage Section.\n"
+                  + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS BINARY(256{)|1}.\n"
+                  + "        PROCEDURE DIVISION.\n";
+
+  public static final String BINARY_TEXT2 =
+          "        Identification Division.\n"
+          + "        Program-Id. 'TEST1'.\n"
+          + "        Data Division.\n"
+          + "         Working-Storage Section.\n"
+          + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS BINARY(-1{)|1}.\n"
+          + "        PROCEDURE DIVISION.\n";
+
+  public static final String BINARY_TEXT3 =
+          "        Identification Division.\n"
+          + "        Program-Id. 'TEST1'.\n"
+          + "        Data Division.\n"
+          + "         Working-Storage Section.\n"
+          + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS VARBINARY(32705{)|1}.\n"
+          + "        PROCEDURE DIVISION.\n";
+
+  public static final String BINARY_TEXT4 =
+          "        Identification Division.\n"
+          + "        Program-Id. 'TEST1'.\n"
+          + "        Data Division.\n"
+          + "         Working-Storage Section.\n"
+          + "       01 {$*VAR-INVALID-BIN} USAGE IS SQL TYPE IS VARBINARY(-1234{)|1}.\n"
+          + "        PROCEDURE DIVISION.\n";
+
   @Test
   void testSupportForResultSetLocator() {
     UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
@@ -79,5 +111,70 @@ public class TestSqlHostVariable {
                 "this DB2 statement is allowed only in LINKAGE SECTION or WORKING-STORAGE SECTION",
                 DiagnosticSeverity.Error,
                 ErrorSource.DIALECT.getText())));
+  }
+
+  @Test
+  void testBinaryHostVariable_whenLargeBinaryValue() {
+    UseCaseEngine.runTest(
+            BINARY_TEXT1,
+            ImmutableList.of(),
+            ImmutableMap.of(
+                    "1",
+                    new Diagnostic(
+                            new Range(),
+                            "Allowed range is 1 to 255",
+                            DiagnosticSeverity.Error,
+                            ErrorSource.PARSING.getText())));
+  }
+
+  @Test
+  void testBinaryHostVariable_whenNegativeBinaryValue() {
+    UseCaseEngine.runTest(
+            BINARY_TEXT2,
+            ImmutableList.of(),
+            ImmutableMap.of(
+                    "1",
+                    new Diagnostic(
+                            new Range(),
+                            "Allowed range is 1 to 255",
+                            DiagnosticSeverity.Error,
+                            ErrorSource.PARSING.getText()
+                    )
+            )
+    );
+  }
+
+  @Test
+  void testBinaryHostVariable_whenLargeVarbinaryValue() {
+    UseCaseEngine.runTest(
+            BINARY_TEXT3,
+            ImmutableList.of(),
+            ImmutableMap.of(
+                    "1",
+                    new Diagnostic(
+                            new Range(),
+                            "Allowed range is 1 to 32704",
+                            DiagnosticSeverity.Error,
+                            ErrorSource.PARSING.getText()
+                    )
+            )
+    );
+  }
+
+  @Test
+  void testBinaryHostVariable_whenNegativeVarbinaryValue() {
+    UseCaseEngine.runTest(
+            BINARY_TEXT4,
+            ImmutableList.of(),
+            ImmutableMap.of(
+                    "1",
+                    new Diagnostic(
+                            new Range(),
+                            "Allowed range is 1 to 32704",
+                            DiagnosticSeverity.Error,
+                            ErrorSource.PARSING.getText()
+                    )
+            )
+    );
   }
 }


### PR DESCRIPTION
## How Has This Been Tested?

### VS Code Extension

Tested the new grammar locally and using the following small COBOL program with valid/invalid/negative values:
```
       Identification Division.
        Program-Id. 'TEST1'.
        Data Division.
         Working-Storage Section.
         01 VAR-BIN USAGE IS SQL TYPE IS BINARY(255).
         01 VAR-BIN-VARY USAGE IS SQL TYPE IS BINARY VARYING.
         01 VAR-VBIN USAGE IS SQL TYPE IS VARBINARY(32704).

         01 VAR-NOUSAGE-BIN SQL TYPE IS BINARY(255).
         01 VAR-BIN-NOUSAGE-VARY SQL TYPE IS BINARY VARYING.
         01 VAR-NOUSAGE-VBIN SQL TYPE IS VARBINARY(32704).
         
         01 VAR-INVALID-BIN USAGE IS SQL TYPE IS BINARY(256).
         01 VAR-INVALID-VBIN USAGE IS SQL TYPE IS VARBINARY(32705).

         01 VAR-NEGATIVE-BIN USAGE IS SQL TYPE IS BINARY(-1);
         01 VAR-NEGATIVE-VBIN USAGE IS SQL TYPE IS VARBINARY(-1234).
        PROCEDURE division.
```

Was given the intended results matching what is in IBM's documentation:
![Screenshot 2024-06-13 at 9 01 59 AM](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/assets/170667132/f0fd1575-8ebb-4082-813d-e0f973d24272)

### Unit Tests
Wrote four new unit tests checking the bounds of the size for both BINARY and VARBINARY types.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
