### PR TITLE
fix: fix right insertion of copy node

### DIFF
--- a/server/dialect-daco/src/test/java/org/eclipse/lsp/cobol/dialects/daco/usecases/TestDacoCopynodeInsertion.java
+++ b/server/dialect-daco/src/test/java/org/eclipse/lsp/cobol/dialects/daco/usecases/TestDacoCopynodeInsertion.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.dialects.daco.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.dialects.daco.DaCoDialect;
+import org.eclipse.lsp.cobol.dialects.daco.utils.DialectConfigs;
+import org.eclipse.lsp.cobol.dialects.idms.IdmsDialect;
+import org.eclipse.lsp.cobol.test.CobolText;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** Tests right insertion of {@link org.eclipse.lsp.cobol.dialects.daco.nodes.DaCoCopyNode} */
+public class TestDacoCopynodeInsertion {
+    public static final String TEXT =
+            "000200 IDENTIFICATION DIVISION.\n"
+                    + "000300 PROGRAM-ID.    TEST12.\n"
+                    + "006700 ENVIRONMENT  DIVISION.\n"
+                    + "006800 IDMS-CONTROL SECTION.\n"
+                    + "006900 PROTOCOL.    MODE IS IDMS-DC-NONAUTO DEBUG\n"
+                    + "007000              IDMS-RECORDS MANUAL.\n"
+                    + "007100 CONFIGURATION    SECTION.\n"
+                    + "007200 OBJECT-COMPUTER. IBM-370.\n"
+                    + "007300 DATA   DIVISION.\n"
+                    + "007400 WORKING-STORAGE SECTION.\n"
+                    + "007500 01  {$*WS-AREA}.\n"
+                    + "053500     03 {$*AREA-XWE}.                                                \n"
+                    + "053600       05 COPY MAID {~TESTCPY!DaCo} KMK.                                \n"
+                    + "055300 01  COPY IDMS {~SUBSCHEMA-NAMES!IDMS}.";
+
+    public static final String COPYBOOK_CONTENT =
+            "     1 01  {$*TEST-X`TEST-XWE}.          \n"
+                    + "     2     03 {$*TEST1-X`TEST1-XWE}                 PIC X(4)    VALUE SPACE.";
+
+    private static final String SUBSCHEMA_NAMES =
+            "      *   * This copybook remains empty,\n"
+                    + "      *   * because the content is of no interest while editing COBOL\n"
+                    + "       01  FILLER                      PIC X(0).\n";
+
+    @Test
+    void test() {
+        UseCaseEngine.runTest(
+                TEXT,
+                ImmutableList.of(
+                        new CobolText("TESTCPY", DaCoDialect.NAME, COPYBOOK_CONTENT),
+                        new CobolText("SUBSCHEMA-NAMES", IdmsDialect.NAME, SUBSCHEMA_NAMES, "url", true)),
+                ImmutableMap.of(),
+                ImmutableList.of(),
+                DialectConfigs.getDaCoAnalysisConfig());
+    }
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/processors/SectionNodeProcessorHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/processors/SectionNodeProcessorHelper.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
@@ -41,6 +40,9 @@ import org.eclipse.lsp.cobol.common.model.tree.CopyNode;
 import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp.cobol.common.model.tree.variable.*;
 import org.eclipse.lsp.cobol.common.model.tree.variables.*;
+import org.eclipse.lsp.cobol.common.utils.RangeUtils;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 
 /** The utility class is for converting VariableDefinitionNode into appropriate VariableNode. */
 @UtilityClass
@@ -104,14 +106,14 @@ public class SectionNodeProcessorHelper {
    * @return a list of unwrapped variables
    */
   private List<VariableDefinitionNode> unwrapVariables(Node node) {
-    List<VariableDefinitionNode> variables = new ArrayList<>();
+    List<Node> variables = new ArrayList<>();
     List<CopyNode> copybooks = new LinkedList<>();
 
     node.getChildren()
         .forEach(
             c -> {
               if (c.getNodeType() == NodeType.VARIABLE_DEFINITION) {
-                variables.add((VariableDefinitionNode) c);
+                variables.add(c);
               }
               if (c.getNodeType() == NodeType.COPY) {
                 copybooks.add((CopyNode) c);
@@ -127,48 +129,77 @@ public class SectionNodeProcessorHelper {
             .map(CopyNode.class::cast)
             .collect(Collectors.toList());
 
-//   Below could be problematic if a copybook is referenced at multiple places in a cobol doc.
-//    As the uri of copybooks would match with all variable definition and would result in a wrong node tree structure.
-//
-//    allCopybooks.stream()
-//        .filter(c -> c.getUri() != null)
-//        .forEach(
-//            c ->
-//                new ArrayList<>(variables)
-//                    .stream()
-//                        .filter(Objects::nonNull)
-//                        .filter(v -> v.getLocality() != null)
-//                        .filter(v -> v.getLocality().getUri() != null)
-//                        .filter(v -> v.getLocality().getUri().equals(c.getUri()))
-//                        .forEach(
-//                            v -> {
-//                              variables.remove(v);
-//                              c.addChild(v);
-//                            }));
+    int index = 0;
+    for (CopyNode copyNode : allCopybooks) {
+      index = insertCopybook(variables, index, copyNode);
+    }
 
-    allCopybooks.forEach(
-        copyNode -> {
-          int copybookLine = copyNode.getLocality().getRange().getStart().getLine();
-          String uri = copyNode.getLocality().getUri();
-          AtomicInteger index = new AtomicInteger();
-          for (Node variable : variables) {
-            int variableLine = variable.getLocality().getRange().getStart().getLine();
-            if (variable.getLocality().getUri().equals(uri) && variableLine > copybookLine) {
-              break;
-            }
-            index.incrementAndGet();
-          }
+    return variables.stream()
+        .flatMap(
+            n -> {
+              if (n.getNodeType() == NodeType.COPY) {
+                return n.getDepthFirstStream();
+              }
+              return ImmutableList.of(n).stream();
+            })
+        .filter(hasType(NodeType.VARIABLE_DEFINITION))
+        .map(VariableDefinitionNode.class::cast)
+        .collect(Collectors.toList());
+  }
 
-          copyNode
-              .getDepthFirstStream()
-              .filter(hasType(NodeType.COPY))
-              .flatMap(Node::getDepthFirstStream)
-              .filter(hasType(NodeType.VARIABLE_DEFINITION))
-              .map(VariableDefinitionNode.class::cast)
-              .forEach(
-                  copyNodeVariable -> variables.add(index.getAndIncrement(), copyNodeVariable));
-        });
-    return variables;
+  private static int insertCopybook(List<Node> variables, int index, CopyNode copyNode) {
+    if (index > variables.size() - 1) {
+      variables.add(copyNode);
+      return index;
+    }
+    for (int i = index; i < variables.size(); i++) {
+      index++;
+      if (!canInsertCopyNodeAtIndex(copyNode, i, variables)) {
+        index = i;
+        break;
+      }
+    }
+
+    // append at last
+    if (index >= variables.size()) {
+      variables.add(copyNode);
+      return variables.indexOf(copyNode);
+    }
+
+    variables.add(index, copyNode);
+    if (adjustCopyNodeChild(copyNode, variables, index + 1)) {
+      return variables.indexOf(copyNode) + 1;
+    }
+    return index;
+  }
+
+  private static boolean adjustCopyNodeChild(CopyNode copyNode, List<Node> variables, int index) {
+    boolean areNodesAdjusted = false;
+    ArrayList<Node> nodes = new ArrayList<>(variables);
+    for (int i = index; i < nodes.size(); i++) {
+      Node variable = nodes.get(i);
+      String variableNodeUri = variable.getLocality().getUri();
+      String copybookNodeUri = copyNode.getUri();
+      if (variableNodeUri.equals(copybookNodeUri)) {
+        copyNode.addChild(variable);
+        variables.remove(variable);
+        areNodesAdjusted = true;
+      } else {
+        break;
+      }
+    }
+    return areNodesAdjusted;
+  }
+
+  private static boolean canInsertCopyNodeAtIndex(
+      CopyNode copyNode, int index, List<Node> variables) {
+    String copybookLocalityUri = copyNode.getLocality().getUri();
+    Range copybookLocalityRange = copyNode.getLocality().getRange();
+    Node variableDefinitionNode = variables.get(index);
+    String variableUri = variableDefinitionNode.getLocality().getUri();
+    Position variableStartPosition = variableDefinitionNode.getLocality().getRange().getEnd();
+    return variableUri.equals(copybookLocalityUri)
+        && RangeUtils.isBefore(variableStartPosition, copybookLocalityRange.getStart());
   }
 
   /**


### PR DESCRIPTION
fix right insertion of dialect copy node. Dialect which insert copy node when followed by other copy node from dialect should be placed at right location. This was introduced by commit 53c16faac605cc46c151ec1c1a6c572dd408b630 , where RootNodeUpdateCopyNodesByPositionInTree step in TransformTreeStage pipleline step was moved from USAGE to TRANSFORMATION

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] No regression. Please check the added use-case tests , which fails in current development branch.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
