### PR TITLE
fix: minor fixes for db2 host variable

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/db2/parser/Db2SqlParser.g4
@@ -43,9 +43,9 @@ result_set_locator_variable: dbs_level_01 entry_name host_variable_usage result_
 
 tableLocators_variable: dbs_host_var_levels entry_name host_variable_usage tableLocators;
 
-lob_xml_host_variables: dbs_host_var_levels entry_name  host_variable_usage (xml_as lobWithSize | xml_as lobNoSize);
+lob_xml_host_variables: dbs_host_var_levels entry_name  host_variable_usage xml_as (lobWithSize | xml_lobNO_size);
 
-lob_host_variables: dbs_host_var_levels entry_name host_variable_usage (lobWithSize | lobNoSize);
+lob_host_variables: dbs_integer entry_name host_variable_usage (lobWithSize | lobNoSize);
 
 dbs_host_var_levels: dbs_level_01 | T=dbs_integer {validateIntegerRange($T.text, 2, 48);};
 
@@ -57,8 +57,11 @@ lobWithSize
     : (BINARY LARGE OBJECT | BLOB | CHARACTER LARGE OBJECT | CHAR LARGE OBJECT | CLOB | DBCLOB) LPARENCHAR dbs_integer k_m_g? RPARENCHAR
     ;
 lobNoSize
-    : BLOB_LOCATOR | CLOB_LOCATOR | DBCLOB_LOCATOR | BLOB_FILE | CLOB_FILE | DBCLOB_FILE
+    : BLOB_LOCATOR | CLOB_LOCATOR | DBCLOB_LOCATOR |  xml_lobNO_size
     ;
+
+xml_lobNO_size: BLOB_FILE | CLOB_FILE | DBCLOB_FILE;
+
 xml_as: XML AS;
 
 entry_name : (FILLER |dbs_host_names);

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlVisitor.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlVisitor.java
@@ -102,7 +102,7 @@ class Db2SqlVisitor extends Db2SqlParserBaseVisitor<List<Node>> {
 
     @Override
     public List<Node> visitLob_host_variables(Db2SqlParser.Lob_host_variablesContext ctx) {
-        List<Node> hostVariableDefinitionNode = createHostVariableDefinitionNode(ctx, ctx.dbs_host_var_levels(), ctx.entry_name());
+        List<Node> hostVariableDefinitionNode = createHostVariableDefinitionNode(ctx, ctx.dbs_integer(), ctx.entry_name());
         if (ctx.lobWithSize() != null && ctx.lobWithSize().BINARY() != null) {
             generateVarbinVariables((VariableDefinitionNode) hostVariableDefinitionNode.get(0),
                     ctx.lobWithSize().dbs_integer().getText(), ctx);

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlHostVariable.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlHostVariable.java
@@ -123,7 +123,7 @@ public class TestSqlHostVariable {
                   + "        Data Division.\n"
                   + "         Working-Storage Section.\n"
                   + "       01 {$*GREET}.\n"
-                  + "          49 {$*VAR|1} USAGE IS SQL TYPE IS CHARACTER LARGE OBJECT (10 M).\n"
+                  + "          49 {$*VAR} USAGE IS SQL TYPE IS CHARACTER LARGE OBJECT (10 M).\n"
                   + "        PROCEDURE DIVISION.\n"
                   + "           DISPLAY {$VAR}.";
 
@@ -138,9 +138,6 @@ public class TestSqlHostVariable {
                   + "       01 {$*VAR-NAME4} USAGE IS SQL TYPE IS XML AS CHAR LARGE OBJECT (10 G).\n"
                   + "       01 {$*VAR-NAME5} USAGE IS SQL TYPE IS XML AS CLOB (20).\n"
                   + "       01 {$*VAR-NAME6} USAGE IS SQL TYPE IS XML AS DBCLOB (30 K).\n"
-                  + "       01 {$*VAR-NAME7} USAGE IS SQL TYPE IS XML AS BLOB-LOCATOR.\n"
-                  + "       01 {$*VAR-NAME8} USAGE IS SQL TYPE IS XML AS CLOB-LOCATOR.\n"
-                  + "       01 {$*VAR-NAME9} USAGE IS SQL TYPE IS XML AS DBCLOB-LOCATOR.\n"
                   + "       01 {$*VAR-NAME10} USAGE IS SQL TYPE IS XML AS  BLOB-FILE.\n"
                   + "       01 {$*VAR-NAME11} USAGE IS SQL TYPE IS XML AS  CLOB-FILE.\n"
                   + "       01 {$*VAR-NAME12} USAGE IS SQL TYPE IS XML AS  DBCLOB-FILE.\n"
@@ -272,15 +269,7 @@ public class TestSqlHostVariable {
 
   @Test
   void testLobVariables_levelError() {
-    UseCaseEngine.runTest(LOD_VARS_TEXT1, ImmutableList.of(), ImmutableMap.of(
-            "1",
-            new Diagnostic(
-                    new Range(),
-                    "Allowed range is 2 to 48",
-                    DiagnosticSeverity.Error,
-                    ErrorSource.PARSING.getText()
-            )
-    ));
+    UseCaseEngine.runTest(LOD_VARS_TEXT1, ImmutableList.of(), ImmutableMap.of());
   }
 
   @Test


### PR DESCRIPTION
This commit fixes below minor issues for db2 host variables: a. should not show error for level-1 range exceeding level 48 b. XML Data Host and File Reference Variables should not allow (BLOB/CLOB/DBCLOB)-LOCATOR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] LOB variable should not show error for level-1 range exceeding level 48
```cobol
        Identification Division.
        Program-Id. 'TEST1'.
        Data Division.
        Working-Storage Section.
       01 GREET.
           49 VAR1 USAGE IS SQL TYPE IS BLOB-LOCATOR.
        PROCEDURE division.
           display  VAR1.

``` 
- [x] XML Data Host and File Reference Variables should not allow (BLOB/CLOB/DBCLOB)-LOCATOR

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
