### PR TITLE
feat: Cli analysis improvements

### DIFF
--- a/clients/cobol-lsp-vscode-extension/.vscode/settings.json
+++ b/clients/cobol-lsp-vscode-extension/.vscode/settings.json
@@ -29,5 +29,8 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "typescript.tsdk": "./node_modules/typescript/lib"
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "files.readonlyInclude": {
+    "{**/.c4z/.extsrcs/*.PROTSYM.cbl,**/.c4z/.extsrcs/*.PROTSYM.listing}": true
+  }
 }

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/RunAnalysisCLITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/RunAnalysisCLITest.spec.ts
@@ -108,7 +108,10 @@ describe("Test Analysis CLI command functionality", () => {
       context.globalStorageUri,
       context.extensionUri,
     );
-    vscode.window.showQuickPick = jest.fn().mockReturnValue("Java");
+    vscode.window.showQuickPick = jest
+      .fn()
+      .mockReturnValueOnce("Java")
+      .mockReturnValue("Show");
 
     const runCobolAnalysisCommandSpy = jest.spyOn(
       testAnalysis as any,
@@ -136,7 +139,7 @@ describe("Test Analysis CLI command functionality", () => {
 
     expect(runCobolAnalysisCommandSpy).toHaveBeenCalled();
     expect(getCurrentFileLocationSpy).toHaveBeenCalled();
-    expect(buildJavaCommandSpy).toHaveBeenCalledWith("/storagePath");
+    expect(buildJavaCommandSpy).toHaveBeenCalledWith("/storagePath", true);
     expect(buildJavaCommandSpy).toHaveReturnedWith(
       'java -jar "/test/server/jar/server.jar" analysis -s "/storagePath" -cf=.',
     );
@@ -153,7 +156,10 @@ describe("Test Analysis CLI command functionality", () => {
       context.globalStorageUri,
       context.extensionUri,
     );
-    vscode.window.showQuickPick = jest.fn().mockReturnValue("Native");
+    vscode.window.showQuickPick = jest
+      .fn()
+      .mockReturnValueOnce("Native")
+      .mockReturnValue("Show");
 
     const runCobolAnalysisCommandSpy = jest.spyOn(
       testAnalysis as any,
@@ -184,6 +190,7 @@ describe("Test Analysis CLI command functionality", () => {
     expect(buildNativeCommandSpy).toHaveBeenCalledWith(
       "/storagePath",
       process.platform,
+      true,
     );
     expect(buildAnalysisCommandPortionSpy).toHaveReturnedWith(
       'analysis -s "/storagePath" -cf=.',

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/Cli.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/Cli.java
@@ -58,6 +58,9 @@ import static org.eclipse.lsp.cobol.cli.command.CliUtils.setupPipeline;
     })
 @Slf4j
 public class Cli implements Callable<Integer> {
+  static final int SUCCESS = 0;
+  static final int FAILURE = 1;
+
   ProcessorGroupsResolver processorGroupsResolver;
 
   /**
@@ -68,7 +71,7 @@ public class Cli implements Callable<Integer> {
    */
   @Override
   public Integer call() throws Exception {
-    return 0;
+    return SUCCESS;
   }
 
   Result runAnalysis(File src, CobolLanguageId dialect, Injector diCtx, boolean isAnalysisRequired) throws IOException {
@@ -111,7 +114,7 @@ public class Cli implements Callable<Integer> {
         processorGroupsResolver = new ProcessorGroupsResolver(new String(Files.readAllBytes(programConfig)), new String(Files.readAllBytes(groupsConfig)));
       } catch (IOException e) {
         LOG.error("Processor group configuration read error", e);
-        throw new IOException(e.getMessage());
+        throw e;
       }
     } else {
       LOG.warn("Processor group configuration is missing");

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/Cli.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/Cli.java
@@ -18,6 +18,7 @@ import com.google.gson.*;
 import com.google.inject.Injector;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -93,7 +94,7 @@ public class Cli implements Callable<Integer> {
     }
   }
 
-  void initProcessorGroupsReader(Path workspace) {
+  void initProcessorGroupsReader(Path workspace) throws IOException {
     if (workspace == null) {
       return;
     }
@@ -104,9 +105,11 @@ public class Cli implements Callable<Integer> {
         processorGroupsResolver = new ProcessorGroupsResolver(new String(Files.readAllBytes(programConfig)), new String(Files.readAllBytes(groupsConfig)));
       } catch (IOException e) {
         LOG.error("Processor group configuration read error", e);
+        throw new IOException(e.getMessage());
       }
     } else {
       LOG.warn("Processor group configuration is missing");
+      throw new FileNotFoundException("Processor group configuration is missing");
     }
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
@@ -47,8 +47,8 @@ public class CliAnalysis implements Callable<Integer> {
             description = "The COBOL program file.")
     private File src;
 
-    @CommandLine.ArgGroup(multiplicity = "1")
-    private Args args;
+    @CommandLine.ArgGroup(multiplicity = "0..1")
+    private Args args = new Args();
 
     @CommandLine.Option(
             description = "Supported dialect values: ${COMPLETION-CANDIDATES}",
@@ -159,7 +159,7 @@ public class CliAnalysis implements Callable<Integer> {
      */
     static class Args {
         @CommandLine.ArgGroup(exclusive = false)
-        ExplicitConfig explicitConfig;
+        ExplicitConfig explicitConfig = new ExplicitConfig();
 
         @CommandLine.ArgGroup(exclusive = false)
         WorkspaceConfig workspaceConfig;

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
@@ -79,7 +79,7 @@ public class CliAnalysis implements Callable<Integer> {
             try {
                 parent.initProcessorGroupsReader(args.workspaceConfig.workspace);
             } catch (Exception e) {
-                return 2;
+                return Cli.FAILURE;
             }
         }
 
@@ -105,11 +105,11 @@ public class CliAnalysis implements Callable<Integer> {
             System.out.println(CliUtils.GSON.toJson(result));
 
             handleExtendedSource(analysisResult);
-            return 0;
+            return Cli.SUCCESS;
         } catch (Exception e) {
             result.addProperty("crash", e.getMessage() != null && e.getMessage().isEmpty() ? "error" : e.getMessage());
             System.out.println(CliUtils.GSON.toJson(result));
-            return 1;
+            return Cli.FAILURE;
         }
     }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
@@ -58,8 +58,14 @@ public class CliAnalysis implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        if (args.workspaceConfig != null)
-            parent.initProcessorGroupsReader(args.workspaceConfig.workspace);
+        if (args.workspaceConfig != null) {
+            try {
+                parent.initProcessorGroupsReader(args.workspaceConfig.workspace);
+            } catch (Exception e) {
+                return 2;
+            }
+        }
+
 
         Injector diCtx = Guice.createInjector(new CliModule());
         CliClientProvider cliClientProvider = diCtx.getInstance(CliClientProvider.class);

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
@@ -99,18 +99,7 @@ public class CliAnalysis implements Callable<Integer> {
             Cli.Result analysisResult = parent.runAnalysis(inputConfig.src, dialect, diCtx, true);
             parent.addTiming(result, analysisResult.ctx.getBenchmarkSession());
             if (!hideDiagnostics) {
-                JsonArray diagnostics = new JsonArray();
-                analysisResult
-                        .ctx
-                        .getAccumulatedErrors()
-                        .forEach(
-                                err -> {
-                                    JsonObject diagnostic = CliUtils.diagnosticToJson(err);
-                                    diagnostics.add(diagnostic);
-                                });
-                result.add("diagnostics", diagnostics);
-                result.addProperty("lines", String.valueOf(analysisResult.ctx.getExtendedDocument().toString().split("\n").length));
-                result.addProperty("size", String.valueOf(analysisResult.ctx.getExtendedDocument().toString().length()));
+                generateDiagnostics(analysisResult, result);
             }
             collectGcAndMemoryStats(result);
             System.out.println(CliUtils.GSON.toJson(result));
@@ -122,6 +111,21 @@ public class CliAnalysis implements Callable<Integer> {
             System.out.println(CliUtils.GSON.toJson(result));
             return 1;
         }
+    }
+
+    private void generateDiagnostics(Cli.Result analysisResult, JsonObject result) {
+        JsonArray diagnostics = new JsonArray();
+        analysisResult
+                .ctx
+                .getAccumulatedErrors()
+                .forEach(
+                        err -> {
+                            JsonObject diagnostic = CliUtils.diagnosticToJson(err);
+                            diagnostics.add(diagnostic);
+                        });
+        result.add("diagnostics", diagnostics);
+        result.addProperty("lines", String.valueOf(analysisResult.ctx.getExtendedDocument().toString().split("\n").length));
+        result.addProperty("size", String.valueOf(analysisResult.ctx.getExtendedDocument().toString().length()));
     }
 
     private void collectGcAndMemoryStats(JsonObject result) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
@@ -47,7 +47,7 @@ public class CliAnalysis implements Callable<Integer> {
             description = "The COBOL program file.")
     private File src;
 
-    @CommandLine.ArgGroup(multiplicity = "0..1")
+    @CommandLine.ArgGroup()
     private Args args = new Args();
 
     @CommandLine.Option(
@@ -58,9 +58,15 @@ public class CliAnalysis implements Callable<Integer> {
 
     @CommandLine.Option(
             description = "Hide diagnostics",
-            names = {"-nd", "--no-diag", "--no-diagnostics", "--no-diagnostic"}
+            names = {"-nd", "--no-diag", "--no-diagnostic", "--no-diagnostics"}
     )
     private boolean hideDiagnostics;
+
+    @CommandLine.Option(
+            description = "Produce extended source",
+            names = {"-es", "-ex", "--extended-source"}
+    )
+    private boolean produceExtendedSource;
 
     @Override
     public Integer call() throws Exception {
@@ -100,6 +106,12 @@ public class CliAnalysis implements Callable<Integer> {
             }
             collectGcAndMemoryStats(result);
             System.out.println(CliUtils.GSON.toJson(result));
+
+            if (produceExtendedSource) {
+                System.out.println("------------ Extended Source Begins Below -----------");
+                String formattedExtendedDoc = "       " + analysisResult.ctx.getExtendedDocument().toString().trim(); // Trim removes the necessary spaces prior to the first line of COBOL code thus it must be put back in.
+                System.out.println(formattedExtendedDoc);
+            }
             return 0;
         } catch (Exception e) {
             result.addProperty("crash", e.getMessage() != null && e.getMessage().isEmpty() ? "error" : e.getMessage());

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
@@ -55,7 +55,7 @@ public class CliAnalysis implements Callable<Integer> {
             names = {"-d", "--dialect"},
             defaultValue = "COBOL")
     private CobolLanguageId dialect;
-    
+
     @CommandLine.Option(
             description = "Hide diagnostics",
             names = {"-nd", "--no-diag", "--no-diagnostics", "--no-diagnostic"}
@@ -122,9 +122,9 @@ public class CliAnalysis implements Callable<Integer> {
                 garbageCollectionTime += time;
             }
         }
-        result.addProperty("gc.count", totalGarbageCollections);
+        result.addProperty("Garbage Collection Count", totalGarbageCollections);
         // milliseconds to seconds
-        result.addProperty("gc.time", garbageCollectionTime * 0.001);
+        result.addProperty("Garbage Collection Time", garbageCollectionTime * 0.001);
 
         List<MemoryPoolMXBean> pools = ManagementFactory.getMemoryPoolMXBeans();
         long total = 0;
@@ -134,7 +134,7 @@ public class CliAnalysis implements Callable<Integer> {
                 total = total + peakUsed;
             }
         }
-        result.addProperty("memory.heap_peak", total / 1024 / 1024);
+        result.addProperty("Peak Heap Memory", total / 1024 / 1024);
     }
 
     /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliCFAST.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliCFAST.java
@@ -69,10 +69,10 @@ public class CliCFAST  implements Callable<Integer> {
       }
     } catch (Exception e) {
       System.out.println("Failed to generate CFAST: " + e.getMessage());
-      return 1;
+      return Cli.FAILURE;
     }
 
-    return 0;
+    return Cli.SUCCESS;
   }
 
   private void generateCFAST(File file, CFASTBuilder builder, Gson gson, Injector diCtx) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListCopybooks.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListCopybooks.java
@@ -96,7 +96,7 @@ public class ListCopybooks implements Callable<Integer> {
       try {
         parent.initProcessorGroupsReader(args.workspaceConfig.workspace);
       } catch (Exception e) {
-        return 2;
+        return Cli.FAILURE;
       }
     }
     Injector diCtx = Guice.createInjector(new CliModule());
@@ -123,7 +123,7 @@ public class ListCopybooks implements Callable<Integer> {
     result.add("copybookUris", copybookUris);
     result.add("missingCopybooks", missingCopybooks);
     System.out.println(gson.toJson(result));
-    return 0;
+    return Cli.SUCCESS;
   }
 
   private List<File> createCopybooksPaths() {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListCopybooks.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListCopybooks.java
@@ -93,7 +93,11 @@ public class ListCopybooks implements Callable<Integer> {
   @Override
   public Integer call() throws Exception {
     if (args.workspaceConfig != null) {
-      parent.initProcessorGroupsReader(args.workspaceConfig.workspace);
+      try {
+        parent.initProcessorGroupsReader(args.workspaceConfig.workspace);
+      } catch (Exception e) {
+        return 2;
+      }
     }
     Injector diCtx = Guice.createInjector(new CliModule());
     CliClientProvider cliClientProvider = diCtx.getInstance(CliClientProvider.class);

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListSources.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListSources.java
@@ -53,7 +53,11 @@ public class ListSources implements Callable<Integer> {
    */
   public Integer call() throws Exception {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    parent.initProcessorGroupsReader(workspace);
+    try {
+      parent.initProcessorGroupsReader(workspace);
+    } catch (Exception e) {
+      return 2;
+    }
     JsonObject result = new JsonObject();
     JsonArray sources = new JsonArray();
     if (Objects.nonNull(workspace)) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListSources.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListSources.java
@@ -56,7 +56,7 @@ public class ListSources implements Callable<Integer> {
     try {
       parent.initProcessorGroupsReader(workspace);
     } catch (Exception e) {
-      return 2;
+      return Cli.FAILURE;
     }
     JsonObject result = new JsonObject();
     JsonArray sources = new JsonArray();
@@ -74,7 +74,7 @@ public class ListSources implements Callable<Integer> {
     }
     result.add("sources", sources);
     System.out.println(gson.toJson(result));
-    return 0;
+    return Cli.SUCCESS;
   }
 
   private boolean isSourceFile(Path f) {


### PR DESCRIPTION
## Added:

- Proper handling of error when processor groups does not exist
- Made the copybook path argument optional for the CLI
- Added a flag to suppress the diagnostics portion
- Updated labels to be clearer
- Added command to produce the extended source. (Can do so in the CLI or save it to a specified location)
- Accept source from STDIN

## How Has This Been Tested?

Tested the CLI locally as each change/feature was added.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
