### PR TITLE
fix: allow standalone node without pic clause for the supported usage…

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/variable/UsageFormat.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/variable/UsageFormat.java
@@ -44,7 +44,7 @@ public enum UsageFormat {
   INDEX,
   NATIONAL,
   UTF_8,
-  OBJECT_REFERENCE,
+  OBJECT_REFERENCE("OBJECTREFERENCE"),
   PACKED_DECIMAL,
   POINTER,
   POINTER_32,
@@ -53,11 +53,18 @@ public enum UsageFormat {
   UNDEFINED;
 
   private static final Map<String, UsageFormat> MAP;
+  private final String text;
 
   static {
-    MAP =
-        Arrays.stream(values())
-            .collect(toMap(it -> it.toDisplayString(), Function.identity()));
+    MAP = Arrays.stream(values()).collect(toMap(it -> it.text, Function.identity()));
+  }
+
+  UsageFormat(String text) {
+    this.text = text.replace("_", "-");
+  }
+
+  UsageFormat() {
+    this.text = this.name().replace("_", "-");
   }
 
   /**
@@ -76,6 +83,6 @@ public enum UsageFormat {
    * @return the name to display
    */
   public String toDisplayString() {
-    return toString().replace("_", "-");
+    return this.text;
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/processors/StandAloneDataItemCheck.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/processors/StandAloneDataItemCheck.java
@@ -14,19 +14,36 @@
  */
 package org.eclipse.lsp.cobol.core.engine.processors;
 
+import com.google.common.collect.ImmutableList;
 import org.eclipse.lsp.cobol.common.message.MessageTemplate;
+import org.eclipse.lsp.cobol.common.model.tree.variable.UsageFormat;
 import org.eclipse.lsp.cobol.common.processor.ProcessingContext;
 import org.eclipse.lsp.cobol.common.processor.Processor;
 import org.eclipse.lsp.cobol.common.model.tree.variable.StandAloneDataItemNode;
-import org.eclipse.lsp.cobol.common.model.tree.variable.UsageFormat;
+
+import java.util.List;
 
 import static org.eclipse.lsp.cobol.common.VariableConstants.EMPTY_STRUCTURE_MSG;
 
 /** StandAloneDataItemNode processor */
 public class StandAloneDataItemCheck implements Processor<StandAloneDataItemNode> {
+  private static final List<UsageFormat> USAGE_FOR_NO_MANDATORY_PIC_CLAUSE =
+      ImmutableList.of(
+          UsageFormat.INDEX,
+          UsageFormat.POINTER,
+          UsageFormat.POINTER_32,
+          UsageFormat.PROCEDURE_POINTER,
+          UsageFormat.FUNCTION_POINTER,
+          UsageFormat.OBJECT_REFERENCE,
+          UsageFormat.COMPUTATIONAL_1,
+          UsageFormat.COMP_1,
+          UsageFormat.COMPUTATIONAL_2,
+          UsageFormat.COMP_2);
+
   @Override
   public void accept(StandAloneDataItemNode node, ProcessingContext ctx) {
-    if (node.getPicClause().isEmpty() && node.getUsageFormat() != UsageFormat.INDEX) {
+    if (node.getPicClause().isEmpty()
+        && !USAGE_FOR_NO_MANDATORY_PIC_CLAUSE.contains(node.getUsageFormat())) {
       ctx.getErrors().add(node.getError(MessageTemplate.of(EMPTY_STRUCTURE_MSG, node.getName())));
     }
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/VisitorHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/VisitorHelper.java
@@ -193,8 +193,7 @@ public class VisitorHelper {
     return contexts.stream()
             .map(org.eclipse.lsp.cobol.core.CobolParser.DataUsageClauseContext::usageFormat)
             .filter(Objects::nonNull)
-            .map(org.eclipse.lsp.cobol.core.CobolParser.UsageFormatContext::getStart)
-            .map(Token::getText)
+            .map(org.eclipse.lsp.cobol.core.CobolParser.UsageFormatContext::getText)
             .map(UsageFormat::of)
             .collect(toList());
   }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestElementaryVariableWithoutPicClause.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestElementaryVariableWithoutPicClause.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** Test allowed elementary variables without pic clause */
+public class TestElementaryVariableWithoutPicClause {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST1.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01  {$*PARENT} USAGE POINTER-32.\n"
+          + "       01  {$*PARENT2} USAGE POINTER.\n"
+          + "       01  {$*PARENT3} USAGE INDEX.\n"
+          + "       01  {$*PARENT4} USAGE COMP-1.\n"
+          + "       01  {$*PARENT5} USAGE COMPUTATIONAL-1.\n"
+          + "       01  {$*PARENT6} USAGE COMPUTATIONAL-2.\n"
+          + "       01  {$*PARENT7} USAGE COMP-2.\n"
+          + "       01  {$*PARENT8} USAGE PROCEDURE-POINTER.\n"
+          + "       01  {$*PARENT9} USAGE FUNCTION-POINTER.\n"
+          + "       01  {$*PARENT10} USAGE OBJECT REFERENCE.\n"
+          + "       PROCEDURE DIVISION.\n";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+}

--- a/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/CobolLexer.g4
+++ b/server/parser/src/main/antlr4/org/eclipse/lsp/cobol/core/CobolLexer.g4
@@ -324,6 +324,7 @@ PERFORM                : P E R F O R M {cobolVerbTokens.add(PERFORM);};
 PIC : P I C  {cobolVerbTokens.add(PIC);} -> pushMode(PICTURECLAUSE) ;
 PICTURE : P I C T U R E  {cobolVerbTokens.add(PICTURE);} -> pushMode(PICTURECLAUSE) ;
 POINTER                : P O I N T E R {cobolVerbTokens.add(POINTER);};
+POINTER_32                : P O I N T E R MINUSCHAR '3' '2' {cobolVerbTokens.add(POINTER_32);};
 PORT : P O R T;
 POSITION               : P O S I T I O N {cobolVerbTokens.add(POSITION);};
 POSITIVE               : P O S I T I V E {cobolVerbTokens.add(POSITIVE);};


### PR DESCRIPTION
… clause

allow standalone node without pic clause for the following usage clause: 
INDEX, POINTER, POINTER_32, PROCEDURE_POINTER, FUNCTION_POINTER, OBJECT_REFERENCE, COMPUTATIONAL_1, COMPUTATIONAL_2, COMP_1, COMP_2

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test below code  do not throw diagnostics as it compiles fine ( also IBM doc says the same)
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. TEST1.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01  PARENT USAGE POINTER-32.
       01  PARENT2 USAGE POINTER.
       01  PARENT3 USAGE INDEX.
       01  PARENT4 USAGE COMP-1.
       01  PARENT5 USAGE COMPUTATIONAL-1.
       01  PARENT6 USAGE COMPUTATIONAL-2.
       01  PARENT7 USAGE COMP-2.
       01  PARENT8 USAGE PROCEDURE-POINTER.
       01  PARENT9 USAGE FUNCTION-POINTER.
       01  PARENT10 USAGE OBJECT REFERENCE.
       PROCEDURE DIVISION.
``` 
## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
