### PR TITLE
fix: Fix copybook text insertion for multiline statements

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedText.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedText.java
@@ -162,7 +162,9 @@ public class ExtendedText {
       ExtendedTextLine copybookLine = copybook.lines.get(0);
       ExtendedTextLine firstLine = lines.get(initialLine);
       copybookLine.trim();
-      firstLine.insert(copyStatementRange.getEnd().getCharacter(), updateLine(copybookLine, initialLocation));
+
+      delete(copyStatementRange);
+      firstLine.insert(copyStatementRange.getStart().getCharacter(), updateLine(copybookLine, initialLocation));
 
       for (int i = 1; i < copybook.lines.size() - 1; i++) {
         copybookLine = copybook.lines.get(i);

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -20,7 +20,6 @@ import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for ExtendedText class
@@ -363,13 +362,13 @@ class ExtendedTextTest {
     Range range = new Range(new Position(1, 2), new Position(2, 4));
     ExtendedText extendedText = new ExtendedText("example_text\nexample_text", "example_uri");
     ExtendedText copybook1 = new ExtendedText("COPY1 LINE 0\nCOPY1 LINE 1\nCOPY1 LINE 2", "copybook1");
-    ExtendedText expectedCopybook = new ExtendedText("COPY1 LINE 0\nCO  example_text        \n  example_text      LINE 2", "copybook1");
+    ExtendedText expectedCopybook = new ExtendedText("COPY1 LINE 0\nCOexample_text\n  example_text LINE 2", "copybook1");
 
     copybook1.insertWithPadding(range, extendedText);
 
-    assertTrue(copybook1.getLines().get(0).toString().equals(expectedCopybook.getLines().get(0).toString()));
-    assertTrue(copybook1.getLines().get(1).toString().equals(expectedCopybook.getLines().get(1).toString()));
-    assertTrue(copybook1.getLines().get(2).toString().equals(expectedCopybook.getLines().get(2).toString()));
+    assertEquals(expectedCopybook.getLines().get(0).toString(), copybook1.getLines().get(0).toString());
+    assertEquals(expectedCopybook.getLines().get(1).toString(), copybook1.getLines().get(1).toString());
+    assertEquals(expectedCopybook.getLines().get(2).toString(), copybook1.getLines().get(2).toString());
   }
 
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/copybooks/CopybookPreprocessorService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/copybooks/CopybookPreprocessorService.java
@@ -99,7 +99,6 @@ class CopybookPreprocessorService {
                           int maxCopybookLen, List<ReplacementContext> replacementContext) {
     CopybookName name = getCopybookName(copySource);
     String copybookName = name.getQualifiedName();
-    String copybookId = name.toCopybookId(programDocumentUri).toString();
 
     Range range = VisitorHelper.constructRange(ctx);
     Locality nameLocality = mapLocality(retrieveLocality(copySource));

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCopybookMultilineMapping.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCopybookMultilineMapping.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.CobolText;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks for the copybook multiline statement
+ */
+class TestCopybookMultilineMapping {
+
+  private static final String TEXT =
+      "        IDENTIFICATION DIVISION.\r\n"
+          + "        PROGRAM-ID. test1.\r\n"
+          + "        DATA DIVISION.\r\n"
+          + "        WORKING-STORAGE SECTION.\r\n"
+          + "        PROCEDURE DIVISION.\r\n"
+          + "           DISPLAY COPY\r\n"
+          + "           {~COPY1}. .\r\n";
+
+  private static final String COPY = "            \"scenario 4\"";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(new CobolText("COPY1", COPY)), ImmutableMap.of());
+  }
+}


### PR DESCRIPTION
## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
