### PR TITLE
Add root "gen" folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,9 +108,6 @@ local.properties
 
 # ANTLR plugin
 /server/engine/gen
-/server/dialect-idms/gen
-/server/dialect-daco/gen
-/server/test/gen
 /server/parser/gen
 .antlr/
 gen/

--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ local.properties
 /server/test/gen
 /server/parser/gen
 .antlr/
+gen/
 
 # TeXlipse plugin
 .texlipse


### PR DESCRIPTION
Added the root "gen" folder to the gitignore. This should stop the generated files from showing when trying to do or track the contents of a commit.

## How Has This Been Tested?

Saw generated files in list of possible options, added the folder to the gitignore, no longer have those files showing.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
