### PR TITLE
Disable hp analysis

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -131,17 +131,10 @@
       },
       {
         "id": "hpcobol",
-        "extensions": [
-          ".hpcbl",
-          ".hpcobol",
-          ".hp",
-          "ecobol"
-        ],
         "aliases": [
           "HP-COBOL"
         ],
-        "configuration": "./syntaxes/lang-config-hp.json",
-        "firstLine": "^[ ]( *([Ii][Dd]([Ee][Nn][Tt][Ii][Ff][Ii][Cc][Aa][Tt][Ii][Oo][Nn])? +[Dd][Ii][Vv][Ii][Ss][Ii][Oo][Nn][.].*?)$|^\\?.*"
+        "configuration": "./syntaxes/lang-config-hp.json"
       }
     ],
     "grammars": [

--- a/clients/cobol-lsp-vscode-extension/syntaxes/HP.COBOL.tmLanguage.json
+++ b/clients/cobol-lsp-vscode-extension/syntaxes/HP.COBOL.tmLanguage.json
@@ -82,7 +82,7 @@
       ]
     },
     "cobol-condition-keyword": {
-      "match": "(?<![\\-\\w])(?i:IF|ELSE|END-IF|EVALUATE|NOT|WHEN\\s+OTHER|WHEN|END-EVALUATE|CONTINUE)(?![\\-\\w])",
+      "match": "(?<![\\-\\w])(?i:IF|ELSE|END-IF|ENDIF|EVALUATE|NOT|WHEN\\s+OTHER|WHEN|END-EVALUATE|CONTINUE)(?![\\-\\w])",
       "name": "keyword.control.condition.cobol"
     },
     "cobol-branch-keyword": {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/CobolLanguageEngine.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/CobolLanguageEngine.java
@@ -140,7 +140,7 @@ public class CobolLanguageEngine {
   public AnalysisResult run(
           @NonNull String documentUri, @NonNull String text, @NonNull AnalysisConfig analysisConfig, CobolLanguageId languageId) {
     ThreadInterruptionUtil.checkThreadInterrupted();
-    if (isEmpty(text)) {
+    if (shouldNotAnalyse(text, languageId)) {
       return AnalysisResult.builder().build();
     }
 
@@ -189,6 +189,10 @@ public class CobolLanguageEngine {
                   .collect(toList())),
           documentUri);
     }
+  }
+
+  private static boolean shouldNotAnalyse(String text, CobolLanguageId languageId) {
+    return isEmpty(text) || languageId == CobolLanguageId.HP_COBOL;
   }
 
   /**

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/hpcobol/TestHPCobol.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/hpcobol/TestHPCobol.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.eclipse.lsp.cobol.common.dialects.CobolLanguageId;
 import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Sample test for HP Cobol language id. */
@@ -141,6 +142,7 @@ public class TestHPCobol {
           + "*                     E N D     O F     P R O G R A M                          *\n"
           + "********************************************************************************";
 
+  @Disabled("HP-COBOL analysis is disabled")
   @Test
   void test() {
     UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of(), CobolLanguageId.HP_COBOL);


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test ENDIF is colored in below code for HP-COBOL languageID
```cobol
*BLANK
?SAVE ALL
?SAVEABEND
?SYMBOLS
?HEADING "DUMMY MODULE TO SHOW USE of DOLLAR ZERO"

 IDENTIFICATION DIVISION.


    PROGRAM-ID.                  TESTAB.

/
 ENVIRONMENT DIVISION.
**********************

 CONFIGURATION SECTION.

 SOURCE-COMPUTER.                TANDEM.
 OBJECT-COMPUTER.                TANDEM.

?IF 1
 SPECIAL-NAMES.
     FIL COBOLLIB IS COBOLLIB
 .
?ENDIF 1  
``` 
- [x] Test no analysis/diagnostics are returned for HP-COBOL. Server side analysis for HP-COBOL is disabled
- [x] Test HP-COBOL file association for `.hpcbl, .hpcobol, .hp , ecobol` are no more available.
- [x] Test auto detection of HP-COBOL is removed

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
