### PR TITLE
fix: Add PARAGRAPH to autocomplete

### DIFF
--- a/server/engine/src/main/resources/LanguageKeywords.txt
+++ b/server/engine/src/main/resources/LanguageKeywords.txt
@@ -1543,6 +1543,7 @@ PAGE-INFO=
 PAGE=When PAGE is specified, the record is printed on the logical page BEFORE or AFTER (depending on the phrase used) the device is positioned to the next logical page.<br>[Read more](https://www.ibm.com/support/knowledgecenter/en/SS6SG3_6.2.0/com.ibm.cobol62.ent.doc/PGandLR/ref/rlpswrit.html)<br>\u00A9 Copyright IBM Corporation 1994, 2019.<br>U.S. Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 PAGENUM=
 PAGING=
+PARAGRAPH=
 PARALLEL=
 PARAMETER=
 PARMS=

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/delegates/completions/KeywordCompletionTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/delegates/completions/KeywordCompletionTest.java
@@ -96,7 +96,7 @@ class KeywordCompletionTest {
 
     Keywords keywords = new Keywords(mock(SettingsService.class), dialectService);
     List<String> dialectType = ImmutableList.of();
-    assertEquals(2350, keywords.getDataMap(dialectType).size());
+    assertEquals(2351, keywords.getDataMap(dialectType).size());
 
     dialectType = ImmutableList.of("IDMS");
     assertEquals(2351, keywords.getDataMap(dialectType).size());

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/delegates/completions/KeywordCompletionTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/delegates/completions/KeywordCompletionTest.java
@@ -99,13 +99,13 @@ class KeywordCompletionTest {
     assertEquals(2351, keywords.getDataMap(dialectType).size());
 
     dialectType = ImmutableList.of("IDMS");
-    assertEquals(2351, keywords.getDataMap(dialectType).size());
-
-    dialectType = ImmutableList.of("DaCo");
     assertEquals(2352, keywords.getDataMap(dialectType).size());
 
-    dialectType = ImmutableList.of("DaCo", "IDMS");
+    dialectType = ImmutableList.of("DaCo");
     assertEquals(2353, keywords.getDataMap(dialectType).size());
+
+    dialectType = ImmutableList.of("DaCo", "IDMS");
+    assertEquals(2354, keywords.getDataMap(dialectType).size());
   }
 
   @Test


### PR DESCRIPTION
The language keyword for PARAGRAPH was missing, causing it to not show in autocomplete. Added it to the list and now it works.

## How Has This Been Tested?

Before:
![Screenshot 2024-07-17 at 9 25 42 AM](https://github.com/user-attachments/assets/292e87a6-b694-40b0-ba7e-ebc716ddce0b)

After:
![Screenshot 2024-07-17 at 3 05 59 PM](https://github.com/user-attachments/assets/5bbb2e8b-eeef-494f-9fdb-dcc9ac8e2e80)

Tested by adding it to the list, compiling the extension and typing "PARA" in a cobol program within VS Code.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
