### PR TITLE
fix: fix re-analysis of a cobol source when triggerd by a copybook up…

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/CobolWorkspaceServiceImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/CobolWorkspaceServiceImpl.java
@@ -110,14 +110,13 @@ public class CobolWorkspaceServiceImpl extends LspEventConsumer implements Works
             if (file.getType() == FileChangeType.Deleted) {
               path = path.getParent();
             }
-            String uriString = uriDecodeService.decode(path.toUri().toString());
-            if (sourceUnitGraph.isFileOpened(uriString)) {
+              if (sourceUnitGraph.isFileOpened(uriDecodeService.decode(path.toUri().toString()))) {
               // opened files are taken care by textChange events
               return;
             }
             boolean isDirectory = Files.isDirectory(path);
             if (!isDirectory) {
-              triggerAnalysisForChangedFile(uriString);
+              triggerAnalysisForChangedFile(path.toUri().toString());
             } else {
               triggerAnalysisForFilesInDirectory(path);
             }
@@ -127,8 +126,9 @@ public class CobolWorkspaceServiceImpl extends LspEventConsumer implements Works
 
   @SneakyThrows
   private void triggerAnalysisForChangedFile(String uri) {
+    String copybookUri = uriDecodeService.decode(uri);
     List<String> uris =
-        sourceUnitGraph.getAllAssociatedFilesForACopybook(uriDecodeService.decode(uri));
+        sourceUnitGraph.getAllAssociatedFilesForACopybook(copybookUri);
     String fileContent = null;
     if (uris.isEmpty()) {
       asyncAnalysisService.reanalyseOpenedPrograms();
@@ -140,7 +140,7 @@ public class CobolWorkspaceServiceImpl extends LspEventConsumer implements Works
     }
     if (!sourceUnitGraph.isFileOpened(uri)) {
       asyncAnalysisService.reanalyseCopybooksAssociatedPrograms(
-          uris, uri, fileContent, SourceUnitGraph.EventSource.FILE_SYSTEM);
+          uris, copybookUri, fileContent, SourceUnitGraph.EventSource.FILE_SYSTEM);
     }
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/SourceUnitGraph.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/SourceUnitGraph.java
@@ -285,8 +285,15 @@ public class SourceUnitGraph implements AnalysisStateListener {
 
   /**
    * Update the graph with the latest content from the file system
-   *
-   * @param uri
+   * @param uri {@link URI}
+   */
+  public synchronized void updateContent(URI uri) {
+    updateContent(uri.toString());
+  }
+
+  /**
+   * Update the graph with the latest content from the file system
+   * @param uri - String representation of URI
    */
   public synchronized void updateContent(String uri) {
     if (objectRef.containsKey(uri)) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/UriDecodeService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/UriDecodeService.java
@@ -18,6 +18,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.inject.Singleton;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +31,15 @@ import lombok.extern.slf4j.Slf4j;
 public class UriDecodeService {
 
   private final BiMap<String, String> mapper = HashBiMap.create();
+
+  /**
+   * Decode given uri
+   * @param uri to decode
+   * @return decoded uri
+   */
+  public String decode(URI uri) {
+    return decode(uri.toString());
+  }
 
   /**
    * Decode given uri


### PR DESCRIPTION
…date from file explorer

fix re-analysis of a Cobol source when triggered by a copybook update from file explorer, when the path included spaces or other special characters

** This is a temporary solution and a refactoring around copybooks would be required 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] re-analysis of a Cobol source when triggered by a copybook update from file explorer, when the path included spaces
- [ ] Test no regression introduced for copybook download and content updates of copybook

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
