### PR TITLE
Experimental unc path support

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/LanguageClientServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/LanguageClientServiceTest.spec.ts
@@ -136,6 +136,7 @@ describe("LanguageClientService positive scenario", () => {
         args: [
           "-Dline.separator=\r\n",
           `-Ddialect.path=${expectedDialectPath}`,
+          `-Duser.dir=${serverPath}`,
           "-Xmx768M",
           "-jar",
           serverPath,

--- a/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
@@ -171,6 +171,7 @@ export class LanguageClientService {
       args: [
         "-Dline.separator=\r\n",
         "-Ddialect.path=" + this.dialectsPath,
+        `-Duser.dir=${jarPath}`, // this makes sure that a java process started with UNC path like \\.\c:\Users doesn't fail
         "-Xmx768M",
         "-jar",
         jarPath,

--- a/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
@@ -86,6 +86,12 @@ function globSearch(
     copybookName +
     ext;
   pattern = pattern + suffix;
+
+  // Special handling of //./ UNC path as glob module doesn't support this. refer: https://github.com/isaacs/node-glob
+  if (pattern.startsWith("//./") && process.platform === "win32") {
+    pattern = pattern.replace("//./", "//?/");
+  }
+
   const result = globSync(pattern, { cwd, dot: true });
   // TODO report the case with more then one copybook fit the pattern.
   return result[0]

--- a/clients/cobol-lsp-vscode-extension/src/test/runTest.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/runTest.ts
@@ -52,6 +52,11 @@ async function main() {
     }
     // run tests
     await runTests(options);
+    if (process.platform === "win32") {
+      console.log("----- RUNNING TEST USING UNC PATH ------");
+      launchArgs[0] = "\\\\.\\" + launchArgs[0];
+      await runTests(options);
+    }
   } catch (error) {
     console.log(error);
     console.error("Tests Failed");

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.copybooks.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.copybooks.test.ts
@@ -30,8 +30,7 @@ suite("Integration Test Suite: Copybooks", function () {
   );
 
   test("TC174655: Copybook - Nominal", async () => {
-    await helper.showDocument("USERC1N1.cbl");
-    const editor = helper.get_editor("USERC1N1.cbl");
+    const editor = await helper.showDocument("USERC1N1.cbl");
     await helper.waitForDiagnostics(editor.document.uri);
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(
@@ -44,8 +43,7 @@ suite("Integration Test Suite: Copybooks", function () {
     .slow(1000);
 
   test("TC174657: Copybook - not exist: no syntax ok message", async () => {
-    await helper.showDocument("USERC1F.cbl");
-    const editor = helper.get_editor("USERC1F.cbl");
+    const editor = await helper.showDocument("USERC1F.cbl");
     await helper.waitForDiagnostics(editor.document.uri);
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(
@@ -58,8 +56,7 @@ suite("Integration Test Suite: Copybooks", function () {
     .slow(1000);
 
   test("TC174658, TC174658: Copybook - not exist: error underlying and detailed hint", async () => {
-    await helper.showDocument("USERC1F.cbl");
-    const editor = helper.get_editor("USERC1F.cbl");
+    const editor = await helper.showDocument("USERC1F.cbl");
     await helper.waitForDiagnostics(editor.document.uri);
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 3);
@@ -73,8 +70,7 @@ suite("Integration Test Suite: Copybooks", function () {
     .slow(1000);
 
   test("TC174916/TC174917 Copybook - recursive error and detailed hint", async () => {
-    await helper.showDocument("USERC1R.cbl");
-    const editor = helper.get_editor("USERC1R.cbl");
+    const editor = await helper.showDocument("USERC1R.cbl");
     await helper.waitForDiagnostics(editor.document.uri);
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 3);
@@ -91,8 +87,7 @@ suite("Integration Test Suite: Copybooks", function () {
     .slow(1000);
 
   test("TC174932/TC174933 Copybook - invalid definition and hint", async () => {
-    await helper.showDocument("USERC1N2.cbl");
-    const editor = helper.get_editor("USERC1N2.cbl");
+    const editor = await helper.showDocument("USERC1N2.cbl");
     await helper.waitForDiagnostics(editor.document.uri);
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 4);
@@ -109,8 +104,7 @@ suite("Integration Test Suite: Copybooks", function () {
     .slow(1000);
 
   test("TC174952 Copybook - not exist, but dynamically appears", async () => {
-    await helper.showDocument("VAR.cbl");
-    let editor = helper.get_editor("VAR.cbl");
+    let editor = await helper.showDocument("VAR.cbl");
     await helper.waitForDiagnostics(editor.document.uri);
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 2);
@@ -135,8 +129,7 @@ suite("Integration Test Suite: Copybooks", function () {
     .slow(1000);
 
   test("TC174952 / TC174953 Copybook - definition not exist, but dynamically appears", async () => {
-    await helper.showDocument("USERC1F.cbl");
-    let editor = helper.get_editor("USERC1F.cbl");
+    let editor = await helper.showDocument("USERC1F.cbl");
     await helper.waitForDiagnostics(editor.document.uri);
     let diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     helper.assertRangeIsEqual(

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
@@ -30,8 +30,7 @@ suite("Integration Test Suite", function () {
   );
 
   test("TC152047, TC152052, TC152051, TC152050, TC152053: Error case - file has syntax errors and are marked with detailed hints", async () => {
-    await helper.showDocument("USER2.cbl");
-    const editor = helper.get_editor("USER2.cbl");
+    const editor = await helper.showDocument("USER2.cbl");
     await helper.waitForDiagnostics(editor.document.uri);
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 2);
@@ -55,8 +54,7 @@ suite("Integration Test Suite", function () {
   });
 
   test("TC152050, TC152053: Error case - file has semantic errors and are marked with detailed hints", async () => {
-    await helper.showDocument("REPLACING.CBL");
-    const editor = helper.get_editor("REPLACING.CBL");
+    const editor = await helper.showDocument("REPLACING.CBL");
     await helper.waitForDiagnostics(editor.document.uri);
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 1);
@@ -68,8 +66,7 @@ suite("Integration Test Suite", function () {
   });
 
   test("TC288736 error message for 80chars limit", async () => {
-    await helper.showDocument("TEST.CBL");
-    const editor = helper.get_editor("TEST.CBL");
+    const editor = await helper.showDocument("TEST.CBL");
     const noise =
       "oi3Bd5kC1f3nMFp0IWg62ZZgWMxHPJnuLWm4DqplZDzMIX69C6vjeL24YbobdQnoQsDenL35omljznHd0l1fP";
     await helper.insertString(editor, pos(22, 7), noise);
@@ -90,8 +87,7 @@ suite("Integration Test Suite", function () {
     ?.slow(1000);
 
   test("TC312735 Check EXEC CICS is in Procedure Division", async () => {
-    await helper.showDocument("ADSORT.cbl");
-    let editor = helper.get_editor("ADSORT.cbl");
+    let editor = await helper.showDocument("ADSORT.cbl");
     await helper.deleteLine(editor, 58);
     await helper.insertString(
       editor,
@@ -111,8 +107,7 @@ suite("Integration Test Suite", function () {
     .slow(1000);
 
   test.skip("TC312753 Check EXEC CICS allows free arguments order", async () => {
-    await helper.showDocument("ADSORT.cbl");
-    let editor = helper.get_editor("ADSORT.cbl");
+    let editor = await helper.showDocument("ADSORT.cbl");
     await helper.deleteLine(editor, 58);
     await helper.insertString(
       editor,
@@ -137,7 +132,7 @@ suite("Integration Test Suite", function () {
       pos(40, 0),
       "               SEND MAP('DETAIL') MAPSET(MODULE-NAME-1)    ERASE",
     );
-    editor = helper.get_editor("ADSORT.cbl");
+    // editor = helper.get_editor("ADSORT.cbl");
     await helper.waitFor(
       () => vscode.languages.getDiagnostics(editor.document.uri).length === 0,
     );
@@ -148,8 +143,7 @@ suite("Integration Test Suite", function () {
   // .slow(1000);
 
   test("TC312745 Error check", async () => {
-    await helper.showDocument("ADSORT.cbl");
-    let editor = helper.get_editor("ADSORT.cbl");
+    let editor = await helper.showDocument("ADSORT.cbl");
     await helper.deleteLine(editor, 58);
     await helper.insertString(
       editor,
@@ -172,7 +166,7 @@ suite("Integration Test Suite", function () {
       pos(58, 0),
       "           EXEC CICS XCTL PROGRAM (XCTL1) END-EXEC.",
     );
-    editor = helper.get_editor("ADSORT.cbl");
+    // editor = helper.get_editor("ADSORT.cbl");
     await helper.waitFor(
       () => vscode.languages.getDiagnostics(editor.document.uri).length === 0,
     );
@@ -183,8 +177,7 @@ suite("Integration Test Suite", function () {
     .slow(1000);
 
   test("TC312738 CICS variables and paragraphs support", async () => {
-    await helper.showDocument("ADSORT.cbl");
-    let editor = helper.get_editor("ADSORT.cbl");
+    let editor = await helper.showDocument("ADSORT.cbl");
     await helper.waitFor(async () => {
       helper.sleep(100);
       const result: any[] = await vscode.commands.executeCommand(
@@ -224,8 +217,7 @@ suite("Integration Test Suite", function () {
     .slow(1000);
 
   test("TC314992 CICS as a Variable Name", async () => {
-    await helper.showDocument("ADSORT.cbl");
-    let editor = helper.get_editor("ADSORT.cbl");
+    let editor = await helper.showDocument("ADSORT.cbl");
     await helper.insertString(
       editor,
       pos(28, 0),
@@ -245,7 +237,7 @@ suite("Integration Test Suite", function () {
       pos(28, 0),
       "       88  CICS VALUE 'CICS '.",
     );
-    editor = helper.get_editor("ADSORT.cbl");
+    // editor = helper.get_editor("ADSORT.cbl");
     await helper.waitFor(
       () => vscode.languages.getDiagnostics(editor.document.uri).length === 0,
     );
@@ -256,8 +248,7 @@ suite("Integration Test Suite", function () {
     .slow(1000);
 
   test("TC266094 Underline the entire incorrect variable structure", async () => {
-    await helper.showDocument("VAR.cbl");
-    let editor = helper.get_editor("VAR.cbl");
+    let editor = await helper.showDocument("VAR.cbl");
     await helper.waitForDiagnostics(editor.document.uri);
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 2);
@@ -282,8 +273,7 @@ suite("Integration Test Suite", function () {
     .slow(1000);
 
   test("Load resource file", async () => {
-    await helper.showDocument("RES.cbl");
-    const editor = helper.get_editor("RES.cbl");
+    const editor = await helper.showDocument("RES.cbl");
     await helper.waitForDiagnostics(editor.document.uri);
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
 
@@ -309,8 +299,7 @@ suite("Integration Test Suite", function () {
         path.join(getWorkspacePath(), extSrcUser1FilePath),
       );
 
-      await helper.showDocument(extSrcUser1FilePath);
-      let editor = helper.get_editor(extSrcUser1FilePath);
+      let editor = await helper.showDocument(extSrcUser1FilePath);
       await helper.insertString(editor, pos(25, 0), "           COPY ABC.");
 
       let diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
@@ -333,8 +322,7 @@ suite("Integration Test Suite", function () {
         1,
       );
 
-      await helper.showDocument("USER1.cbl");
-      editor = helper.get_editor("USER1.cbl");
+      editor = await helper.showDocument("USER1.cbl");
       await helper.insertString(editor, pos(40, 0), "           COPY ABC.");
       await helper.waitFor(
         () => vscode.languages.getDiagnostics(editor.document.uri).length > 0,
@@ -367,8 +355,7 @@ suite("Integration Test Suite", function () {
     ?.slow(1000);
 
   test("TC250108 Test Program Name", async () => {
-    await helper.showDocument("USER1.cbl");
-    const editor = helper.get_editor("USER1.cbl");
+    const editor = await helper.showDocument("USER1.cbl");
     await editor.edit((edit) => {
       edit.replace(range(pos(48, 30), pos(48, 32)), "1.");
     });
@@ -384,8 +371,7 @@ suite("Integration Test Suite", function () {
     ?.slow(1000);
 
   test("TC250109 Test Area B", async () => {
-    await helper.showDocument("USER1.cbl");
-    const editor = helper.get_editor("USER1.cbl");
+    const editor = await helper.showDocument("USER1.cbl");
     await editor.edit((edit) => edit.delete(range(pos(32, 0), pos(32, 3))));
     await helper.waitForDiagnostics(editor.document.uri);
     let diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
@@ -412,8 +398,7 @@ suite("Integration Test Suite", function () {
     ?.slow(1000);
 
   test("TC250107 Test Area A, Check FD/SD level data", async () => {
-    await helper.showDocument("USER1.cbl");
-    let editor = helper.get_editor("USER1.cbl");
+    let editor = await helper.showDocument("USER1.cbl");
     await helper.insertString(editor, pos(17, 0), "       FILE SECTION.\n");
     await helper.insertString(
       editor,
@@ -438,8 +423,7 @@ suite("Integration Test Suite", function () {
     .slow(1000);
 
   test("TC250107 Test Area A, check DIVISION and paragraph name warnings", async () => {
-    await helper.showDocument("USER1.cbl");
-    let editor = helper.get_editor("USER1.cbl");
+    let editor = await helper.showDocument("USER1.cbl");
     await helper.insertString(editor, pos(13, 0), "      ");
     await helper.waitForDiagnostics(editor.document.uri);
     let diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
@@ -484,8 +468,7 @@ suite("Integration Test Suite", function () {
   test("TC314771: Support INCLUDE in EXEC SQL to build extended document", async () => {
     const extSrcPath = path.join("ADSORT.cbl");
     const diagPromise = helper.waitForDiagnosticsChange(extSrcPath);
-    await helper.showDocument(extSrcPath);
-    let editor = helper.get_editor("ADSORT.cbl");
+    let editor = await helper.showDocument(extSrcPath);
     await helper.deleteLine(editor, 58);
     await helper.insertString(
       editor,
@@ -529,11 +512,11 @@ suite("Integration Test Suite", function () {
 
   test("Show errors only for opened files", async () => {
     // Open program with error inside a copybook
-    await helper.showDocument("TESTCPY1.cbl");
-    const progUri = await helper.getUri("TESTCPY1.cbl");
+    let editor = await helper.showDocument("TESTCPY1.cbl");
+    const progUri = editor.document.uri;
 
     const copybookPath = path.join("testing", "COPYE");
-    const copybookUri = await helper.getUri(copybookPath);
+    let copybookUri = await helper.getUri(copybookPath);
 
     await helper.waitFor(
       () => vscode.languages.getDiagnostics(progUri).length === 1,
@@ -551,8 +534,8 @@ suite("Integration Test Suite", function () {
     assert.strictEqual(copyDiagnostics.length, 0);
 
     // Open copybook with an error
-    await helper.showDocument(copybookPath);
-
+    editor = await helper.showDocument(copybookPath);
+    copybookUri = editor.document.uri;
     await helper.waitFor(
       () => vscode.languages.getDiagnostics(copybookUri).length === 2,
     );

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.user1.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.user1.test.ts
@@ -33,8 +33,7 @@ suite("Tests with USER1.cbl", function () {
     helper.TEST_TIMEOUT,
   );
   this.beforeEach(async () => {
-    await helper.showDocument(WORKSPACE_FILE);
-    editor = helper.get_editor(WORKSPACE_FILE);
+    editor = await helper.showDocument(WORKSPACE_FILE);
   });
 
   // open 'open' file, should be recognized as COBOL

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/replacingstatement.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/replacingstatement.spec.test.ts
@@ -33,8 +33,7 @@ suite("TF35623: Support for Replacing and Mapping statement", function () {
   test("TC248045: Replacing Basic Scenario", async () => {
     const extSrcPath = path.join("TEST1.CBL");
     let diagPromise = helper.waitForDiagnosticsChange(extSrcPath);
-    await helper.showDocument(extSrcPath);
-    let editor = helper.get_editor("TEST1.CBL");
+    let editor = await helper.showDocument(extSrcPath);
     let diagnostics = await diagPromise;
     assert.strictEqual(diagnostics.length, 1);
     const message = diagnostics[0].message;
@@ -55,8 +54,7 @@ suite("TF35623: Support for Replacing and Mapping statement", function () {
   test("TC248087: Replacing twice for one variable", async () => {
     const extSrcPath = path.join("TEST2.CBL");
     let diagPromise = helper.waitForDiagnosticsChange(extSrcPath);
-    await helper.showDocument(extSrcPath);
-    let editor = helper.get_editor("TEST2.CBL");
+    let editor = await helper.showDocument(extSrcPath);
     let diagnostics = await diagPromise;
     assert.strictEqual(diagnostics.length, 1);
     const message = diagnostics[0].message;
@@ -128,6 +126,7 @@ suite("TF35623: Support for Replacing and Mapping statement", function () {
     editor = await helper.showDocument(extSrcPath);
     await helper.waitFor(
       () => vscode.languages.getDiagnostics(editor.document.uri).length === 1,
+      8000,
     );
     let diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 1);

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/snippet.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/snippet.spec.test.ts
@@ -31,8 +31,7 @@ suite.skip(
 
     test("Autocompletion basic dialect", async () => {
       helper.updateConfig("basic.json");
-      await helper.showDocument("SNIPPET.cbl");
-      const editor = helper.get_editor("SNIPPET.cbl");
+      const editor = await helper.showDocument("SNIPPET.cbl");
       await helper.waitFor(() => editor.document.languageId === "cobol");
       await helper.insertString(editor, pos(2, 0), "   IDENTIFICATION");
       await vscode.commands.executeCommand(
@@ -49,8 +48,7 @@ suite.skip(
     }).timeout(helper.TEST_TIMEOUT);
 
     test("Autocompletion with IDMS dialect", async () => {
-      await helper.showDocument("SNIPPET_IDMS.cbl");
-      const editor = helper.get_editor("SNIPPET_IDMS.cbl");
+      const editor = await helper.showDocument("SNIPPET_IDMS.cbl");
       await helper.waitFor(() => editor.document.languageId === "cobol");
       await helper.insertString(editor, pos(1, 0), "   COPY");
       await vscode.commands.executeCommand(
@@ -65,8 +63,7 @@ suite.skip(
     }).timeout(helper.TEST_TIMEOUT);
 
     test("Keywords Autocompletion for IDMS dialect", async () => {
-      await helper.showDocument("SNIPPET_IDMS.cbl");
-      const editor = helper.get_editor("SNIPPET_IDMS.cbl");
+      const editor = await helper.showDocument("SNIPPET_IDMS.cbl");
       await helper.waitFor(() => editor.document.languageId === "cobol");
       await helper.insertString(editor, pos(1, 0), "   IDMS-STATIST");
       await vscode.commands.executeCommand(
@@ -83,8 +80,7 @@ suite.skip(
     }).timeout(helper.TEST_TIMEOUT);
 
     test("TC152058 Autocompletion basic dialect", async () => {
-      await helper.showDocument("USER1.cbl");
-      const editor = helper.get_editor("USER1.cbl");
+      const editor = await helper.showDocument("USER1.cbl");
       helper.updateConfig("basic.json");
       await helper.waitFor(() => editor.document.languageId === "cobol");
       await helper.insertString(editor, pos(40, 0), "           A");
@@ -124,8 +120,7 @@ suite("TF42379 COBOL LS F96588 - Insert code snippets", function () {
   );
 
   test.skip("TC289633 Provide default COBOL code snippets - basic scenario", async () => {
-    await helper.showDocument("SNIPPET.cbl");
-    const editor = helper.get_editor("SNIPPET.cbl");
+    const editor = await helper.showDocument("SNIPPET.cbl");
     await helper.insertString(editor, pos(2, 0), "sh");
     await vscode.commands.executeCommand(
       "editor.action.triggerSuggest",
@@ -144,8 +139,7 @@ suite("TF42379 COBOL LS F96588 - Insert code snippets", function () {
   // .timeout(helper.TEST_TIMEOUT);
 
   test.skip("TC289635 Provide default COBOL code snippets - upper case", async () => {
-    await helper.showDocument("SNIPPET.cbl");
-    const editor = helper.get_editor("SNIPPET.cbl");
+    const editor = await helper.showDocument("SNIPPET.cbl");
     await helper.insertString(editor, pos(2, 0), "sh");
     await vscode.commands.executeCommand(
       "editor.action.triggerSuggest",
@@ -181,8 +175,7 @@ suite("TF42379 COBOL LS F96588 - Insert code snippets", function () {
   // .timeout(helper.TEST_TIMEOUT);
 
   test.skip("TC289636 Provide default COBOL code snippets - lower case", async () => {
-    await helper.showDocument("SNIPPET.cbl");
-    const editor = helper.get_editor("SNIPPET.cbl");
+    const editor = await helper.showDocument("SNIPPET.cbl");
     await helper.insertString(editor, pos(2, 0), "sh");
     await vscode.commands.executeCommand(
       "editor.action.triggerSuggest",

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/testHelper.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/testHelper.ts
@@ -40,10 +40,14 @@ export async function activate() {
   }
 }
 
-export function getWorkspacePath(): string {
+export function getWorkspaceUri(): vscode.Uri {
   if (vscode.workspace.workspaceFolders)
-    return vscode.workspace.workspaceFolders[0].uri.fsPath;
+    return vscode.workspace.workspaceFolders[0].uri;
   throw new Error("Workspace not found");
+}
+
+export function getWorkspacePath(): string {
+  return getWorkspaceUri().fsPath;
 }
 
 export function getWorkspace(): vscode.WorkspaceFolder {
@@ -56,7 +60,7 @@ export function get_editor(workspace_file: string): vscode.TextEditor {
   const editor = vscode.window.activeTextEditor!;
   assert.strictEqual(
     editor.document.uri.fsPath,
-    path.join(getWorkspacePath(), workspace_file),
+    vscode.Uri.joinPath(getWorkspaceUri(), workspace_file).fsPath,
   );
   return editor;
 }


### PR DESCRIPTION
## ** This PR is just to initiate discussion around support for UNC path

## Discussion:
- [ ] should client handle all file content. May be introduce 'textDocument/getContent' . Because User can implement their own fs-provider, which ideally would not break the schema validation, but what if it does? 
- [ ] Should we normalize uri's on entry to LSP server or have a middleware at client to normalize all uri's before sending requests. So, that //./c:/path and c:/path are always normalized as file:///c:/path (just an example). Also this would cover case (in)sensitivity  for drive names

- [ ] OR avoid above and just make the current server run with changes like the one's in this PR
