### PR TITLE
fix: provide dummy node name for document symbol without name

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/utils/BuildOutlineTreeFromSyntaxTree.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/utils/BuildOutlineTreeFromSyntaxTree.java
@@ -89,7 +89,6 @@ public class BuildOutlineTreeFromSyntaxTree {
   }
 
   private DocumentSymbol convertFileEntry(FileEntryNode node) {
-    node.getLocality().getUri();
     return createDocumentSymbol(node.getFileName(), NodeSymbolType.FILE, node);
   }
 
@@ -102,7 +101,10 @@ public class BuildOutlineTreeFromSyntaxTree {
   }
 
   private DocumentSymbol convertProgramId(ProgramIdNode node) {
-    return createDocumentSymbol(node.getSubtype().subtypeName + "-ID " + node.getProgramId(), NodeSymbolType.PROGRAM_ID, node);
+    return createDocumentSymbol(
+        node.getSubtype().subtypeName + "-ID " + node.getProgramId(),
+        NodeSymbolType.PROGRAM_ID,
+        node);
   }
 
   private DocumentSymbol convertDivision(DivisionNode node) {
@@ -126,12 +128,14 @@ public class BuildOutlineTreeFromSyntaxTree {
   private DocumentSymbol convertProgram(ProgramNode node) {
     String subtype = node.getSubtype().subtypeName;
     String name = node.getProgramName();
-    if (name != null)
-      subtype += ": " + name;
+    if (name != null) subtype += ": " + name;
     return createDocumentSymbol(subtype, NodeSymbolType.PROGRAM, node);
   }
 
   private DocumentSymbol createDocumentSymbol(String name, NodeSymbolType type, Node treeNode) {
+    if (name == null || name.trim().isEmpty()) {
+      name = "UNKNOWN (" + type.name() + ")";
+    }
     return new DocumentSymbol(
         name,
         type.getSymbolKind(),

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestOutlineTreeLineNumbers.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestOutlineTreeLineNumbers.java
@@ -41,6 +41,18 @@ class TestOutlineTreeLineNumbers {
           + "05     01 STRUCTNAME.\n"
           + "06     03 VARNAME  PIC X(20).";
 
+  public static final String DUMMY_NODE_TEXT =
+          "       IDENTIFICATION DIVISION.\n"
+                  + "       PROGRAM-ID. CBLMERGE.\n"
+                  + "       \n"
+                  + "       ENVIRONMENT DIVISION.\n"
+                  + "        INPUT-OUTPUT SECTION.\n"
+                  + "        FILE-CONTROL.\n"
+                  + "           SELECT INPUT1 ASSIGN TO IN1.\n"
+                  + "           SELECT INPUT2 ASSIGN TO IN2.\n"
+                  + "           SELECT OUTPUT ASSIGN TO OUT.\n"
+                  + "           SELECT WORK ASSIGN TO WRK.";
+
   @Test
   void test() {
     AnalysisResult result =
@@ -88,6 +100,32 @@ class TestOutlineTreeLineNumbers {
             extractLineRange(
                     BuildOutlineTreeFromSyntaxTree.convert(
                             result.getRootNode(), result.getRootNode().getLocality().getUri())));
+  }
+
+  @Test
+  void unknownNodeName_whenNodeNameIsEmpty() {
+    AnalysisResult result =
+            UseCaseUtils.analyze(UseCase.builder().text(DUMMY_NODE_TEXT).cicsTranslator(false).build());
+
+    List<DocumentSymbol> actualOutline =
+            BuildOutlineTreeFromSyntaxTree.convert(
+                    result.getRootNode(), result.getRootNode().getLocality().getUri());
+
+    assertEquals(getDummyNodeOutlineRange(), extractLineRange(actualOutline));
+  }
+
+  private Map<String, LineRange> getDummyNodeOutlineRange() {
+    return new ImmutableMap.Builder<String, LineRange>()
+            .put("PROGRAM: CBLMERGE", new LineRange(0, 9))
+            .put("IDENTIFICATION DIVISION", new LineRange(0, 1))
+            .put("PROGRAM-ID CBLMERGE", new LineRange(1, 1))
+            .put("ENVIRONMENT DIVISION", new LineRange(3, 9))
+            .put("INPUT-OUTPUT SECTION", new LineRange(4, 9))
+            .put("INPUT1", new LineRange(6, 6))
+            .put("INPUT2", new LineRange(7, 7))
+            .put("UNKNOWN (FILE)", new LineRange(8, 8))
+            .put("WORK", new LineRange(9, 9))
+            .build();
   }
 
   private Map<String, LineRange> extractLineRange(List<DocumentSymbol> documentSymbols) {


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test below code doesn't throw document symbol error (though there are diagnostics error)
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. CBLMERGE.
       
       ENVIRONMENT DIVISION.
        INPUT-OUTPUT SECTION.
        FILE-CONTROL.
           SELECT INPUT1 ASSIGN TO IN1.
           SELECT INPUT2 ASSIGN TO IN2.
           SELECT OUTPUT ASSIGN TO OUT.
           SELECT WORK ASSIGN TO WRK.
``` 
compiler gives below error in this case
```
   000009                    SELECT OUTPUT ASSIGN TO OUT.                                          *

 ==000009==> IGYDS1189-S A file-name was missing following "FD", "SD" or "SELECT".  The
                         compiler-generated name " DUMMYSL00001" was inserted and the entry was
                         checked for syntax only.
``` 
Below is a screen shot of behavior as per this PR
![image](https://github.com/user-attachments/assets/c9993b0f-8570-4c77-b0d5-c48bdae1f918)

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
