### PR TITLE
test: fix failing tests when java is not installed

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/child_process.utility.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/child_process.utility.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Broadcom.
+ * Copyright (c) 2024 Broadcom.
  * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
  *
  * This program and the accompanying materials are made

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/child_process.utility.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/child_process.utility.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+import * as cp from "child_process";
+import { PassThrough } from "stream";
+
+export function mockSpawnProcess(stdout: string, stderr: string, exitCode = 0) {
+  const stdoutStream = new PassThrough();
+  const stderrStream = new PassThrough();
+
+  const mockProcess: Partial<cp.ChildProcess> = {
+    stdout: stdoutStream,
+    stderr: stderrStream,
+    on: (event, callback) => {
+      if (event === "close") {
+        stdoutStream.emit("data", stdout);
+        stderrStream.emit("data", stderr);
+        callback(exitCode, null);
+      }
+      return {} as cp.ChildProcess;
+    },
+  };
+
+  return jest
+    .spyOn(cp, "spawn")
+    .mockReturnValue(mockProcess as cp.ChildProcess);
+}


### PR DESCRIPTION
Added a mock for the `spawn` function from the `child_process` module to the failing tests, so the real `java` process is not executed in a test run. 
Added a new test to check if the `checkPrerequisites` function fails - when `java` is not installed or an old version is installed.

## How Has This Been Tested?
Run tests on a computer without installed JVM.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
