### PR TITLE
fix: allow SQL objects names with unicode char and is not limited to …

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlLexer.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlLexer.g4
@@ -857,7 +857,7 @@ DATELITERAL: '\'' (DIGIT DIGIT DIGIT DIGIT '-' DIGIT DIGIT '-' DIGIT DIGIT | //y
 
 SINGLEDIGITLITERAL : DIGIT;
 INTEGERLITERAL : DIGIT+;
-IDENTIFIER : [a-zA-Z0-9][_a-zA-Z0-9-]*;
+IDENTIFIER : [\p{Alnum}\p{General_Category=Other_Letter}] [-_\p{Alnum}\p{General_Category=Other_Letter}]*;
 COPYBOOK_IDENTIFIER : [a-zA-Z0-9#@$][_a-zA-Z0-9#@$]*;
 
 NUMERICLITERAL : (PLUSCHAR | MINUSCHAR)? DIGIT* (DOT_FS | COMMACHAR) DIGIT+ (('e' | 'E') (PLUSCHAR | MINUSCHAR)? DIGIT+)?;

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlObjectsName.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/sql/TestSqlObjectsName.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases.sql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** Test SQL objects names with unicode char not in [A-z0-9] doesn't break parsing */
+public class TestSqlObjectsName {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. test232.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       CONFIGURATION SECTION.\n"
+          + "       SPECIAL-NAMES.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       FILE-CONTROL.\n"
+          + "       DATA DIVISION.\n"
+          + "        FILE SECTION.\n"
+          + "        WORKING-STORAGE SECTION.\n"
+          + "        01 {$*ARB-HELLO} pic x.\n"
+          + "        01 {$*ARB-MD} pic x.\n"
+          + "        LINKAGE SECTION.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "003428     EXEC SQL\n"
+          + "003429         SELECT FÖ1R\n"
+          + "003430         INTO :{$ARB-HELLO}\n"
+          + "003431         FROM 你好\n"
+          + "003432         WHERE AD.FÖLR = :{$ARB-HELLO}\n"
+          + "                  and AD.XYZ = 'hello'\n"
+          + "                  and AD.OIY =  :{$ARB-MD}\n"
+          + "                  and привет = hello_halo \n"
+          + "                  and сайнуу = 'asa' \n"
+          + "                  and नमस = 'नमस्ते'\n"
+          + "003434         WITH UR\n"
+          + "003435     END-EXEC. ";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+}


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Check added usecase test
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. test232.
       ENVIRONMENT DIVISION.
       CONFIGURATION SECTION.
       SPECIAL-NAMES.
       INPUT-OUTPUT SECTION.
       FILE-CONTROL.
       DATA DIVISION.
        FILE SECTION.
        WORKING-STORAGE SECTION.
        01 AB-FR pic x.
        01 A-MD pic x.
        LINKAGE SECTION.
       PROCEDURE DIVISION.
000000     EXEC SQL
000000         SELECT FÖLJENR
000000         INTO :A-FR
000000         FROM D51.TFÖLJESR
000000         WHERE FÖLJENR = :A-FR
000000           AND MTRLID = :A-MD
000000         WITH UR
000000     END-EXEC
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
