### PR TITLE
fix: fix go to definition for copybook in shared drive (UNC)

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookMessageHandlerTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookMessageHandlerTest.spec.ts
@@ -36,7 +36,7 @@ jest.mock("url", () => {
 (globSync as any) = jest.fn().mockImplementation((x: any) => [x]);
 (fs.realpathSync.native as any) = jest.fn().mockImplementation((x: any) => x);
 (vscode.Uri.file as any) = jest.fn().mockImplementation((x: any) => {
-  return { fsPath: x };
+  return { fsPath: x, toString: jest.fn().mockReturnValue("file://" + x) };
 });
 
 describe("Test the copybook message handler", () => {

--- a/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
@@ -15,7 +15,6 @@
 import * as fs from "fs";
 import * as path from "path";
 import { globSync, hasMagic } from "glob";
-import * as urlUtil from "url";
 import { Uri } from "vscode";
 import * as vscode from "vscode";
 import { Utils } from "./Utils";
@@ -38,13 +37,7 @@ export function searchCopybookInExtensionFolder(
     for (const ext of extensions) {
       const searchResult = globSearch(extensionFolder, p, copybookName, ext);
       if (searchResult) {
-        const root = path.parse(searchResult).root;
-        const urlPath = searchResult
-          .substring(root.length)
-          .split(path.sep)
-          .map((s) => encodeURIComponent(s))
-          .join(path.sep);
-        return new urlUtil.URL("file://" + root + urlPath).href;
+        return vscode.Uri.file(searchResult).toString();
       }
     }
   }


### PR DESCRIPTION
fix go to definition for copybook in shared drive (UNC). 
Vs Code is **unable** to resolve below UNC path
` file:////<hostname>/Users/FILE` ,
 but can **resolve**  `file://<hostname>/Users/FILE`

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x]  Configure copybooks on an accessible shared drive. Include these copybooks in a Cobol source. After the Cobol source is analyzed , try go to definition for copybooks in the shared drive.  Vs code should be able to locates copybooks

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
