### PR TITLE
fix: fix wrong variable reference in a continued line #2360

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedDocument.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedDocument.java
@@ -119,6 +119,18 @@ public class ExtendedDocument {
   }
 
   /**
+   * Replaces given range of text with a new text
+   * @param range - range of text to replace
+   * @param textLine - a new Extended text
+   */
+  public void replace(Range range, ExtendedTextLine textLine) {
+    Range updatedRange = updateRangeDueToChanges(range);
+    currentText.clear(updatedRange);
+    currentText.append(updatedRange.getStart().getLine(), textLine);
+    dirty = true;
+  }
+
+  /**
    * Cleares a range of text
    * @param range - a range of text
    */

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextLine.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextLine.java
@@ -43,7 +43,7 @@ public class ExtendedTextLine {
     this(line, new Position(lineNumber, 0), uri);
   }
 
-  ExtendedTextLine(String line, Position start, String uri) {
+  public ExtendedTextLine(String line, Position start, String uri) {
     for (int i = 0; i < line.length(); i++) {
       char character = line.charAt(i);
       checkCharacter(character);
@@ -127,7 +127,7 @@ public class ExtendedTextLine {
    * Appends the line with given line
    * @param line - line that will be added to the end of this line
    */
-  void append(ExtendedTextLine line) {
+  public void append(ExtendedTextLine line) {
     characters.addAll(line.characters);
     characters.forEach(c -> c.setParent(this));
   }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/dialects/ibm/CobolLineWriterImplTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/dialects/ibm/CobolLineWriterImplTest.java
@@ -44,8 +44,11 @@ class CobolLineWriterImplTest extends AbstractCobolLinePreprocessorTest {
       "CBL DATA(24)\n"
           + "                       PERFORM BBAB-MOVE-TO-DETAIL-MAP\n"
           + "                       MOVE -1 TO SNAMEDL\n"
-          + "                       MOVE 'PRESS \"CLEAR\" OR \"ENTER\" TO RETURN TO THE MENU WHEN FINISHED'\n\n"
-          + "                       MOVE \"PRESS 'CLEAR' OR 'ENTER' TO RETURN TO THE MENU WHEN FINISHED\"\n\n"
+          + "                       MOVE 'PRESS \"CLEAR\" OR \"ENTER\" TO RETURN TO THE MENU WHEN FINISHED'\n"
+          + "                                      \n"
+          + "                                      \n"
+          + "                       MOVE \"PRESS 'CLEAR' OR 'ENTER' TO RETURN TO THE MENU WHEN FINISHED\"\n"
+          + "                                               \n"
           + "                       MOVE 'asd' NEXT LINE\n";
 
   @Test

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestContinuationLine.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestContinuationLine.java
@@ -94,20 +94,33 @@ class TestContinuationLine {
           + "           MOVE \"TEST\" to {$DATA-T}.\n"
           + "           DISPLAY {$WRK-XN-160-1}.";
 
-  private static final String TEXT4 = "       IDENTIFICATION DIVISION.\n"
-      + "       PROGRAM-ID. TEST1.\n"
-      + "       DATA DIVISION.\n"
-      + "       WORKING-STORAGE SECTION.\n"
-      + "       01  {$*CCVS-C-1}.                                                    NC2354.2\n"
-      + "           02 FILLER  PIC IS X(99)    VALUE IS \" FEATURE              PANC2354.2\n"
-      + "      -    \"SS  PARAGRAPH-NAME                                          NC2354.2\n"
-      + "      -    \"       REMARKS\".                                            NC2354.2\n"
-      + "       01  {$*HYPHEN-LINE}.                                                 NC2354.2\n"
-      + "           02 FILLER  PIC IS X VALUE IS SPACE.                          NC2354.2\n"
-      + "           02 FILLER  PIC IS X(65)    VALUE IS \"************************NC2354.2\n"
-      + "      -    \"*****************************************\".                 NC2354.2\n"
-      + "           02 FILLER  PIC IS X(54)    VALUE IS \"************************NC2354.2\n"
-      + "      -    \"******************************\".";
+  private static final String TEXT4 =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST1.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01  {$*CCVS-C-1}.                                                    NC2354.2\n"
+          + "           02 FILLER  PIC IS X(99)    VALUE IS \" FEATURE              PANC2354.2\n"
+          + "      -    \"SS  PARAGRAPH-NAME                                          NC2354.2\n"
+          + "      -    \"       REMARKS\".                                            NC2354.2\n"
+          + "       01  {$*HYPHEN-LINE}.                                                 NC2354.2\n"
+          + "           02 FILLER  PIC IS X VALUE IS SPACE.                          NC2354.2\n"
+          + "           02 FILLER  PIC IS X(65)    VALUE IS \"************************NC2354.2\n"
+          + "      -    \"*****************************************\".                 NC2354.2\n"
+          + "           02 FILLER  PIC IS X(54)    VALUE IS \"************************NC2354.2\n"
+          + "      -    \"******************************\".";
+
+  private static final String CONT_LINE_DATA_REF =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. test12.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*tst} pic x. \n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           move 'this is a long mssg ...................................\n"
+          + "      -    'message continues...........................................\n"
+          + "      -    '' to {$tst}.\n"
+          + "             STOP RUN.";
 
   @Test
   void testWhenContinuousLineStartsWithOneQuote_thenOneLiteralIsIdentified() {
@@ -130,24 +143,33 @@ class TestContinuationLine {
 
   @Test
   void
-  testWhenContinuousLineStartsWithOneQuoteAndContinuedLineIsOpenLiteral_thenOneLiteralIdentified() {
+      testWhenContinuousLineStartsWithOneQuoteAndContinuedLineIsOpenLiteral_thenOneLiteralIdentified() {
     UseCaseEngine.runTest(TEXT3, ImmutableList.of(), ImmutableMap.of());
   }
 
   @Test
-  void
-  testWhenThereAre2ContinuousLines() {
+  void testWhenThereAre2ContinuousLines() {
     AnalysisResult result = UseCaseEngine.runTest(TEXT4, ImmutableList.of(), ImmutableMap.of());
-    Optional<VariableNode> node = result.getRootNode().getDepthFirstStream().filter(n -> n.getNodeType() == NodeType.VARIABLE)
-        .map(VariableNode.class::cast)
-        .filter(v -> v.getName().equals("HYPHEN-LINE"))
-        .findFirst();
+    Optional<VariableNode> node =
+        result
+            .getRootNode()
+            .getDepthFirstStream()
+            .filter(n -> n.getNodeType() == NodeType.VARIABLE)
+            .map(VariableNode.class::cast)
+            .filter(v -> v.getName().equals("HYPHEN-LINE"))
+            .findFirst();
 
     assertTrue(node.isPresent());
-    assertEquals(Locality.builder()
-        .uri("file:c:/workspace/document.cbl")
-        .range(new Range(new Position(8, 7), new Position(13, 44)))
-        .build(), node.get().getLocality());
+    assertEquals(
+        Locality.builder()
+            .uri("file:c:/workspace/document.cbl")
+            .range(new Range(new Position(8, 7), new Position(13, 44)))
+            .build(),
+        node.get().getLocality());
   }
 
+  @Test
+  void testDataRefInContinuedLine() {
+    UseCaseEngine.runTest(CONT_LINE_DATA_REF, ImmutableList.of(), ImmutableMap.of());
+  }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestPseudoTextContentConstraint.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestPseudoTextContentConstraint.java
@@ -22,7 +22,6 @@ import org.eclipse.lsp.cobol.test.CobolText;
 import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +37,8 @@ class TestPseudoTextContentConstraint {
           + "3      WORKING-STORAGE SECTION.\n";
   private static final String TEXT =
       BASE
-          + "5      COPY {~REPL} REPLACING {_==asasasasasasasasasasasasa|1_}\n"
+          + "5      COPY {~REPL}\n"
+          + "          REPLACING {_==asasasasasasasasasasasasa\n"
           + "      -    cccccccccccccccccccccccccccccccccccccccccccccccccccc\n"
           + "      -    oooooooooooooooooooooooooooooooooooooooooooooooooooo\n"
           + "      -    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
@@ -47,8 +47,8 @@ class TestPseudoTextContentConstraint {
           + "      -    IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII\n"
           + "      -    BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n"
           + "      -    MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM\n"
-          + "      -    == BY ====.\n"
-          + "8      PROCEDURE DIVISION.\n";
+          + "      -    == BY ====|1_}.\n"
+          + "8      PROCEDURE DIVISION.";
   private static final String PSEUDO_COPY_TEXT =
       BASE
           + "5      COPY {~REPL} REPLACING {_==COPY== BY ====|1_}.\n"
@@ -80,7 +80,7 @@ class TestPseudoTextContentConstraint {
         ImmutableMap.of(
             "1",
             new Diagnostic(
-                new Range(new Position(4, 27), new Position(13, 22)),
+                new Range(),
                 "Max 322 chars allowed for each individual word in pseudo text",
                 DiagnosticSeverity.Error,
                 ErrorSource.EXTENDED_DOCUMENT.getText())));


### PR DESCRIPTION
## How Has This Been Tested?

- [x] Test data reference for 'tst' variable in below code
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. test12.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 tst pic x. 
       PROCEDURE DIVISION.
           move 'this is a long mssg ...................................
      -    'message continues...........................................
      -    '' to tst.
             STOP RUN.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
