### PR TITLE
Change getClass to use the Rule Index instead for CICS statement checks

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSAllocateOptionsCheckUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSAllocateOptionsCheckUtility.java
@@ -64,12 +64,18 @@ public class CICSAllocateOptionsCheckUtility extends CICSOptionsCheckBaseUtility
    * @param <E> A subclass of ParserRuleContext
    */
   public <E extends ParserRuleContext> void checkOptions(E ctx) {
-    if (ctx.getClass() == CICSParser.Cics_allocate_appc_partnerContext.class) {
-      checkAppcPartner((CICSParser.Cics_allocate_appc_partnerContext) ctx);
-    } else if (ctx.getClass() == CICSParser.Cics_allocate_appc_mro_lut61_sysidContext.class) {
-      checkAppcMroLut61Sysid((CICSParser.Cics_allocate_appc_mro_lut61_sysidContext) ctx);
-    } else if (ctx.getClass() == CICSParser.Cics_allocate_lut61_sessionContext.class) {
-      checkLut61Session((CICSParser.Cics_allocate_lut61_sessionContext) ctx);
+    switch (ctx.getRuleIndex()) {
+      case CICSParser.RULE_cics_allocate_appc_partner:
+        checkAppcPartner((CICSParser.Cics_allocate_appc_partnerContext) ctx);
+        break;
+      case CICSParser.RULE_cics_allocate_appc_mro_lut61_sysid:
+        checkAppcMroLut61Sysid((CICSParser.Cics_allocate_appc_mro_lut61_sysidContext) ctx);
+        break;
+      case CICSParser.RULE_cics_allocate_lut61_session:
+        checkLut61Session((CICSParser.Cics_allocate_lut61_sessionContext) ctx);
+        break;
+      default:
+        break;
     }
     checkDuplicates(ctx);
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSDefineOptionsCheckUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSDefineOptionsCheckUtility.java
@@ -91,18 +91,27 @@ public class CICSDefineOptionsCheckUtility extends CICSOptionsCheckBaseUtility {
    * @param <E> A subclass of ParserRuleContext
    */
   public <E extends ParserRuleContext> void checkOptions(E ctx) {
-    if (ctx.getClass() == CICSParser.Cics_define_activityContext.class) {
-      checkActivity((CICSParser.Cics_define_activityContext) ctx);
-    } else if (ctx.getClass() == CICSParser.Cics_define_composite_eventContext.class) {
-      checkCompositeEvent((CICSParser.Cics_define_composite_eventContext) ctx);
-    } else if (ctx.getClass() == CICSParser.Cics_define_counter_dcounterContext.class) {
-      checkCounter((CICSParser.Cics_define_counter_dcounterContext) ctx);
-    } else if (ctx.getClass() == CICSParser.Cics_define_input_eventContext.class) {
-      checkInputEvent((CICSParser.Cics_define_input_eventContext) ctx);
-    } else if (ctx.getClass() == CICSParser.Cics_define_processContext.class) {
-      checkDefineProcess((CICSParser.Cics_define_processContext) ctx);
-    } else if (ctx.getClass() == CICSParser.Cics_define_timerContext.class) {
-      checkDefineTimer((CICSParser.Cics_define_timerContext) ctx);
+    switch (ctx.getRuleIndex()) {
+      case CICSParser.RULE_cics_define_activity:
+        checkActivity((CICSParser.Cics_define_activityContext) ctx);
+        break;
+      case CICSParser.RULE_cics_define_composite_event:
+        checkCompositeEvent((CICSParser.Cics_define_composite_eventContext) ctx);
+        break;
+      case CICSParser.RULE_cics_define_counter_dcounter:
+        checkCounter((CICSParser.Cics_define_counter_dcounterContext) ctx);
+        break;
+      case CICSParser.RULE_cics_define_input_event:
+        checkInputEvent((CICSParser.Cics_define_input_eventContext) ctx);
+        break;
+      case CICSParser.RULE_cics_define_process:
+        checkDefineProcess((CICSParser.Cics_define_processContext) ctx);
+        break;
+      case CICSParser.RULE_cics_define_timer:
+        checkDefineTimer((CICSParser.Cics_define_timerContext) ctx);
+        break;
+      default:
+        break;
     }
     checkDuplicates(ctx);
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSExtractOptionsUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSExtractOptionsUtility.java
@@ -136,24 +136,37 @@ public class CICSExtractOptionsUtility extends CICSOptionsCheckBaseUtility {
    * @param <E> A subclass of ParserRuleContext
    */
   public <E extends ParserRuleContext> void checkOptions(E ctx) {
-    if (ctx.getClass() == CICSParser.Cics_extract_attachContext.class)
-      checkAttach((CICSParser.Cics_extract_attachContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_extract_attributesContext.class)
-      checkAttributes((CICSParser.Cics_extract_attributesContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_extract_certificateContext.class)
-      checkCertificate((CICSParser.Cics_extract_certificateContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_extract_logonmessageContext.class)
-      checkLogonMsg((CICSParser.Cics_extract_logonmessageContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_extract_processContext.class)
-      checkProcess((CICSParser.Cics_extract_processContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_extract_tcpipContext.class)
-      checkTcpIp((CICSParser.Cics_extract_tcpipContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_extract_tctContext.class)
-      checkTCT((CICSParser.Cics_extract_tctContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_extract_web_clientContext.class)
-      checkWebClient((CICSParser.Cics_extract_web_clientContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_extract_web_serverContext.class)
-      checkWebServer((CICSParser.Cics_extract_web_serverContext) ctx);
+    switch (ctx.getRuleIndex()) {
+      case CICSParser.RULE_cics_extract_attach:
+        checkAttach((CICSParser.Cics_extract_attachContext) ctx);
+        break;
+      case CICSParser.RULE_cics_extract_attributes:
+        checkAttributes((CICSParser.Cics_extract_attributesContext) ctx);
+        break;
+      case CICSParser.RULE_cics_extract_certificate:
+        checkCertificate((CICSParser.Cics_extract_certificateContext) ctx);
+        break;
+      case CICSParser.RULE_cics_extract_logonmessage:
+        checkLogonMsg((CICSParser.Cics_extract_logonmessageContext) ctx);
+        break;
+      case CICSParser.RULE_cics_extract_process:
+        checkProcess((CICSParser.Cics_extract_processContext) ctx);
+        break;
+      case CICSParser.RULE_cics_extract_tcpip:
+        checkTcpIp((CICSParser.Cics_extract_tcpipContext) ctx);
+        break;
+      case CICSParser.RULE_cics_extract_tct:
+        checkTCT((CICSParser.Cics_extract_tctContext) ctx);
+        break;
+      case CICSParser.RULE_cics_extract_web_client:
+        checkWebClient((CICSParser.Cics_extract_web_clientContext) ctx);
+        break;
+      case CICSParser.RULE_cics_extract_web_server:
+        checkWebServer((CICSParser.Cics_extract_web_serverContext) ctx);
+        break;
+      default:
+        break;
+    }
     checkDuplicates(ctx);
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSIssueOptionsCheckUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSIssueOptionsCheckUtility.java
@@ -111,50 +111,76 @@ public class CICSIssueOptionsCheckUtility extends CICSOptionsCheckBaseUtility {
    * @param <E> A subclass of ParserRuleContext
    */
   public <E extends ParserRuleContext> void checkOptions(E ctx) {
-    if (ctx.getClass() == CICSParser.Cics_issue_abendContext.class)
-      checkAbend((CICSParser.Cics_issue_abendContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_abortContext.class)
-      checkAbort((CICSParser.Cics_issue_abortContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_addContext.class)
-      checkAdd((CICSParser.Cics_issue_addContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_confirmationContext.class)
-      checkConfirmation((CICSParser.Cics_issue_confirmationContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_copyContext.class)
-      checkCopy((CICSParser.Cics_issue_copyContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_disconnectContext.class)
-      checkDisconnect((CICSParser.Cics_issue_disconnectContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_endContext.class)
-      checkEnd((CICSParser.Cics_issue_endContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_eodsContext.class)
-      checkEODS((CICSParser.Cics_issue_eodsContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_eraseContext.class)
-      checkErase((CICSParser.Cics_issue_eraseContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_erase_aupContext.class)
-      checkEraseAUP((CICSParser.Cics_issue_erase_aupContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_errorContext.class)
-      checkError((CICSParser.Cics_issue_errorContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_loadContext.class)
-      checkLoad((CICSParser.Cics_issue_loadContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_noteContext.class)
-      checkNote((CICSParser.Cics_issue_noteContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_passContext.class)
-      checkPass((CICSParser.Cics_issue_passContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_prepareContext.class)
-      checkPrepare((CICSParser.Cics_issue_prepareContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_printContext.class)
-      checkPrint((CICSParser.Cics_issue_printContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_queryContext.class)
-      checkQuery((CICSParser.Cics_issue_queryContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_receiveContext.class)
-      checkReceive((CICSParser.Cics_issue_receiveContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_replaceContext.class)
-      checkReplace((CICSParser.Cics_issue_replaceContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_sendContext.class)
-      checkSend((CICSParser.Cics_issue_sendContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_signalContext.class)
-      checkSignal((CICSParser.Cics_issue_signalContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_issue_waitContext.class)
-      checkWait((CICSParser.Cics_issue_waitContext) ctx);
+    switch (ctx.getRuleIndex()) {
+      case CICSParser.RULE_cics_issue_abend:
+        checkAbend((CICSParser.Cics_issue_abendContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_abort:
+        checkAbort((CICSParser.Cics_issue_abortContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_add:
+        checkAdd((CICSParser.Cics_issue_addContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_confirmation:
+        checkConfirmation((CICSParser.Cics_issue_confirmationContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_copy:
+        checkCopy((CICSParser.Cics_issue_copyContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_disconnect:
+        checkDisconnect((CICSParser.Cics_issue_disconnectContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_end:
+        checkEnd((CICSParser.Cics_issue_endContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_eods:
+        checkEODS((CICSParser.Cics_issue_eodsContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_erase:
+        checkErase((CICSParser.Cics_issue_eraseContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_erase_aup:
+        checkEraseAUP((CICSParser.Cics_issue_erase_aupContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_error:
+        checkError((CICSParser.Cics_issue_errorContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_load:
+        checkLoad((CICSParser.Cics_issue_loadContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_note:
+        checkNote((CICSParser.Cics_issue_noteContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_pass:
+        checkPass((CICSParser.Cics_issue_passContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_prepare:
+        checkPrepare((CICSParser.Cics_issue_prepareContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_print:
+        checkPrint((CICSParser.Cics_issue_printContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_query:
+        checkQuery((CICSParser.Cics_issue_queryContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_receive:
+        checkReceive((CICSParser.Cics_issue_receiveContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_replace:
+        checkReplace((CICSParser.Cics_issue_replaceContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_send:
+        checkSend((CICSParser.Cics_issue_sendContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_signal:
+        checkSignal((CICSParser.Cics_issue_signalContext) ctx);
+        break;
+      case CICSParser.RULE_cics_issue_wait:
+        checkWait((CICSParser.Cics_issue_waitContext) ctx);
+        break;
+      default:
+        break;
+    }
     checkDuplicates(ctx);
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSReceiveOptionsCheckUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSReceiveOptionsCheckUtility.java
@@ -73,14 +73,21 @@ public class CICSReceiveOptionsCheckUtility extends CICSOptionsCheckBaseUtility 
    * @param <E> A subclass of ParserRuleContext
    */
   public <E extends ParserRuleContext> void checkOptions(E ctx) {
-    if (ctx.getClass() == CICSParser.Cics_receive_group_oneContext.class) {
-      checkGroupOne((CICSParser.Cics_receive_group_oneContext) ctx);
-    } else if (ctx.getClass() == CICSParser.Cics_receive_partnContext.class) {
-      checkPartn((CICSParser.Cics_receive_partnContext) ctx);
-    } else if (ctx.getClass() == CICSParser.Cics_receive_mapContext.class) {
-      checkMap((CICSParser.Cics_receive_mapContext) ctx);
-    } else if (ctx.getClass() == CICSParser.Cics_receive_map_mappingdevContext.class) {
-      checkMapMappingDev((CICSParser.Cics_receive_map_mappingdevContext) ctx);
+    switch (ctx.getRuleIndex()) {
+      case CICSParser.RULE_cics_receive_group_one:
+        checkGroupOne((CICSParser.Cics_receive_group_oneContext) ctx);
+        break;
+      case CICSParser.RULE_cics_receive_partn:
+        checkPartn((CICSParser.Cics_receive_partnContext) ctx);
+        break;
+      case CICSParser.RULE_cics_receive_map:
+        checkMap((CICSParser.Cics_receive_mapContext) ctx);
+        break;
+      case CICSParser.RULE_cics_receive_map_mappingdev:
+        checkMapMappingDev((CICSParser.Cics_receive_map_mappingdevContext) ctx);
+        break;
+      default:
+        break;
     }
     checkDuplicates(ctx);
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSWaitOptionsCheckUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSWaitOptionsCheckUtility.java
@@ -67,16 +67,25 @@ public class CICSWaitOptionsCheckUtility extends CICSOptionsCheckBaseUtility {
    * @param <E> A subclass of ParserRuleContext
    */
   public <E extends ParserRuleContext> void checkOptions(E ctx) {
-    if (ctx.getClass() == CICSParser.Cics_wait_convidContext.class)
-      checkConvid((CICSParser.Cics_wait_convidContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_wait_eventContext.class)
-      checkEvent((CICSParser.Cics_wait_eventContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_wait_externalContext.class)
-      checkExternal((CICSParser.Cics_wait_externalContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_wait_journalnameContext.class)
-      checkJournalName((CICSParser.Cics_wait_journalnameContext) ctx);
-    else if (ctx.getClass() == CICSParser.Cics_wait_terminalContext.class)
-      checkTerminal((CICSParser.Cics_wait_terminalContext) ctx);
+    switch (ctx.getRuleIndex()) {
+      case CICSParser.RULE_cics_wait_convid:
+        checkConvid((CICSParser.Cics_wait_convidContext) ctx);
+        break;
+      case CICSParser.RULE_cics_wait_event:
+        checkEvent((CICSParser.Cics_wait_eventContext) ctx);
+        break;
+      case CICSParser.RULE_cics_wait_external:
+        checkExternal((CICSParser.Cics_wait_externalContext) ctx);
+        break;
+      case CICSParser.RULE_cics_wait_journalname:
+        checkJournalName((CICSParser.Cics_wait_journalnameContext) ctx);
+        break;
+      case CICSParser.RULE_cics_wait_terminal:
+        checkTerminal((CICSParser.Cics_wait_terminalContext) ctx);
+        break;
+      default:
+        break;
+    }
     checkDuplicates(ctx);
   }
 


### PR DESCRIPTION
Change getClass to use the Rule Index instead.

## How Has This Been Tested?

Ran all existing unit tests, which passed without issue. These changes only affect how we get into the functions by using the ruleIndex property instead of constantly getting and comparing the classes of the context object. This should result in faster operation as it is now comparing integers. Especially on the larger classes such as with `ISSUE`.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
