### PR TITLE
fix: add language element to the cli analysis response in case of crash

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
@@ -18,7 +18,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-
 import java.io.File;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
@@ -29,7 +28,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
-
 import org.eclipse.lsp.cobol.cli.di.CliModule;
 import org.eclipse.lsp.cobol.cli.modules.CliClientProvider;
 import org.eclipse.lsp.cobol.common.dialects.CobolLanguageId;
@@ -70,6 +68,7 @@ public class CliAnalysis implements Callable<Integer> {
         cliClientProvider.setCpyExt(createCopybooksExtensions());
         JsonObject result = new JsonObject();
         result.addProperty("uri", src.toURI().toString());
+        result.addProperty("language", dialect.getId());
         try {
             Cli.Result analysisResult = parent.runAnalysis(src, dialect, diCtx, true);
             parent.addTiming(result, analysisResult.ctx.getBenchmarkSession());
@@ -83,7 +82,6 @@ public class CliAnalysis implements Callable<Integer> {
                                 diagnostics.add(diagnostic);
                             });
             result.add("diagnostics", diagnostics);
-            result.addProperty("language", analysisResult.ctx.getLanguageId().getId());
             result.addProperty("lines", String.valueOf(analysisResult.ctx.getExtendedDocument().toString().split("\n").length));
             result.addProperty("size", String.valueOf(analysisResult.ctx.getExtendedDocument().toString().length()));
             collectGcAndMemoryStats(result);


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] cli response in case of crash includes language parameter
> > When the crash entry is written the details about the language id (cobol vs expcobol) are not captured.
> > ```
> > file:/test-source/COBOL85/COBPGM/negative/NC1074.2.cbl,2024-06-28 17:42:04.938657,,,,0,"Cannot invoke ""org.antlr.v4.runtime.Token.getLine()"" because ""end"" is null"
> > ```
> 



## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
