### PR TITLE
fix: detect downloaded copybooks as COBOL

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -121,7 +121,10 @@
           "COBOL"
         ],
         "configuration": "./syntaxes/lang-config.json",
-        "firstLine": "^[0-9 ]{6}([*].*|[ Dd] *([Ii][Dd]([Ee][Nn][Tt][Ii][Ff][Ii][Cc][Aa][Tt][Ii][Oo][Nn])? +[Dd][Ii][Vv][Ii][Ss][Ii][Oo][Nn][. ]|[0-9][0-9] +[@#$A-Z][-A-Z0-9]*[. ]|[*](CBL|PROCESS) ).*)$|^([0-9].{5})?[ ]*(CBL|PROCESS) "
+        "firstLine": "^[0-9 ]{6}([*].*|[ Dd] *([Ii][Dd]([Ee][Nn][Tt][Ii][Ff][Ii][Cc][Aa][Tt][Ii][Oo][Nn])? +[Dd][Ii][Vv][Ii][Ss][Ii][Oo][Nn][. ]|[0-9][0-9] +[@#$A-Z][-A-Z0-9]*[. ]|[*](CBL|PROCESS) ).*)$|^([0-9].{5})?[ ]*(CBL|PROCESS) ",
+        "filenamePatterns": [
+          "**/broadcommfd.cobol-language-support/*/copybooks/**"
+        ]
       },
       {
         "id": "expcobol",


### PR DESCRIPTION
Downloaded copybooks should be automatically detected as COBOL.