### PR TITLE
fix: fix variable definitions inside embedded copybooks

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/Node.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/Node.java
@@ -71,6 +71,18 @@ public abstract class Node {
     children.add(node);
   }
 
+
+  /**
+   * Add a child node to this node and updates the child parent link.
+   *
+   * @param index index of insertion
+   * @param node a child node.
+   */
+  public void addChildAt(int index, Node node) {
+    node.setParent(this);
+    children.add(index, node);
+  }
+
   /**
    * Remove a child node.
    *

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSameCopybooksWithDifferentCases.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSameCopybooksWithDifferentCases.java
@@ -38,9 +38,9 @@ class TestSameCopybooksWithDifferentCases {
 
   private static final String STRUCT1 =
       "       02  {$*PARENT2}.\n"
-          + "           03  {$*CHILD1}         PIC 9   VALUE IS '0'.\n"
-          + "           03  {$*CHILD2}         PIC 9   VALUE IS '1'.\n"
-          + "           03  {$*CHILD3}         PIC 9   VALUE IS '2'.";
+          + "           03  {$*CHILD1}         PIC 9   VALUE IS 0.\n"
+          + "           03  {$*CHILD2}         PIC 9   VALUE IS 1.\n"
+          + "           03  {$*CHILD3}         PIC 9   VALUE IS 2.";
 
   private static final String CPY_NAME = "STRUCT1";
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestWithCopybook.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestWithCopybook.java
@@ -104,6 +104,27 @@ class TestWithCopybook {
           + "       {#*bug-test2}.\n"
           + "           move 0 to {$test1}.";
 
+  public static final String TEXT7 =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. ABCDEF.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       copy {~AMAZE}.    \n"
+          + "       copy {~AMAZE2}.      \n"
+          + "       PROCEDURE DIVISION.\n";
+
+  public static final String AMAZE_TEXT =
+      "       01  {$*CHK-PARMS}.\n" + "P#1325         07  {$*CHECK}    PIC 9(09) COMP SYNC.\n";
+
+  public static final String AMAZE2_TEXT =
+      "001600 01  {$*META-TABLE}.\n"
+          + "001700     05  {$*META-FIELD} OCCURS 12500 TIMES.\n"
+          + "FMC    COPY {~AMAZE3}.\n"
+          + "       01  {$*TEST-ULTI} pic x.";
+
+  public static final String AMAZE3_TEXT =
+      "\n" + "         10  {$*META-FIELD-NAME}               PIC  X(35).\n";
+
   private static final String COPYBOOK_CONTENT = "       01  {$*VAR}     PIC S9(4) COMP.";
 
   @Test
@@ -150,5 +171,16 @@ class TestWithCopybook {
             TEXT6,
             ImmutableList.of(new CobolText("BUG0", "            \"scenario 4\"\n")),
             ImmutableMap.of());
+  }
+
+  @Test
+  void testEmbeddedCopybooks() {
+    UseCaseEngine.runTest(
+        TEXT7,
+        ImmutableList.of(
+            new CobolText("AMAZE", AMAZE_TEXT),
+            new CobolText("AMAZE2", AMAZE2_TEXT),
+            new CobolText("AMAZE3", AMAZE3_TEXT)),
+        ImmutableMap.of());
   }
 }


### PR DESCRIPTION
fix variable definitions inside embedded copybooks. 
For below program . 
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. ABCDEF.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       copy AMAZE.
       copy AMAZE2.
       PROCEDURE DIVISION.
``` 
copy AMAZE
```cobol
       01  CHK-PARMS.
P#1325         07  CHECK    PIC 9(09) COMP SYNC.

``` 

copybook AMAZE2
```cobol
001600 01  META-TABLE.
001700     05  META-FIELD OCCURS 12500 TIMES.
FMC    COPY AMAZE3.
       01  TEST-ULTI pic x.
``` 

copybook AMAZE3
```cobol

         10  META-FIELD-NAME               PIC  X(35).

``` 

 **The produced AST should be like**
```
 
 COPYNODE AMAZE
      | -----> VAR NODE IN SIDE AMAZE COPYBOOK
 COPYNODE AMAZE2
     |-------> VAR NODE IN SIDE AMAZE2 COPYBOOK
     |-------> COPYNODE AMAZE 3
                     |-----> VAR NODE IN SIDE AMAZE3 COPYBOOK
     |-------->  VAR NODE IN SIDE AMAZE2 COPYBOOK
``` 


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Check the Use case tests or the PR description

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
