### PR TITLE
fix: do not invalidate implicit copybook cache on re-analysis

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/copybook/CopybookService.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/copybook/CopybookService.java
@@ -15,10 +15,7 @@
 package org.eclipse.lsp.cobol.common.copybook;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Set;
-
-import com.google.common.collect.ImmutableSet;
 import lombok.NonNull;
 import org.eclipse.lsp.cobol.common.CleanerPreprocessor;
 import org.eclipse.lsp.cobol.common.ResultWithErrors;
@@ -30,7 +27,7 @@ import org.eclipse.lsp.cobol.common.ResultWithErrors;
 public interface CopybookService {
   String FILE_BASENAME_VARIABLE = "${fileBasenameNoExtension}";
   /** Remove all the stored copybook. */
-  void invalidateCache();
+  void invalidateCache(boolean onlyNonImplicit);
 
   void invalidateCache(CopybookId copybookId);
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/GrammarPreprocessorImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/GrammarPreprocessorImpl.java
@@ -15,6 +15,8 @@
 package org.eclipse.lsp.cobol.core.preprocessor.delegates;
 
 import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.NonNull;
 import org.antlr.v4.runtime.BufferedTokenStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -33,9 +35,6 @@ import org.eclipse.lsp.cobol.core.preprocessor.delegates.copybooks.*;
 import org.eclipse.lsp.cobol.core.preprocessor.delegates.replacement.ReplacePreProcessorListener;
 import org.eclipse.lsp.cobol.core.preprocessor.delegates.replacement.ReplacePreprocessorFactory;
 import org.eclipse.lsp.cobol.core.semantics.CopybooksRepository;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This class runs pre-processing for COBOL using CobolPreprocessor.g4 grammar file. As a result, it
@@ -84,6 +83,7 @@ public class GrammarPreprocessorImpl implements GrammarPreprocessor {
 
     GrammarPreprocessorListener<CopybooksRepository> listener = listenerFactory.create(context, preprocessor);
 
+    ThreadInterruptionUtil.checkThreadInterrupted();
     CobolPreprocessor parser = new CobolPreprocessor(tokens);
     parser.removeErrorListeners();
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/copybooks/GrammarPreprocessorListenerImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/copybooks/GrammarPreprocessorListenerImpl.java
@@ -32,6 +32,7 @@ import org.eclipse.lsp.cobol.common.error.ErrorSource;
 import org.eclipse.lsp.cobol.common.error.SyntaxError;
 import org.eclipse.lsp.cobol.common.message.MessageService;
 import org.eclipse.lsp.cobol.common.model.Locality;
+import org.eclipse.lsp.cobol.common.utils.ThreadInterruptionUtil;
 import org.eclipse.lsp.cobol.core.CobolPreprocessorBaseListener;
 import org.eclipse.lsp.cobol.core.preprocessor.delegates.GrammarPreprocessor;
 import org.eclipse.lsp.cobol.core.preprocessor.delegates.PreprocessorContext;
@@ -173,6 +174,12 @@ public class GrammarPreprocessorListenerImpl extends CobolPreprocessorBaseListen
       return true;
     }
     return false;
+  }
+
+  @Override
+  public void enterEveryRule(ParserRuleContext ctx) {
+    ThreadInterruptionUtil.checkThreadInterrupted();
+    super.enterEveryRule(ctx);
   }
 
   @Override

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/VisitorHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/VisitorHelper.java
@@ -14,7 +14,15 @@
  */
 package org.eclipse.lsp.cobol.core.visitor;
 
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.lsp.cobol.common.OutlineNodeNames.FILLER_NAME;
+import static org.eclipse.lsp.cobol.core.CobolDataDivisionParser.*;
+
 import com.google.common.collect.ImmutableList;
+import java.util.*;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
@@ -24,21 +32,12 @@ import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp.cobol.common.model.Locality;
 import org.eclipse.lsp.cobol.common.model.tree.Node;
-import org.eclipse.lsp.cobol.core.CobolDataDivisionParser;
-import org.eclipse.lsp.cobol.common.model.tree.variable.ValueInterval;
 import org.eclipse.lsp.cobol.common.model.tree.variable.UsageFormat;
+import org.eclipse.lsp.cobol.common.model.tree.variable.ValueInterval;
+import org.eclipse.lsp.cobol.core.CobolDataDivisionParser;
 import org.eclipse.lsp.cobol.core.CobolParser;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-
-import javax.annotation.Nonnull;
-import java.util.*;
-import java.util.function.Function;
-
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.toList;
-import static org.eclipse.lsp.cobol.core.CobolDataDivisionParser.*;
-import static org.eclipse.lsp.cobol.common.OutlineNodeNames.FILLER_NAME;
 
 /** Utility class for visitor and delegates classes with useful methods */
 @Slf4j
@@ -304,7 +303,7 @@ public class VisitorHelper {
    * specific exception
    */
   public static void checkInterruption() {
-    if (Thread.interrupted()) {
+    if (Thread.currentThread().isInterrupted()) {
       LOG.debug("Parsing interrupted by user");
       throw new ParseCancellationException("Parsing interrupted by user");
     }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/CICSVisitor.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/CICSVisitor.java
@@ -21,6 +21,10 @@ import static org.antlr.v4.runtime.Lexer.HIDDEN;
 
 import com.google.common.collect.ImmutableList;
 import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -48,6 +52,7 @@ import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp.cobol.common.model.tree.StopNode;
 import org.eclipse.lsp.cobol.common.model.tree.variable.QualifiedReferenceNode;
 import org.eclipse.lsp.cobol.common.model.tree.variable.VariableUsageNode;
+import org.eclipse.lsp.cobol.common.utils.ThreadInterruptionUtil;
 import org.eclipse.lsp.cobol.implicitDialects.cics.nodes.ExecCicsHandleNode;
 import org.eclipse.lsp.cobol.implicitDialects.cics.nodes.ExecCicsNode;
 import org.eclipse.lsp.cobol.implicitDialects.cics.nodes.ExecCicsReturnNode;
@@ -55,11 +60,6 @@ import org.eclipse.lsp.cobol.implicitDialects.cics.utility.VisitorUtility;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * This visitor analyzes the parser tree for CICS and returns its semantic context as a syntax tree
@@ -195,6 +195,7 @@ class CICSVisitor extends CICSParserBaseVisitor<List<Node>> {
 
   @Override
   public List<Node> visitChildren(RuleNode node) {
+    ThreadInterruptionUtil.checkThreadInterrupted();
     return super.visitChildren(node);
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/SourceUnitGraph.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/SourceUnitGraph.java
@@ -187,6 +187,10 @@ public class SourceUnitGraph implements AnalysisStateListener {
                 copyUri = copyUri.replace(" ", "%20");
                 return new URL(decodeUri).sameFile(new URL(copyUri));
               } catch (IOException e) {
+                if (ImplicitCodeUtils.isImplicit(copyUri)) {
+                  LOG.debug("{} is a implicit copybook", copyUri);
+                  return true;
+                }
                 LOG.error("IOException encountered while comparing paths {} and {}", copyUri, uri);
                 return false;
               }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
@@ -189,7 +189,7 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
       TimeUnit.MILLISECONDS.sleep(100);
     } while (analysisInProgress);
 
-    copybookService.invalidateCache();
+    copybookService.invalidateCache(true);
     subroutineService.invalidateCache();
     LOG.info("Cache invalidated");
     openDocuments

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/workspace/DidChangeConfigurationHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/workspace/DidChangeConfigurationHandler.java
@@ -20,6 +20,7 @@ import static org.eclipse.lsp.cobol.service.settings.SettingsParametersEnum.*;
 import com.google.inject.Inject;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.common.copybook.CopybookService;
 import org.eclipse.lsp.cobol.common.message.LocaleStore;
 import org.eclipse.lsp.cobol.common.message.MessageService;
 import org.eclipse.lsp.cobol.common.utils.LogLevelUtils;
@@ -46,6 +47,7 @@ public class DidChangeConfigurationHandler {
   private final MessageService messageService;
   private final AsyncAnalysisService asyncAnalysisService;
   private final CodeLayoutStore codeLayoutStore;
+  private final CopybookService copybookService;
 
   @Inject
   public DidChangeConfigurationHandler(DisposableLSPStateService disposableLSPStateService,
@@ -56,7 +58,8 @@ public class DidChangeConfigurationHandler {
                                        Keywords keywords,
                                        MessageService messageService,
                                        AsyncAnalysisService asyncAnalysisService,
-                                       CodeLayoutStore codeLayoutStore) {
+                                       CodeLayoutStore codeLayoutStore,
+                                       CopybookService copybookService) {
     this.disposableLSPStateService = disposableLSPStateService;
     this.settingsService = settingsService;
     this.copybookNameService = copybookNameService;
@@ -66,6 +69,7 @@ public class DidChangeConfigurationHandler {
     this.messageService = messageService;
     this.asyncAnalysisService = asyncAnalysisService;
     this.codeLayoutStore = codeLayoutStore;
+    this.copybookService = copybookService;
   }
 
   /**
@@ -76,7 +80,7 @@ public class DidChangeConfigurationHandler {
     if (disposableLSPStateService.isServerShutdown()) {
       return;
     }
-
+    copybookService.invalidateCache(false);
     messageService.reloadMessages();
     copybookNameService
         .copybookLocalFolders(null)

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookCache.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookCache.java
@@ -22,8 +22,10 @@ import com.google.inject.name.Named;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.eclipse.lsp.cobol.common.copybook.CopybookId;
 import org.eclipse.lsp.cobol.common.copybook.CopybookModel;
+import org.eclipse.lsp.cobol.common.utils.ImplicitCodeUtils;
 
 /**
  * Implements copybook cache functionality
@@ -50,6 +52,15 @@ public class CopybookCache {
    */
   public void invalidateAll() {
     cache.invalidateAll();
+  }
+
+  /** Invalidates only non-implicit copybook cache */
+  public void invalidateAllNonImplicit() {
+    cache.invalidateAll(
+        cache.asMap().entrySet().stream()
+             .filter(entry -> entry.getValue().getUri() != null)
+            .filter(entry -> !ImplicitCodeUtils.isImplicit(entry.getValue().getUri()))
+            .collect(Collectors.toList()));
   }
 
   /**

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisServiceTest.java
@@ -67,7 +67,7 @@ class AsyncAnalysisServiceTest {
             throw new RuntimeException(e);
         }
 
-        verify(copybookService, times(1)).invalidateCache();
+        verify(copybookService, times(1)).invalidateCache(true);
         verify(subroutineService, times(1)).invalidateCache();
     }
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/handlers/workspace/DidChangeConfigurationHandlerTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/handlers/workspace/DidChangeConfigurationHandlerTest.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonPrimitive;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-
+import org.eclipse.lsp.cobol.common.copybook.CopybookService;
 import org.eclipse.lsp.cobol.common.dialects.CobolLanguageId;
 import org.eclipse.lsp.cobol.common.message.LocaleStore;
 import org.eclipse.lsp.cobol.common.message.MessageService;
@@ -55,6 +55,7 @@ class DidChangeConfigurationHandlerTest {
         DisposableLSPStateService stateService = new CobolLSPServerStateService();
         SettingsService settingsService = mock(SettingsService.class);
         WatcherService watchingService = mock(WatcherService.class);
+        CopybookService copybookService = mock(CopybookService.class);
         LocaleStore localeStore = mock(LocaleStore.class);
         CopybookNameService copybookNameService = mock(CopybookNameService.class);
         Keywords keywords = mock(Keywords.class);
@@ -70,7 +71,7 @@ class DidChangeConfigurationHandlerTest {
                         localeStore,
                         keywords,
                         messageService,
-                        asyncAnalysisService, getMockLayoutStore());
+                        asyncAnalysisService, getMockLayoutStore(), copybookService);
 
 
         when(copybookNameService.copybookLocalFolders(null))
@@ -101,6 +102,7 @@ class DidChangeConfigurationHandlerTest {
         Keywords keywords = mock(Keywords.class);
         MessageService messageService = mock(MessageService.class);
         AsyncAnalysisService asyncAnalysisService = mock(AsyncAnalysisService.class);
+        CopybookService copybookService = mock(CopybookService.class);
 
         DidChangeConfigurationHandler didChangeConfigurationHandler =
                 new DidChangeConfigurationHandler(
@@ -112,7 +114,8 @@ class DidChangeConfigurationHandlerTest {
                         keywords,
                         messageService,
                         asyncAnalysisService,
-                        getMockLayoutStore());
+                        getMockLayoutStore(),
+                        copybookService);
 
         String path = "foo/bar";
 
@@ -145,6 +148,7 @@ class DidChangeConfigurationHandlerTest {
         Keywords keywords = mock(Keywords.class);
         MessageService messageService = mock(MessageService.class);
         AsyncAnalysisService asyncAnalysisService = mock(AsyncAnalysisService.class);
+        CopybookService copybookService = mock(CopybookService.class);
 
         DidChangeConfigurationHandler didChangeConfigurationHandler =
                 new DidChangeConfigurationHandler(
@@ -156,7 +160,7 @@ class DidChangeConfigurationHandlerTest {
                         keywords,
                         messageService,
                         asyncAnalysisService,
-                        getMockLayoutStore());
+                        getMockLayoutStore(), copybookService);
 
         ArgumentCaptor<List<String>> watcherCaptor = forClass(List.class);
         String path = "foo/bar";
@@ -193,6 +197,7 @@ class DidChangeConfigurationHandlerTest {
         Keywords keywords = mock(Keywords.class);
         MessageService messageService = mock(MessageService.class);
         AsyncAnalysisService asyncAnalysisService = mock(AsyncAnalysisService.class);
+        CopybookService copybookService = mock(CopybookService.class);
 
         DidChangeConfigurationHandler didChangeConfigurationHandler =
                 new DidChangeConfigurationHandler(
@@ -204,7 +209,8 @@ class DidChangeConfigurationHandlerTest {
                         keywords,
                         messageService,
                         asyncAnalysisService,
-                        getMockLayoutStore());
+                        getMockLayoutStore(),
+                        copybookService);
         ArgumentCaptor<List<String>> watcherCaptor = forClass(List.class);
         JsonArray arr = new JsonArray();
         String path = "foo/bar";

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/WorkspaceServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/WorkspaceServiceTest.java
@@ -80,7 +80,7 @@ class WorkspaceServiceTest {
             null,
             null,
             messageService,
-            asyncAnalysisService, getMockLayoutStore());
+            asyncAnalysisService, getMockLayoutStore(), copybookService);
     ExecuteCommandHandler executeCommandHandler = new ExecuteCommandHandler(stateService, asyncAnalysisService);
 
     LspMessageBroker lspMessageBroker = new LspMessageBroker();
@@ -116,6 +116,7 @@ class WorkspaceServiceTest {
   void testExecuteNonExistingCommand() throws InterruptedException {
     CopybookNameService copybookNameService = mock(CopybookNameService.class);
     AsyncAnalysisService asyncAnalysisService = mock(AsyncAnalysisService.class);
+    CopybookService copybookService = mock(CopybookService.class);
 
     DidChangeConfigurationHandler didChangeConfigurationHandler = new DidChangeConfigurationHandler(stateService,
             null,
@@ -124,7 +125,7 @@ class WorkspaceServiceTest {
             null,
             null,
             null,
-            asyncAnalysisService, getMockLayoutStore());
+            asyncAnalysisService, getMockLayoutStore(), copybookService);
     ExecuteCommandHandler executeCommandHandler = new ExecuteCommandHandler(stateService, asyncAnalysisService);
 
     LspMessageBroker lspMessageBroker = new LspMessageBroker();
@@ -227,7 +228,7 @@ class WorkspaceServiceTest {
 
     DidChangeConfigurationHandler didChangeConfigurationHandler =
         new DidChangeConfigurationHandler(
-            stateService, null, copybookNameService, null, null, null, null, asyncAnalysisService, getMockLayoutStore());
+            stateService, null, copybookNameService, null, null, null, null, asyncAnalysisService, getMockLayoutStore(), copybookService);
 
     ExecuteCommandHandler executeCommandHandler =
         new ExecuteCommandHandler(stateService, asyncAnalysisService);


### PR DESCRIPTION
Do not invalidate implicit copybook cache on re-analysis. But these needs to be invalidated if configuration changes happen. Also, when a dialec is registered

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] No regressions should be introduced.
- [ ] Some times if a cobol program has a lot of remote copybooks, diagnostics for a missing implicit copybooks are shown. Which clears upon re analysis. These diagnostics should not appear. 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
