### PR TITLE
Fix downloaded copybooks are not getting resolved

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -34,6 +34,7 @@ jest.mock("../../../services/reporter/TelemetryService");
 (vscode.workspace.workspaceFolders as any) = [
   { uri: { fsPath: "/projects" } } as any,
 ];
+(vscode.workspace.findFiles as any) = jest.fn();
 Utils.getZoweExplorerAPI = jest.fn().mockReturnValue({ api: zoweExplorerMock });
 
 describe("Tests copybook download service", () => {

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -252,6 +252,10 @@ export class CopybookDownloadService {
         `Error downloading copybooks : ${err.message}`,
       );
     });
+    if (totalCopybooksToDownload > 0) {
+      await new Promise((f) => setTimeout(f, 100)); //to avoid to be discarded in server
+      vscode.workspace.findFiles(this.storagePath);
+    }
   }
 
   private async isPrerequisiteForDownloadSatisfied(


### PR DESCRIPTION
## How Has This Been Tested?

Open a cobol program that uses copybooks 
configure copybook download paths or use endevor integration
check downloaded copybooks are getting resolved.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
