### PR TITLE
fix copybook resolving method when zowe is selected on e4e element

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -12,7 +12,11 @@
  *   Broadcom, Inc. - initial API and implementation
  */
 
-import { DEFAULT_DIALECT, PROVIDE_PROFILE_MSG } from "../../../constants";
+import {
+  DEFAULT_DIALECT,
+  ENDEVOR_PROCESSOR,
+  PROVIDE_PROFILE_MSG,
+} from "../../../constants";
 import { CopybookDownloadService } from "../../../services/copybook/CopybookDownloadService";
 import { ProfileUtils } from "../../../services/util/ProfileUtils";
 import { Utils } from "../../../services/util/Utils";
@@ -293,9 +297,9 @@ describe("Tests copybook download service", () => {
     (downloader as any).ussDownloader.downloadCopybook = jest
       .fn()
       .mockReturnValue(false);
-    (downloader as any).handleAsEndevorElement = jest
+    SettingsService.getCopybookEndevorDependencySettings = jest
       .fn()
-      .mockReturnValue(true);
+      .mockReturnValue(ENDEVOR_PROCESSOR);
     await downloader.downloadCopybook(
       { name: "copybook", dialect: "COBOL" },
       "document-uri",

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -293,6 +293,9 @@ describe("Tests copybook download service", () => {
     (downloader as any).ussDownloader.downloadCopybook = jest
       .fn()
       .mockReturnValue(false);
+    (downloader as any).handleAsEndevorElement = jest
+      .fn()
+      .mockReturnValue(true);
     await downloader.downloadCopybook(
       { name: "copybook", dialect: "COBOL" },
       "document-uri",

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -54,7 +54,8 @@ export class CopybookDownloadService {
     documentUri: string,
   ): Promise<boolean> {
     if (
-      await this.e4eDownloader?.downloadCopybookE4E(documentUri, copybookName)
+      this.handleAsEndevorElement(documentUri) &&
+      (await this.e4eDownloader?.downloadCopybookE4E(documentUri, copybookName))
     ) {
       return true;
     }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForE4E.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForE4E.ts
@@ -29,6 +29,7 @@ import { CopybookURI } from "../CopybookURI";
 import {
   DATASET,
   E4E_FOLDER,
+  ENDEVOR_PROCESSOR,
   ENVIRONMENT,
   OUTPUT_MSG_SEARCH_LOCATION,
   USE_MAP,
@@ -36,6 +37,7 @@ import {
 import { CopybookName } from "../CopybookDownloadService";
 import { Utils } from "../../util/Utils";
 import { searchCopybookInExtensionFolder } from "../../util/FSUtils";
+import { SettingsService } from "../../Settings";
 
 const defaultConfigs: ExternalConfigurationOptions = {
   compiler: "IGYCRCTL",
@@ -110,7 +112,12 @@ export class CopybookDownloaderForE4E {
     if (config) {
       return config;
     }
-    if (!this.e4e.isEndevorElement(uri)) return undefined;
+    if (
+      !this.e4e.isEndevorElement(uri) &&
+      SettingsService.getCopybookEndevorDependencySettings() !=
+        ENDEVOR_PROCESSOR
+    )
+      return undefined;
 
     const response = this.getE4EConfigImpl(uri).catch((err) => {
       this.E4EConfigs.delete(uri);

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForE4E.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForE4E.ts
@@ -29,7 +29,6 @@ import { CopybookURI } from "../CopybookURI";
 import {
   DATASET,
   E4E_FOLDER,
-  ENDEVOR_PROCESSOR,
   ENVIRONMENT,
   OUTPUT_MSG_SEARCH_LOCATION,
   USE_MAP,
@@ -37,7 +36,6 @@ import {
 import { CopybookName } from "../CopybookDownloadService";
 import { Utils } from "../../util/Utils";
 import { searchCopybookInExtensionFolder } from "../../util/FSUtils";
-import { SettingsService } from "../../Settings";
 
 const defaultConfigs: ExternalConfigurationOptions = {
   compiler: "IGYCRCTL",
@@ -112,12 +110,7 @@ export class CopybookDownloaderForE4E {
     if (config) {
       return config;
     }
-    if (
-      !this.e4e.isEndevorElement(uri) &&
-      SettingsService.getCopybookEndevorDependencySettings() !=
-        ENDEVOR_PROCESSOR
-    )
-      return undefined;
+    if (!this.e4e.isEndevorElement(uri)) return undefined;
 
     const response = this.getE4EConfigImpl(uri).catch((err) => {
       this.E4EConfigs.delete(uri);


### PR DESCRIPTION
## How Has This Been Tested?

Select Zowe for Endevor dependecies. open E4E element check Copybooks fetched from Zowe

## Checklist:
- [x] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
