### PR TITLE
DBCLOB should generates PIC G

### DIFF
--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlHostVariable.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlHostVariable.java
@@ -473,6 +473,16 @@ public class TestSqlHostVariable {
   }
 
   @Test
+  void testLobVariables_dbclobPicClause() {
+    AnalysisResult actual = UseCaseEngine.runTest(LOD_VARS_TEXT_DBCLOB, ImmutableList.of(), ImmutableMap.of());
+    actual.getSymbolTableMap().values().stream()
+            .findFirst().flatMap(firstSymbolTable -> firstSymbolTable.getVariables().values().stream()
+                    .filter(item -> "VAR-DATA".equals(item.getName()))
+                    .findFirst())
+            .ifPresent(varNode -> assertEquals("G(30)", ((ElementaryNode) varNode).getPicClause()));
+  }
+
+  @Test
   void testLobVariables_level() {
     UseCaseEngine.runTest(LOD_VARS_TEXT1, ImmutableList.of(), ImmutableMap.of());
   }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Check the test cases in the PR . 

```cobol
        Identification Division.
        Program-Id. 'TEST1'.
        Data Division.
        Working-Storage Section.
       01 VAR1 USAGE IS SQL TYPE IS DBCLOB (30).
        PROCEDURE division.
           display  VAR1.
```

- [ ] Test A
- [ ] Test B

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
