### PR TITLE
chore: better formatting for logging of time measurements

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/benchmark/BenchmarkServiceImpl.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/benchmark/BenchmarkServiceImpl.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.text.DecimalFormat;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
@@ -64,8 +65,10 @@ public class BenchmarkServiceImpl implements BenchmarkService {
     LOG.debug("---- Benchmark for uri : {}", benchmarkSession.attr("uri"));
     Collection<Measurement> measurements = benchmarkSession
             .getMeasurements();
+
     measurements
-            .forEach(m -> LOG.debug("Timing for {}: {}", m.getId(), m.getTime()));
+            .forEach(m -> LOG.debug("Timing for {}: {} ns", m.getId(), new DecimalFormat("#,###")
+                    .format(m.getTime())));
     Optional.ofNullable(System.getProperty(PERFORMANCE_LOG_PATH))
             .map(Paths::get)
             .ifPresent(path -> {


### PR DESCRIPTION
```
17:30:38.412 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - ---- Benchmark for uri : file:///Users/ishche/projects/team-build_cobol/CASE1.cbl
17:30:38.412 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Compiler Directives processing: 49,416 ns
17:30:38.412 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Preprocessing: 673,250 ns
17:30:38.412 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Dialects processing: 31,125 ns
17:30:38.412 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Transform tree: 4,722,333 ns
17:30:38.412 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for dialects compiler directives processing: 580,125 ns
17:30:38.412 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Implicit dialects processing: 287,916 ns
17:30:38.412 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Cleanup document processing: 2,641,750 ns
17:30:38.412 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Parsing stage: 592,792 ns
```

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
