### PR TITLE
fix: check string quote semantics on extended document

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/rewriter/LineIndicatorProcessor.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/rewriter/LineIndicatorProcessor.java
@@ -39,7 +39,8 @@ public abstract class LineIndicatorProcessor implements CobolLineReWriter {
   private static final String DOUBLE_QUOTE_LITERAL = "\"([^\"]|\"\"|'')*+\"";
   private static final String SINGLE_QUOTE_LITERAL = "'([^']|''|\"\")*+'";
   public static final Pattern FLOATING_COMMENT_LINE =
-      Pattern.compile("(?<validText>.*?)(?<floatingComment>\\*>.*)?");
+      Pattern.compile(
+              "(?<validText>.*?)(?<floatingComment>\\*>.*)?");
 
   protected abstract CobolProgramLayout getLayout();
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/validator/ExtendedDocumentValidation.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/validator/ExtendedDocumentValidation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.preprocessor.delegates.validator;
+
+import org.eclipse.lsp.cobol.common.error.SyntaxError;
+import org.eclipse.lsp.cobol.common.mapping.ExtendedDocument;
+import org.eclipse.lsp.cobol.core.preprocessor.CobolLine;
+
+import java.util.List;
+
+/**
+ * Performs validation on the transformed cobol lines
+ */
+public interface ExtendedDocumentValidation {
+  /**
+   * Perform validation on {@link CobolLine}.
+   *
+   * @param extendedDocument the document URI
+   * @return the validation result
+   */
+  List<SyntaxError> validateLines(ExtendedDocument extendedDocument);
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/validator/StringClosedCorrectlyValidator.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/validator/StringClosedCorrectlyValidator.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.preprocessor.delegates.validator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.common.error.ErrorSource;
+import org.eclipse.lsp.cobol.common.error.SyntaxError;
+import org.eclipse.lsp.cobol.common.mapping.ExtendedDocument;
+import org.eclipse.lsp.cobol.common.mapping.ExtendedTextLine;
+import org.eclipse.lsp.cobol.common.mapping.MappedCharacter;
+import org.eclipse.lsp.cobol.common.message.MessageService;
+import org.eclipse.lsp.cobol.common.model.Locality;
+import org.eclipse.lsp.cobol.core.preprocessor.delegates.transformer.ContinuationLineTransformation;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Optional.ofNullable;
+import static org.eclipse.lsp.cobol.common.error.ErrorSeverity.ERROR;
+
+/** Validates a transformed Cobol lines for correctly quoted Strings */
+@Slf4j
+public class StringClosedCorrectlyValidator implements ExtendedDocumentValidation {
+  private static final Pattern BLANK_LINE_PATTERN = Pattern.compile("\\s*");
+  private static final Pattern QUOTED_STRING_PATTERN = Pattern.compile("('([^'])*'|\"([^\"])*\")");
+  private final MessageService messageService;
+
+    public StringClosedCorrectlyValidator(
+      MessageService messageService) {
+    this.messageService = messageService;
+    }
+
+  @Override
+  public List<SyntaxError> validateLines(ExtendedDocument extendedDocument) {
+    List<SyntaxError> errors = new ArrayList<>();
+    String documentURI = extendedDocument.getCurrentText().getUri();
+    extendedDocument
+        .getCurrentText()
+        .perform(
+            line ->
+                ofNullable(getStringClosedInCorrectlyError(line, documentURI))
+                    .ifPresent(errors::addAll));
+    return errors;
+  }
+
+  /**
+   * Check and raise an error if indicator area A of current line is not empty and the previous line
+   * doesn't end correctly.
+   */
+  private List<SyntaxError> getStringClosedInCorrectlyError(ExtendedTextLine line, String uri) {
+    List<SyntaxError> result = new ArrayList<>();
+    if (isBlankLine(line)) return null;
+
+    List<QuoteInfo> unclosedStringInfo = getUnclosedStringInfo(line);
+
+    if (!unclosedStringInfo.isEmpty()) {
+      unclosedStringInfo.forEach(info -> result.add(registerStringClosingError(uri, line, info)));
+    }
+    return result;
+  }
+
+  /** Check with a good pattern if there is an unclosed string */
+  private List<QuoteInfo> getUnclosedStringInfo(ExtendedTextLine cobolLine) {
+    List<QuoteInfo> result = new ArrayList<>();
+    if (doNotNeedAnalysis(cobolLine)) return result;
+    Matcher matcher = QUOTED_STRING_PATTERN.matcher(cobolLine.toString());
+
+    if (!matcher.find()) {
+      return findQuoteOpeningChar(cobolLine.toString())
+          .map(Collections::singletonList)
+          .orElse(Collections.emptyList());
+    }
+    // Find all matches
+    while (matcher.find()) {
+      String match = matcher.group();
+      // Check if the quotes are balanced
+      if (!areQuotesBalanced(match)) {
+        result.add(new QuoteInfo(match.charAt(0), matcher.start()));
+      }
+    }
+    return result;
+  }
+
+  private Optional<QuoteInfo> findQuoteOpeningChar(String cobolLineToCheck) {
+    int indexOfSingle = cobolLineToCheck.indexOf('\'');
+    int indexOfDouble = cobolLineToCheck.indexOf('"');
+
+    if (indexOfSingle == indexOfDouble) return Optional.empty();
+
+    if (indexOfSingle != -1 && indexOfDouble == -1)
+      return Optional.of(new QuoteInfo('\'', indexOfSingle));
+    if (indexOfSingle == -1) return Optional.of(new QuoteInfo('"', indexOfDouble));
+    return indexOfSingle > indexOfDouble
+        ? Optional.of(new QuoteInfo('"', indexOfDouble))
+        : Optional.of(new QuoteInfo('\'', indexOfSingle));
+  }
+
+  private static boolean areQuotesBalanced(String str) {
+    char firstChar = str.charAt(0);
+    char lastChar = str.charAt(str.length() - 1);
+    return (firstChar == '\'' && lastChar == '\'') || (firstChar == '"' && lastChar == '"');
+  }
+
+  private boolean doNotNeedAnalysis(ExtendedTextLine cobolLine) {
+    return Objects.isNull(cobolLine) || isBlankLine(cobolLine);
+  }
+
+  private boolean isBlankLine(ExtendedTextLine cobolLine) {
+    return BLANK_LINE_PATTERN.matcher(cobolLine.toString()).matches();
+  }
+
+  private SyntaxError registerStringClosingError(
+      String uri, ExtendedTextLine line, QuoteInfo quoteInfo) {
+    MappedCharacter mappedCharacter = line.getCharacters().get(quoteInfo.index);
+    Position originalPosition = mappedCharacter.getOriginalPosition();
+    SyntaxError error =
+        SyntaxError.syntaxError()
+            .errorSource(ErrorSource.PREPROCESSING)
+            .location(
+                Locality.builder()
+                    .uri(uri)
+                    .range(new Range(originalPosition, originalPosition))
+                    .recognizer(ContinuationLineTransformation.class)
+                    .build()
+                    .toOriginalLocation())
+            .suggestion(messageService.getMessage("ContinuationLineTransformation.periodRequired"))
+            .severity(ERROR)
+            .build();
+
+    LOG.debug(
+        "Syntax error by ContinuationLineTransformation#registerStringClosingError: {}",
+        error.toString());
+    return error;
+  }
+
+  private static class QuoteInfo {
+    final char quoteChar;
+    final int index;
+
+    QuoteInfo(char quoteChar, int index) {
+      this.quoteChar = quoteChar;
+      this.index = index;
+    }
+  }
+}

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCobolStringWithContinuationLineConcatenatedCorrectly.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCobolStringWithContinuationLineConcatenatedCorrectly.java
@@ -32,23 +32,67 @@ class TestCobolStringWithContinuationLineConcatenatedCorrectly {
           + "000301 AUTHOR.       A PROGRAMMER.\n"
           + "000000 DATA DIVISION.\n"
           + "000000 WORKING-STORAGE SECTION.\n"
-          + "000000  01 {$*ID1}.\n"
-          + "000000  01 {$*ID2}.\n"
+          + "000000  01 {$*ID1} pic x.\n"
+          + "000000  01 {$*ID2} pic x.\n"
           + "000400 PROCEDURE DIVISION.\n"
-          + "078070 {#*000-MAIN}.\n"
-          + "078076     EVALUATE TRUE\n"
-          + "078081         WHEN {$ID1}\n"
+          + "078070 000-MAIN.\n"
           + "078089                 MOVE 'PRESS \"CLEAR\" OR \"ENTER\" TO RETURN TO THE M\n"
-          + "078089-                     'ENU WHEN FINISHED' TO {$ID2}\n"
-          + "078091                 PERFORM {#PROGRAM2}\n"
-          + "000000     END-EVALUATE.\n"
-          + "000000 {#*PROGRAM2}.\n"
-          + "000000  DISPLAY 'HELLO'.";
+          + "078089-                     'ENU WHEN FINISHED' TO {$ID2}.\n"
+          + "000000 PROGRAM2.\n"
+          + "000000       DISPLAY 'HELLO'.";
 
-  @Disabled("Continuation line cause a semantic error #414")
+  public static final String TEXT2 =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. testas.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       CONFIGURATION SECTION.\n"
+          + "       SPECIAL-NAMES.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       FILE-CONTROL.\n"
+          + "       DATA DIVISION.\n"
+          + "        FILE SECTION.\n"
+          + "        WORKING-STORAGE SECTION.\n"
+          + "       01  FILLER  PIC  X(62) VALUE                                     \n"
+          + "           '  then it must be either ''CLOSE'', ''NOCLOSE'', ''ENHANCED'\n"
+          + "      -    '''.    \n"
+          + "        LINKAGE SECTION.\n"
+          + "       PROCEDURE DIVISION.";
+
+  public static final String TEXT3 =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. testabb.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       CONFIGURATION SECTION.\n"
+          + "       SPECIAL-NAMES.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       FILE-CONTROL.\n"
+          + "       DATA DIVISION.\n"
+          + "        FILE SECTION.\n"
+          + "        WORKING-STORAGE SECTION.\n"
+          + "       01 {$*WS-COND-UPD} pic x(232).\n"
+          + "       01 {$*RANDOMV} pic x(2).\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "               display 'tetsing....'\n"
+          + "                 IF {$WS-COND-UPD} = SPACES OR '= ' OR      \n"
+          + "              '< ' OR '> ' OR '¬=' OR '<=' OR '>=' OR \"P'\" OR       \n"
+          + "              \"T'\" OR \"C'\" OR \"N'\" OR \"X'\"                          \n"
+          + "            MOVE 'Y' TO {$RANDOMV}    \n"
+          + "           END-IF  . ";
+
+  @Disabled("Mapping Issue for the continued line variables")
   // TODO: #414
   @Test
   void test() {
     UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void test1() {
+    UseCaseEngine.runTest(TEXT2, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void test2() {
+    UseCaseEngine.runTest(TEXT3, ImmutableList.of(), ImmutableMap.of());
   }
 }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test below code works without diagnostics
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. testabb.
       ENVIRONMENT DIVISION.
       CONFIGURATION SECTION.
       SPECIAL-NAMES.
       INPUT-OUTPUT SECTION.
       FILE-CONTROL.
       DATA DIVISION.
        FILE SECTION.
        WORKING-STORAGE SECTION.
       01 WS-COND-UPD pic x(232).
       01 RANDOMV pic x(2).
       PROCEDURE DIVISION.
           display 'tetsing....'
                 IF WS-COND-UPD = SPACES OR '= ' OR      
              '< ' OR '> ' OR '¬=' OR '<=' OR '>=' OR "P'" OR       
              "T'" OR "C'" OR "N'" OR "X'"                          
            MOVE 'Y' TO RANDOMV    
           END-IF  . 
``` 
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. testas.
       ENVIRONMENT DIVISION.
       CONFIGURATION SECTION.
       SPECIAL-NAMES.
       INPUT-OUTPUT SECTION.
       FILE-CONTROL.
       DATA DIVISION.
        FILE SECTION.
        WORKING-STORAGE SECTION.
       01  FILLER  PIC  X(62) VALUE                                     
           '  then it must be either ''CLOSE'', ''NOCLOSE'', ''ENHANCED'
      -    '''.    
        LINKAGE SECTION.
       PROCEDURE DIVISION.
``` 
## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
