### PR TITLE
perf: remove unnecessary rules from preprocessor grammar

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/CobolPreprocessor.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/CobolPreprocessor.g4
@@ -11,22 +11,7 @@ options {tokenVocab = CobolPreprocessorLexer;}
 
 startRule
    : .*? ((includeStatement | copyStatement | replaceAreaStartOrOffStatement | titleDirective | enterDirective
-   | controlDirective | linkageSection | plusplusIncludeStatement | procedureDivision | workingStorageSection)+ .*?)* EOF
-   ;
-
-// procedure devision for resolving predefined labels
-procedureDivision
-   : PROCEDURE DIVISION .*? DOT_FS
-   ;
-
-// linkage section for resolving predefined variables
-linkageSection
-   : LINKAGE SECTION DOT_FS
-   ;
-
-// working storage section for resolving speacal registers as variables
-workingStorageSection
-   : WORKING_STORAGE SECTION DOT_FS
+   | controlDirective | plusplusIncludeStatement)+ .*?)* EOF
    ;
 
 // copy statement


### PR DESCRIPTION
I failed to find places where we actually need to know, if we are in specific division during preprocessing source. So I've removed related rules.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
