### PR TITLE
chore: add correct typings and fix other warnings reported by ESLint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Install dependencies for COBOL LS
         working-directory: clients/cobol-lsp-vscode-extension
         run: npm ci
+      - name: Install & Build VS Code extension dialect API
+        working-directory: clients/cobol-dialect-api
+        run: |
+          npm ci
+          npm run compile     
       - name: Check code formatting for COBOL LS
         working-directory: clients/cobol-lsp-vscode-extension
         run: npm run lint-format
@@ -410,9 +415,7 @@ jobs:
         if: github.event.inputs.skip_ui_tests != 'true'
         uses: coactions/setup-xvfb@v1
         with:
-          run: |
-            npm run compile
-            npm run test:integration
+          run: npm run test:integration
           working-directory: clients/cobol-lsp-vscode-extension          
       - name: Run native executable test code
         working-directory: tests/native-executable-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,6 +411,9 @@ jobs:
           unzip -j dialects-daco/*.vsix extension/dist/extension.js extension/dist/extension.js.map -d clients/daco-dialect-support/dist/
           unzip -j dialects-daco/*.vsix extension/server/jar/dialect-daco.jar -d clients/daco-dialect-support/server/jar
         shell: bash
+      - name: Run extension unit tests
+        run: npm run test
+        working-directory: clients/cobol-lsp-vscode-extension
       - name: Run integration tests
         if: github.event.inputs.skip_ui_tests != 'true'
         uses: coactions/setup-xvfb@v1

--- a/clients/cobol-lsp-vscode-extension/eslint.config.mjs
+++ b/clients/cobol-lsp-vscode-extension/eslint.config.mjs
@@ -8,10 +8,16 @@ export default [
     languageOptions: {
       ecmaVersion: 8,
       globals: { ...globals.node, ...globals.jest },
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+        allowDefaultProject: ["*.mjs"],
+      },
     },
   },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
   {
     rules: {
       "prefer-const": [
@@ -20,7 +26,6 @@ export default [
           destructuring: "all",
         },
       ],
-      "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
@@ -32,6 +37,12 @@ export default [
         "error",
         { allowAsImport: true },
       ],
+    },
+  },
+  {
+    files: ["**/*.spec.ts"],
+    rules: {
+      "@typescript-eslint/unbound-method": "off",
     },
   },
 ];

--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -598,6 +598,7 @@
     "pretty": "prettier -w .",
     "watch": "tsc -watch -p ./",
     "test": "jest -w 1 --unhandled-rejections=strict",
+    "test-watch": "jest --watchAll -w 1 --unhandled-rejections=strict",
     "coverage": "jest --coverage --runInBand",
     "package": "vsce package --no-dependencies",
     "package:web": "vsce package --target web --no-dependencies"

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/UriMock.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/UriMock.ts
@@ -6,9 +6,9 @@ export class Uri {
   }
 
   static file(str: string): Uri {
-    const p = str.replace(/\\/g, "/");
-
-    return new Uri((p[1] === ":" ? "/" : "") + p);
+    // const p = str.replace(/\\/g, "/");
+    return new Uri(str);
+    // return new Uri((p[1] === ":" ? "/" : "") + p);
   }
 
   static joinPath(base: Uri, ...pathSegments: string[]): Uri {

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/UriMock.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/UriMock.ts
@@ -6,9 +6,7 @@ export class Uri {
   }
 
   static file(str: string): Uri {
-    // const p = str.replace(/\\/g, "/");
     return new Uri(str);
-    // return new Uri((p[1] === ":" ? "/" : "") + p);
   }
 
   static joinPath(base: Uri, ...pathSegments: string[]): Uri {

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/child_process.utility.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/child_process.utility.ts
@@ -14,7 +14,12 @@
 import * as cp from "child_process";
 import { PassThrough } from "stream";
 
-export function mockSpawnProcess(stdout: string, stderr: string, exitCode = 0) {
+export function mockSpawnProcess(
+  stdout: string,
+  stderr: string,
+  exitCode = 0,
+  error?: string,
+) {
   const stdoutStream = new PassThrough();
   const stderrStream = new PassThrough();
 
@@ -22,6 +27,11 @@ export function mockSpawnProcess(stdout: string, stderr: string, exitCode = 0) {
     stdout: stdoutStream,
     stderr: stderrStream,
     on: (event, callback) => {
+      if (event === "error" && error) {
+        stdoutStream.emit("data", stdout);
+        stderrStream.emit("data", stderr);
+        callback(error, null);
+      }
       if (event === "close") {
         stdoutStream.emit("data", stdout);
         stderrStream.emit("data", stderr);

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/getZoweExplorerMock.utility.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/getZoweExplorerMock.utility.ts
@@ -24,10 +24,20 @@ export const allMemberMock = jest.fn().mockReturnValue({
     ],
   },
 });
-const error = new Error("Error");
-(error as any).mDetails = {
-  errorCode: 401,
-};
+class MemberError extends Error {
+  mDetails: {
+    errorCode: number;
+  };
+
+  constructor(message: string) {
+    super(message);
+    this.mDetails = {
+      errorCode: 401,
+    };
+  }
+}
+const error = new MemberError("Error");
+
 export const allMemberErrorMock = jest.fn().mockRejectedValue(error);
 export const mvsApiMock = jest.fn().mockReturnValue({
   allMembers: allMemberMock,

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode-languageclient/node.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode-languageclient/node.ts
@@ -1,0 +1,6 @@
+export const LanguageClient = jest.fn();
+export const DidChangeConfigurationNotification = jest.fn();
+export const GenericNotificationHandler = jest.fn();
+export const GenericRequestHandler = jest.fn();
+export const LanguageClientOptions = jest.fn();
+export const StreamInfo = jest.fn();

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/CommentCommandTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/CommentCommandTest.spec.ts
@@ -12,6 +12,7 @@
  *   Broadcom, Inc. - initial API and implementation
  */
 
+import { TextEditorEdit } from "../__mocks__/vscode";
 import {
   CommentAction,
   commentLine,
@@ -183,7 +184,7 @@ describe("Validate ToggleComments", () => {
       edit: jest.fn(),
     } as unknown as vscode.TextEditor;
     new ToggleComments(textEditor, CommentAction.TOGGLE).doIt();
-    expect(textEditor.edit).toBeCalledTimes(0);
+    expect(textEditor.edit).toHaveBeenCalledTimes(0);
   });
 
   // selection[0]
@@ -199,7 +200,7 @@ describe("Validate ToggleComments", () => {
   // selection[3]
   // 25:      d  debug command
 
-  const documentLines = {
+  const documentLines: Record<number, { text: string; range: vscode.Range }> = {
     5: {
       text: "       01  WS-POINT.",
       range: getRange(5, 0, 5, 20),
@@ -221,9 +222,6 @@ describe("Validate ToggleComments", () => {
       range: getRange(25, 0, 25, 22),
     },
   };
-  const editBuilder = {
-    replace: jest.fn(),
-  };
   const textEditor = {
     selections: [
       getRange(5, 12, 6, 25),
@@ -234,37 +232,37 @@ describe("Validate ToggleComments", () => {
     document: {
       lineAt: jest
         .fn()
-        .mockImplementation(
-          (line) => documentLines[line as keyof typeof documentLines],
-        ),
+        .mockImplementation((line: number) => documentLines[line]),
       eol: vscode.EndOfLine.LF,
     },
-    edit: jest.fn().mockImplementation((callback) => callback(editBuilder)),
+    edit: jest
+      .fn()
+      .mockImplementation((callback: (param: unknown) => void) =>
+        callback(TextEditorEdit),
+      ),
   } as unknown as vscode.TextEditor;
 
   afterEach(() => {
-    editBuilder.replace.mockClear();
-    (textEditor.document.lineAt as any).mockClear();
-    (textEditor.edit as any).mockClear();
+    jest.clearAllMocks();
   });
 
   test("with toggle action", () => {
     new ToggleComments(textEditor, CommentAction.TOGGLE).doIt();
     checkCommonCalls();
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(5, 0, 6, 45),
       "      *01  WS-POINT.\n" +
         "      *    05 WS-POINTER USAGE    IS POINTER.",
     );
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(14, 0, 14, 44),
       "           DISPLAY 'From P1:' BAR of FOOBAR.",
     );
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(20, 0, 20, 33),
       '      *    "LLLLLLLLLLMMMMMMMMMM"',
     );
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(25, 0, 25, 22),
       "      *  debug command",
     );
@@ -273,20 +271,20 @@ describe("Validate ToggleComments", () => {
   test("with comment action", () => {
     new ToggleComments(textEditor, CommentAction.COMMENT).doIt();
     checkCommonCalls();
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(5, 0, 6, 45),
       "      *01  WS-POINT.\n" +
         "      *    05 WS-POINTER USAGE    IS POINTER.",
     );
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(14, 0, 14, 44),
       "      **    DISPLAY 'From P1:' BAR of FOOBAR.",
     );
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(20, 0, 20, 33),
       '      *    "LLLLLLLLLLMMMMMMMMMM"',
     );
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(25, 0, 25, 22),
       "      *  debug command",
     );
@@ -295,20 +293,20 @@ describe("Validate ToggleComments", () => {
   test("with uncomment action", () => {
     new ToggleComments(textEditor, CommentAction.UNCOMMENT).doIt();
     checkCommonCalls();
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(5, 0, 6, 45),
       "       01  WS-POINT.\n" +
         "           05 WS-POINTER USAGE    IS POINTER.",
     );
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(14, 0, 14, 44),
       "           DISPLAY 'From P1:' BAR of FOOBAR.",
     );
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(20, 0, 20, 33),
       '      -    "LLLLLLLLLLMMMMMMMMMM"',
     );
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(25, 0, 25, 22),
       "      d  debug command",
     );
@@ -329,34 +327,39 @@ describe("Validate ToggleComments", () => {
       document: {
         lineAt: jest.fn().mockImplementation(
           (line: number) =>
-            documentLines[line as keyof typeof documentLines] ?? {
+            documentLines[line] ?? {
               text: "",
               range: getRange(line, 0, line, 0),
             },
         ),
         eol: vscode.EndOfLine.LF,
       },
-      edit: jest.fn().mockImplementation((callback) => callback(editBuilder)),
+      edit: jest
+        .fn()
+        .mockImplementation(
+          (callback: (param: vscode.TextEditorEdit) => void) =>
+            callback(TextEditorEdit),
+        ),
     } as unknown as vscode.TextEditor;
     new ToggleComments(mixedTextEditor, CommentAction.TOGGLE).doIt();
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(5, 0, 6, 45),
       "      *01  WS-POINT.\n" +
         "      *    05 WS-POINTER USAGE    IS POINTER.",
     );
-    expect(editBuilder.replace).toBeCalledWith(
+    expect(TextEditorEdit.replace).toHaveBeenCalledWith(
       getRange(14, 0, 14, 44),
       "           DISPLAY 'From P1:' BAR of FOOBAR.",
     );
   });
 
   function checkCommonCalls() {
-    expect(textEditor.document.lineAt).toBeCalledTimes(5);
-    expect(textEditor.document.lineAt).toBeCalledWith(5);
-    expect(textEditor.document.lineAt).toBeCalledWith(6);
-    expect(textEditor.document.lineAt).toBeCalledWith(14);
-    expect(textEditor.edit).toBeCalledTimes(1);
-    expect(editBuilder.replace).toBeCalledTimes(4);
+    expect(textEditor.document.lineAt).toHaveBeenCalledTimes(5);
+    expect(textEditor.document.lineAt).toHaveBeenCalledWith(5);
+    expect(textEditor.document.lineAt).toHaveBeenCalledWith(6);
+    expect(textEditor.document.lineAt).toHaveBeenCalledWith(14);
+    expect(textEditor.edit).toHaveBeenCalledTimes(1);
+    expect(TextEditorEdit.replace).toHaveBeenCalledTimes(4);
   }
 });
 
@@ -365,15 +368,9 @@ function getRange(
   startCharacter: number,
   endLine: number,
   endCharacter: number,
-) {
-  return {
-    start: {
-      line: startLine,
-      character: startCharacter,
-    },
-    end: {
-      line: endLine,
-      character: endCharacter,
-    },
-  };
+): vscode.Range {
+  return new vscode.Range(
+    new vscode.Position(startLine, startCharacter),
+    new vscode.Position(endLine, endCharacter),
+  );
 }

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/ClearCopybookCacheCommand.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/ClearCopybookCacheCommand.spec.ts
@@ -15,28 +15,6 @@
 import { clearCache } from "../../commands/ClearCopybookCacheCommand";
 import * as vscode from "vscode";
 
-jest.mock("vscode", () => ({
-  Uri: {
-    joinPath: (uri: { path: string }, ...segments: string[]) => {
-      const result = { ...uri };
-      result.path =
-        uri.path + (uri.path.endsWith("/") ? "" : "/") + segments.join("/");
-      return result;
-    },
-  },
-  window: {
-    setStatusBarMessage: jest.fn().mockResolvedValue(true),
-    showInformationMessage: jest
-      .fn()
-      .mockImplementation((message: string) => Promise.resolve(message)),
-  },
-  workspace: {
-    fs: {
-      delete: jest.fn().mockReturnValue(true),
-      readDirectory: jest.fn().mockResolvedValue([["fileName", 2]]),
-    },
-  },
-}));
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -47,7 +25,7 @@ afterAll(() => {
 
 describe("Tests downloaded copybook cache clear", () => {
   it("verify that the clearCache tries to delete cache directories", async () => {
-    await clearCache({ path: "/storagePath" } as any as vscode.Uri);
+    await clearCache(vscode.Uri.file("/storagePath"));
     expect(vscode.workspace.fs.readDirectory).toHaveBeenNthCalledWith(1, {
       path: "/storagePath/zowe/copybooks",
     });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/FetchCopybookCommandTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/FetchCopybookCommandTest.spec.ts
@@ -30,11 +30,11 @@ test("Test fetchCopybookCommand calls telementry services and copybook download 
   const copybookDownloadService: CopybookDownloadService =
     new CopybookDownloadService(
       "./storage-path",
-      {} as any as IApiRegisterClient,
+      {} as unknown as IApiRegisterClient,
     );
   copybookDownloadService.downloadCopybooks = jest.fn();
   expect(fetchCopybookCommand).toBeTruthy();
-  fetchCopybookCommand(copybook, copybookDownloadService, progName);
+  await fetchCopybookCommand(copybook, copybookDownloadService, progName);
   expect(TelemetryService.registerEvent).toHaveBeenCalledWith(
     "Fetch copybook",
     ["COBOL", "copybook", "quickfix"],

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/OpenSettingsCommandTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/OpenSettingsCommandTest.spec.ts
@@ -27,12 +27,12 @@ test("check gotoCopybookSettings calls telemetry services and vscode execute com
   expect(gotoCopybookSettings).toBeTruthy();
   gotoCopybookSettings();
 
-  expect(TelemetryService.registerEvent).toBeCalledWith(
+  expect(TelemetryService.registerEvent).toHaveBeenCalledWith(
     "Open copybook settings",
     ["COBOL", "copybook", "settings"],
     "The user invokes the open settings quick fix to see the copybook locations stored in the settings file",
   );
-  expect(vscode.commands.executeCommand).toBeCalledWith(
+  expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
     "workbench.action.openSettings",
     "cobol-lsp.cpy-manager",
   );

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/RunAnalysisCLITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/RunAnalysisCLITest.spec.ts
@@ -61,7 +61,7 @@ describe("Test Analysis CLI command functionality", () => {
 
     expect(runCobolAnalysisCommandSpy).toHaveBeenCalled();
     expect(getCurrentFileLocationSpy).toHaveBeenCalled();
-    expect(buildJavaCommandSpy).toHaveBeenCalledWith("/storagePath", true);
+    expect(buildJavaCommandSpy).toHaveBeenCalledWith("/storagePath");
     expect(buildJavaCommandSpy).toHaveReturnedWith(
       'java -jar "/test/server/jar/server.jar" analysis -s "/storagePath" -cf=.',
     );
@@ -115,7 +115,6 @@ describe("Test Analysis CLI command functionality", () => {
     expect(buildNativeCommandSpy).toHaveBeenCalledWith(
       "/storagePath",
       process.platform,
-      true,
     );
     expect(buildAnalysisCommandPortionSpy).toHaveReturnedWith(
       'analysis -s "/storagePath" -cf=.',
@@ -187,7 +186,7 @@ describe("Test Analysis CLI command functionality", () => {
       context.extensionUri,
     );
 
-    const result = testAnalysis["buildJavaCommand"]("", false);
+    const result = testAnalysis["buildJavaCommand"]("");
 
     expect(result).toBe("");
   });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/RunAnalysisCLITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/RunAnalysisCLITest.spec.ts
@@ -15,90 +15,9 @@
 import { RunAnalysis } from "../../commands/RunAnalysisCLI";
 import * as vscode from "vscode";
 
-jest.mock("vscode", () => ({
-  commands: {
-    registerCommand: jest
-      .fn()
-      .mockImplementation((command, callback) => callback()),
-    executeCommand: jest.fn(),
-  },
-  extensions: {
-    getExtension: jest.fn().mockReturnValue({ extensionPath: "/test" }),
-  },
-  FileType: {
-    Directory: 2,
-  },
-  languages: {
-    registerCodeActionsProvider: jest.fn(),
-    registerCompletionItemProvider: jest.fn(),
-  },
-  window: {
-    activeTextEditor: {
-      document: {
-        uri: {
-          path: "/storagePath",
-          fsPath: "/storagePath",
-          scheme: "file",
-        },
-        getText: jest.fn(),
-      },
-    },
-    setStatusBarMessage: jest
-      .fn()
-      .mockImplementation(
-        async (_text: string, _hideWhenDone: Thenable<any>) => {
-          return Promise.resolve(true);
-        },
-      ),
-    showErrorMessage: jest.fn().mockReturnValue("test"),
-    showInformationMessage: jest
-      .fn()
-      .mockImplementation((message: string) => Promise.resolve(message)),
-    showQuickPick: jest.fn(),
-    onDidChangeActiveTextEditor: jest.fn(),
-    createQuickPick: jest
-      .fn()
-      .mockReturnValue({ onDidChangeSelection: jest.fn(), show: jest.fn() }),
-    createOutputChannel: jest.fn().mockReturnValue({
-      appendLine: jest.fn(),
-    }),
-    terminals: {
-      find: jest.fn(),
-    },
-    createTerminal: jest.fn().mockReturnValue({
-      sendText: jest.fn(),
-      show: jest.fn(),
-    }),
-  },
-  workspace: {
-    getConfiguration: jest.fn().mockReturnValue({
-      get: jest.fn().mockReturnValue(9),
-    }),
-    getWorkspaceFolder: jest.fn().mockReturnValue({ name: "workspaceFolder1" }),
-    onDidChangeConfiguration: jest
-      .fn()
-      .mockReturnValue("onDidChangeConfiguration"),
-    workspaceFolders: [{ uri: { fsPath: "ws-path" } } as any],
-    fs: {
-      createDirectory: jest.fn(),
-      readDirectory: jest.fn().mockReturnValue([]),
-      stat: jest.fn().mockReturnValue(2),
-      writeFile: jest.fn(),
-    },
-  },
-  Uri: {
-    joinPath: jest.fn().mockImplementation((inputUri: vscode.Uri, path) => {
-      return {
-        path: inputUri.path + path,
-        fsPath: inputUri.fsPath + path,
-      };
-    }),
-  },
-}));
-
-const context: any = {
-  extensionUri: { fsPath: "/test" },
-  globalStorageUri: { fsPath: "/storagePath" },
+const context = {
+  extensionUri: vscode.Uri.file("/test"),
+  globalStorageUri: vscode.Uri.file("/storagePath"),
   subscriptions: [],
 };
 
@@ -114,26 +33,29 @@ describe("Test Analysis CLI command functionality", () => {
       .mockReturnValue("Show");
 
     const runCobolAnalysisCommandSpy = jest.spyOn(
-      testAnalysis as any,
+      testAnalysis,
       "runCobolAnalysisCommand",
     );
     const getCurrentFileLocationSpy = jest.spyOn(
-      testAnalysis as any,
-      "getCurrentFileLocation",
+      testAnalysis,
+      "getCurrentFileLocation" as keyof RunAnalysis,
     );
     const buildJavaCommandSpy = jest.spyOn(
-      testAnalysis as any,
-      "buildJavaCommand",
+      testAnalysis,
+      "buildJavaCommand" as keyof RunAnalysis,
     );
     const buildNativeCommandSpy = jest.spyOn(
-      testAnalysis as any,
-      "buildNativeCommand",
+      testAnalysis,
+      "buildNativeCommand" as keyof RunAnalysis,
     );
     const buildAnalysisCommandPortionSpy = jest.spyOn(
-      testAnalysis as any,
-      "buildAnalysisCommandPortion",
+      testAnalysis,
+      "buildAnalysisCommandPortion" as keyof RunAnalysis,
     );
-    const sendToTerminalSpy = jest.spyOn(testAnalysis as any, "sendToTerminal");
+    const sendToTerminalSpy = jest.spyOn(
+      testAnalysis,
+      "sendToTerminal" as keyof RunAnalysis,
+    );
 
     await testAnalysis.runCobolAnalysisCommand();
 
@@ -162,26 +84,29 @@ describe("Test Analysis CLI command functionality", () => {
       .mockReturnValue("Show");
 
     const runCobolAnalysisCommandSpy = jest.spyOn(
-      testAnalysis as any,
+      testAnalysis,
       "runCobolAnalysisCommand",
     );
     const getCurrentFileLocationSpy = jest.spyOn(
-      testAnalysis as any,
-      "getCurrentFileLocation",
+      testAnalysis,
+      "getCurrentFileLocation" as keyof RunAnalysis,
     );
     const buildJavaCommandSpy = jest.spyOn(
-      testAnalysis as any,
-      "buildJavaCommand",
+      testAnalysis,
+      "buildJavaCommand" as keyof RunAnalysis,
     );
     const buildNativeCommandSpy = jest.spyOn(
-      testAnalysis as any,
-      "buildNativeCommand",
+      testAnalysis,
+      "buildNativeCommand" as keyof RunAnalysis,
     );
     const buildAnalysisCommandPortionSpy = jest.spyOn(
-      testAnalysis as any,
-      "buildAnalysisCommandPortion",
+      testAnalysis,
+      "buildAnalysisCommandPortion" as keyof RunAnalysis,
     );
-    const sendToTerminalSpy = jest.spyOn(testAnalysis as any, "sendToTerminal");
+    const sendToTerminalSpy = jest.spyOn(
+      testAnalysis,
+      "sendToTerminal" as keyof RunAnalysis,
+    );
 
     await testAnalysis.runCobolAnalysisCommand();
 
@@ -208,20 +133,17 @@ describe("Test Analysis CLI command functionality", () => {
     vscode.window.showQuickPick = jest.fn().mockReturnValue(undefined);
 
     const runCobolAnalysisCommandSpy = jest.spyOn(
-      testAnalysis as any,
+      testAnalysis,
       "runCobolAnalysisCommand",
     );
-    const getVersionToRunSpy = jest.spyOn(
-      testAnalysis as any,
-      "getVersionToRun",
-    );
+    const getVersionToRunSpy = jest.spyOn(testAnalysis, "getVersionToRun");
     const buildJavaCommandSpy = jest.spyOn(
-      testAnalysis as any,
-      "buildJavaCommand",
+      testAnalysis,
+      "buildJavaCommand" as keyof RunAnalysis,
     );
     const buildNativeCommandSpy = jest.spyOn(
-      testAnalysis as any,
-      "buildNativeCommand",
+      testAnalysis,
+      "buildNativeCommand" as keyof RunAnalysis,
     );
 
     await testAnalysis.runCobolAnalysisCommand();
@@ -249,7 +171,10 @@ describe("Test Analysis CLI command functionality", () => {
       );
     }
 
-    const saveTempFileSpy = jest.spyOn(testAnalysis as any, "saveTempFile");
+    const saveTempFileSpy = jest.spyOn(
+      testAnalysis,
+      "saveTempFile" as keyof RunAnalysis,
+    );
 
     await testAnalysis.runCobolAnalysisCommand();
 
@@ -262,7 +187,7 @@ describe("Test Analysis CLI command functionality", () => {
       context.extensionUri,
     );
 
-    const result = (testAnalysis as any).buildJavaCommand("");
+    const result = testAnalysis["buildJavaCommand"]("", false);
 
     expect(result).toBe("");
   });
@@ -273,16 +198,16 @@ describe("Test Analysis CLI command functionality", () => {
       context.extensionUri,
     );
 
-    let result = (testAnalysis as any).getServerPath("initialPath", "win32");
+    let result = testAnalysis["getServerPath"]("initialPath", "win32");
     expect(result).toBe("initialPath");
 
-    result = (testAnalysis as any).getServerPath("initialPath", "linux");
+    result = testAnalysis["getServerPath"]("initialPath", "linux");
     expect(result).toBe("initialPath/server-linux");
 
-    result = (testAnalysis as any).getServerPath("initialPath", "darwin");
+    result = testAnalysis["getServerPath"]("initialPath", "darwin");
     expect(result).toBe("initialPath/server-mac");
 
-    result = (testAnalysis as any).getServerPath("initialPath", "other");
+    result = testAnalysis["getServerPath"]("initialPath", "other");
     expect(result).toBe("");
   });
 });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/SmartTabCommandTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/SmartTabCommandTest.spec.ts
@@ -12,89 +12,95 @@
  *   Broadcom, Inc. - initial API and implementation
  */
 
-import * as vscode from "../../__mocks__/vscode";
+import * as vscode from "vscode";
 import * as smartTab from "../../commands/SmartTabCommand";
 import { initSmartTab } from "../../commands/SmartTabCommand";
 import { TabRule, TabSettings } from "../../services/SmartTabSettings";
-import { Position, Selection, TextEditor } from "vscode";
+import { ExtensionContext, Position, Selection, TextEditor } from "vscode";
+import { asMutable } from "../../test/suite/testHelper";
+import { TextEditorEdit } from "../../__mocks__/vscode";
 
-const context: any = {
+const context = {
   subscriptions: [],
-};
+} as unknown as ExtensionContext;
 
 beforeEach(() => {
   jest.clearAllMocks();
-  context.subscriptions = [];
 });
 
 test("Test initSmartTab calls registerTextEditorCommand to bind 'tab button functionality' keys", () => {
   expect(initSmartTab).toBeTruthy();
   initSmartTab(context);
-  expect(vscode.commands.registerTextEditorCommand).toBeCalledTimes(2);
+  expect(vscode.commands.registerTextEditorCommand).toHaveBeenCalledTimes(2);
 });
 
-test("Default rule was choosen for empty rule list", () => {
+test("Default rule was chosen for empty rule list", () => {
   const tabSettings = new TabSettings([], new TabRule([5, 10, 15, 20], 60));
-  const rule = smartTab.getRule(vscode.TextEditor as any, 10, tabSettings);
+  const editor = {} as TextEditor;
+  const rule = smartTab.getRule(editor, 10, tabSettings);
 
   expect(rule.stops[0]).toBe(5);
   expect(rule.regex).toBeUndefined();
 });
 
-test("SmartTabCommandProvider execution", async () => {
+test("SmartTabCommandProvider execution", () => {
   const stp: smartTab.SmartTabCommandProvider =
     new smartTab.SmartTabCommandProvider(context, "some name");
   const active: Position = new Position(1, 2);
   const mockSelection: Selection = new Selection(active, active);
   const textLine = { text: "" };
-  const mockEditor: TextEditor = {
+  const mockEditor = {
     selections: [mockSelection],
     document: {
       lineAt: jest.fn().mockReturnValue(textLine),
     },
-  } as any;
-  stp.execute(mockEditor, { insert: jest.fn() } as any);
+  } as unknown as TextEditor;
+  stp.execute(mockEditor, TextEditorEdit);
   expect(mockEditor.selections[0].active.character).toBe(6);
 });
 
-test("Multitab SmartTabCommandProvider execution", async () => {
+test("Multi tab SmartTabCommandProvider execution", () => {
   const stp: smartTab.SmartTabCommandProvider =
     new smartTab.SmartTabCommandProvider(context, "some name");
   const smartOut: smartTab.SmartTabCommandProvider =
     new smartTab.SmartOutdentCommandProvider(context, "some name");
   const active: Position = new Position(1, 2);
-  const mockSelection: Selection = new Selection(active, active);
-  (mockSelection as any).start = { line: 1 };
-  (mockSelection as any).end = { line: 3 };
+  const mockSelection = new Selection(active, active);
+  asMutable(mockSelection).start = new Position(1, 1);
+  asMutable(mockSelection).end = new Position(3, 1);
   const textLine = { text: "TEST" };
-  const mockEditor: TextEditor = {
+  const mockEditor = {
     selections: [mockSelection],
     document: {
       lineAt: jest.fn().mockReturnValue(textLine),
     },
-  } as any;
-  stp.execute(mockEditor, { insert: jest.fn() } as any);
-  smartOut.execute(mockEditor, { insert: jest.fn(), delete: jest.fn() } as any);
+  } as unknown as TextEditor;
+  stp.execute(mockEditor, TextEditorEdit);
+  smartOut.execute(mockEditor, TextEditorEdit);
   expect(mockEditor.selections.length).toBe(1);
   expect(mockEditor.selections[0].start.line).toBe(1);
   expect(mockEditor.selections[0].end.line).toBe(3);
 });
 
-test("One of the rule was choosen", () => {
+test("One of the rule was chosen", () => {
   const rule1 = new TabRule([11, 12, 13, 14], 14, "MATCHED");
   const rule2 = new TabRule([15, 16, 17, 18], 18, "TEST");
 
-  vscode.TextEditor.document.lineAt = jest.fn().mockImplementation((line) => {
-    if (line >= 9) return { text: "line9" };
+  const mockEditor = {
+    document: {
+      lineAt: jest.fn().mockImplementation((line) => {
+        if (line >= 9) return { text: "line9" };
 
-    return { text: "MATCHED" };
-  });
+        return { text: "MATCHED" };
+      }),
+    },
+  } as unknown as TextEditor;
 
   const tabSettings = new TabSettings(
     [rule1, rule2],
     new TabRule([5, 10, 15, 20], 60),
   );
-  const rule = smartTab.getRule(vscode.TextEditor as any, 10, tabSettings);
+  const rule = smartTab.getRule(mockEditor, 10, tabSettings);
 
   expect(rule.stops[0]).toBe(11);
   expect(rule.regex).toBe("MATCHED");

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/LanguageClientServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/LanguageClientServiceTest.spec.ts
@@ -24,6 +24,7 @@ import { TelemetryService } from "../../services/reporter/TelemetryService";
 import { Utils } from "../../services/util/Utils";
 import { EXP_LANGUAGE_ID, HP_LANGUAGE_ID } from "../../constants";
 import { mockSpawnProcess } from "../../__mocks__/child_process.utility";
+import { getErrorMessage } from "../../services/util/ErrorsUtils";
 
 jest.mock("../../services/reporter/TelemetryService");
 jest.mock("../../services/copybook/CopybookURI");
@@ -53,9 +54,6 @@ jest.mock("vscode", () => ({
 jest.mock("vscode-languageclient/node", () => ({
   LanguageClient: jest.fn(),
 }));
-jest.mock("fs", () => ({
-  fs: jest.fn(),
-}));
 
 Utils.getZoweExplorerAPI = jest.fn();
 let languageClientService: LanguageClientService;
@@ -65,9 +63,6 @@ const SERVER_ID = "cobol";
 
 beforeEach(() => {
   jest.clearAllMocks();
-  vscode.workspace.getConfiguration(expect.any(String)).get = jest
-    .fn()
-    .mockReturnValue(0);
   vscode.workspace.createFileSystemWatcher = jest.fn();
 });
 
@@ -75,23 +70,14 @@ const SERVER_STOPPED_MSG = "server stopped";
 describe("LanguageClientService positive scenario", () => {
   beforeEach(() => {
     languageClientService = new LanguageClientService(
-      jest.fn() as any,
+      vscode.window.createOutputChannel("test"),
       vscode.Uri.file("/storagePath"),
     );
     new JavaCheck().isJavaInstalled = jest.fn().mockResolvedValue(true);
-    vscode.workspace.getConfiguration(expect.any(String)).get = jest
-      .fn()
-      .mockReturnValue(0);
-    (fs.existsSync as any) = jest.fn().mockReturnValue(true);
   });
 
-  test("Test LanguageClientService switches native flag", async () => {
-    (languageClientService as any).initializeExecutables = jest.fn();
-    (fs.existsSync as any) = jest.fn().mockReturnValue(true);
-    Object.defineProperty(fs, "existsSync", { value: jest.fn() });
-    vscode.workspace.getConfiguration(expect.any(String)).get = jest
-      .fn()
-      .mockReturnValue(9999);
+  test("Test LanguageClientService switches native flag", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
     languageClientService.enableNativeBuild();
 
     expect(TelemetryService.registerEvent).toHaveBeenCalledWith(
@@ -99,7 +85,7 @@ describe("LanguageClientService positive scenario", () => {
       ["COBOL", "native build enabled", "settings"],
       "Native build enabled",
     );
-    expect((languageClientService as any).isNativeBuildEnabled).toBeTruthy();
+    expect(languageClientService["isNativeBuildEnabled"]).toBeTruthy();
   });
 
   test("Test LanguageClientService checkPrerequisites passes", async () => {
@@ -136,10 +122,8 @@ describe("LanguageClientService positive scenario", () => {
 
     try {
       await languageClientService.checkPrerequisites();
-    } catch (error: unknown) {
-      if (typeof error === "string") {
-        message = error;
-      }
+    } catch (error) {
+      message = getErrorMessage(error);
     }
     expect(message).toEqual(
       "An error occurred when checking if Java was installed. Switching to native build.",
@@ -162,9 +146,7 @@ describe("LanguageClientService positive scenario", () => {
     try {
       await languageClientService.checkPrerequisites();
     } catch (error: unknown) {
-      if (typeof error === "string") {
-        message = error;
-      }
+      message = getErrorMessage(error);
     }
     expect(message).toEqual(
       "Minimum expected Java version is 8. Switching to native builds",
@@ -212,7 +194,7 @@ describe("LanguageClientService positive scenario", () => {
       },
       {
         documentSelector: [SERVER_ID, EXP_LANGUAGE_ID, HP_LANGUAGE_ID],
-        outputChannel: expect.any(Function),
+        outputChannel: vscode.window.createOutputChannel("test"),
         synchronize: {
           fileEvents: [undefined, undefined],
         },
@@ -222,9 +204,7 @@ describe("LanguageClientService positive scenario", () => {
 
   test("LanguageClientService starts the language server when port is provided", async () => {
     new JavaCheck().isJavaInstalled = jest.fn().mockResolvedValue(true);
-    vscode.workspace.getConfiguration(expect.any(String)).get = jest
-      .fn()
-      .mockReturnValue(9999);
+    vscode.workspace.getConfiguration().get = jest.fn().mockReturnValue(9999);
     LanguageClient.prototype.start = jest
       .fn()
       .mockReturnValue(Promise.resolve());
@@ -236,7 +216,7 @@ describe("LanguageClientService positive scenario", () => {
       {
         documentSelector: [SERVER_ID, EXP_LANGUAGE_ID, HP_LANGUAGE_ID],
 
-        outputChannel: expect.any(Function),
+        outputChannel: vscode.window.createOutputChannel("test"),
         synchronize: {
           fileEvents: [undefined, undefined, undefined],
         },
@@ -249,7 +229,7 @@ describe("LanguageClientService positive scenario", () => {
       .fn()
       .mockReturnValue(SERVER_STOPPED_MSG);
     // start the server, before shutdown.
-    languageClientService.start();
+    await languageClientService.start();
     const returnedValue = await languageClientService.stop();
     expect(returnedValue).toBe(SERVER_STOPPED_MSG);
   });
@@ -257,47 +237,47 @@ describe("LanguageClientService positive scenario", () => {
   test("LanguageClientServer detects executable path for windows", () => {
     const spy = jest.spyOn(os, "type");
     spy.mockReturnValue("Windows_NT");
-    (languageClientService as any).executableService =
-      new NativeExecutableService("/test");
-    const executable = (
-      languageClientService as any
-    ).executableService.getNativeLanguageClient();
-    expect(executable.command).toBe("engine.exe");
-    expect(executable.options.cwd).toBe(join("/test", "native"));
+    languageClientService["executableService"] = new NativeExecutableService(
+      "/test",
+    );
+    const executable =
+      languageClientService["executableService"].getNativeLanguageClient();
+    expect(executable?.command).toBe("engine.exe");
+    expect(executable?.options?.cwd).toBe(join("/test", "native"));
   });
 
   test("LanguageClientServer detects executable path for Linux", () => {
     const spy = jest.spyOn(os, "type");
     spy.mockReturnValue("Linux");
-    (languageClientService as any).executableService =
-      new NativeExecutableService("/test");
-    const executable = (
-      languageClientService as any
-    ).executableService.getNativeLanguageClient();
-    expect(executable.command).toBe("./server-linux");
-    expect(executable.options.cwd).toBe(join("/test", "native"));
+    languageClientService["executableService"] = new NativeExecutableService(
+      "/test",
+    );
+    const executable =
+      languageClientService["executableService"].getNativeLanguageClient();
+    expect(executable?.command).toBe("./server-linux");
+    expect(executable?.options?.cwd).toBe(join("/test", "native"));
   });
 
   test("LanguageClientServer detects executable path for Mac", () => {
     const spy = jest.spyOn(os, "type");
     spy.mockReturnValue("Darwin");
-    (languageClientService as any).executableService =
-      new NativeExecutableService("/test");
-    const executable = (
-      languageClientService as any
-    ).executableService.getNativeLanguageClient();
-    expect(executable.command).toBe("./server-mac");
-    expect(executable.options.cwd).toBe(join("/test", "native"));
+    languageClientService["executableService"] = new NativeExecutableService(
+      "/test",
+    );
+    const executable =
+      languageClientService["executableService"].getNativeLanguageClient();
+    expect(executable?.command).toBe("./server-mac");
+    expect(executable?.options?.cwd).toBe(join("/test", "native"));
   });
 
   test("LanguageClientServer detects executable path for unKnown OS", () => {
     const spy = jest.spyOn(os, "type");
     spy.mockReturnValue("Android");
-    (languageClientService as any).executableService =
-      new NativeExecutableService("/test");
-    const executable = (
-      languageClientService as any
-    ).executableService.getNativeLanguageClient();
+    languageClientService["executableService"] = new NativeExecutableService(
+      "/test",
+    );
+    const executable =
+      languageClientService["executableService"].getNativeLanguageClient();
     expect(executable).toBeFalsy();
   });
 });
@@ -309,14 +289,14 @@ describe("LanguageClientService negative scenario.", () => {
       `java version "17.0.2" 2022-01-18 LTS\nJava(TM) SE Runtime Environment (build 17.0.2+8-LTS-86)\nJava HotSpot(TM) 64-Bit Server VM (build 17.0.2+8-LTS-86, mixed mode, sharing)\n`,
       0,
     );
-    (fs.existsSync as any) = jest.fn().mockReturnValue(false);
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
     try {
       await new LanguageClientService(
-        jest.fn() as any,
+        vscode.window.createOutputChannel("test"),
         vscode.Uri.file("/storagePath"),
       ).checkPrerequisites();
-    } catch (error: any) {
-      expect(error.toString()).toBe("Error: LSP server for cobol not found");
+    } catch (error) {
+      expect(error).toStrictEqual(new Error("LSP server for cobol not found"));
     }
     mockProcess.mockRestore();
   });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/LanguageClientServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/LanguageClientServiceTest.spec.ts
@@ -238,12 +238,12 @@ describe("LanguageClientService positive scenario", () => {
     const spy = jest.spyOn(os, "type");
     spy.mockReturnValue("Windows_NT");
     languageClientService["executableService"] = new NativeExecutableService(
-      "/test",
+      "C:\\test",
     );
     const executable =
       languageClientService["executableService"].getNativeLanguageClient();
     expect(executable?.command).toBe("engine.exe");
-    expect(executable?.options?.cwd).toBe(join("/test", "native"));
+    expect(executable?.options?.cwd).toBe(join("C:\\test", "native"));
   });
 
   test("LanguageClientServer detects executable path for Linux", () => {

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/SettingsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/SettingsTest.spec.ts
@@ -23,6 +23,8 @@ import {
 } from "../../services/DialectRegistry";
 
 import { asMutable } from "../../test/suite/testHelper";
+import { SETTINGS_CPY_LOCAL_PATH } from "../../constants";
+import * as extension from "../../extension";
 
 function makefsPath(p: string): string {
   return path.join(process.platform == "win32" ? "a:" : "", p);
@@ -314,6 +316,27 @@ describe("SettingService lspConfigHandler", () => {
     });
   });
 
+  describe("setting local copybook path section", () => {
+    beforeAll(() => {
+      jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+        get: () => ["local-copybooks"],
+      } as unknown as vscode.WorkspaceConfiguration);
+    });
+
+    test("returns local copybook path setting", async () => {
+      const result = await lspConfigHandler({
+        items: [
+          {
+            section: SETTINGS_CPY_LOCAL_PATH,
+            scopeUri: "file:///workspace/program.cob",
+          },
+        ],
+      });
+
+      expect(result).toEqual(expect.arrayContaining([["local-copybooks"]]));
+    });
+  });
+
   describe("unknown section", () => {
     test("returns matching vscode configuration item", async () => {
       const configurationValue = { random: "configuration" };
@@ -332,6 +355,36 @@ describe("SettingService lspConfigHandler", () => {
 
       expect(result).toEqual(expect.arrayContaining([configurationValue]));
       expect(configKey).toEqual("unknown.config.section");
+    });
+  });
+
+  describe("Invalid configuration provided", () => {
+    let outputChannelMock: jest.SpyInstance;
+    beforeAll(() => {
+      jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+        get: () => ["correct-path", 2, false],
+      } as unknown as vscode.WorkspaceConfiguration);
+
+      outputChannelMock = jest.fn();
+      jest.spyOn(extension, "getChannel").mockReturnValue({
+        appendLine: outputChannelMock,
+      } as unknown as vscode.OutputChannel);
+    });
+
+    test("returns empty setting instead of wrong configuration", async () => {
+      const result = await lspConfigHandler({
+        items: [
+          {
+            section: SETTINGS_CPY_LOCAL_PATH,
+            scopeUri: "file:///workspace/program.cob",
+          },
+        ],
+      });
+
+      expect(result).toEqual(expect.arrayContaining([]));
+      expect(outputChannelMock).toHaveBeenCalledWith(
+        "Invalid settings: cobol-lsp.cpy-manager.paths-local - Invalid value 2 supplied to : Array<string>/1: string\nInvalid value false supplied to : Array<string>/2: string",
+      );
     });
   });
 });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/SettingsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/SettingsTest.spec.ts
@@ -11,7 +11,6 @@
  * Contributors:
  *   Broadcom, Inc. - initial API and implementation
  */
-import { Uri } from "../../__mocks__/UriMock";
 import * as path from "path";
 import * as vscode from "vscode";
 import { lspConfigHandler, SettingsService } from "../../services/Settings";
@@ -23,27 +22,7 @@ import {
   DialectRegistry,
 } from "../../services/DialectRegistry";
 
-const fsPath = "tmp-ws";
-beforeAll(() => {
-  (vscode.workspace.workspaceFolders as any) = [
-    { uri: { fsPath: makefsPath(fsPath), path: makePath(fsPath) } } as any,
-  ];
-});
-
-// TODO: this is horrifying as well
-jest.mock("vscode", () => {
-  return {
-    Uri,
-    workspace: {
-      fs: {
-        readFile: jest.fn().mockImplementation(() => {
-          throw { code: "FileNotFound" };
-        }),
-      },
-      getWorkspaceFolder: () => {},
-    },
-  };
-});
+import { asMutable } from "../../test/suite/testHelper";
 
 function makefsPath(p: string): string {
   return path.join(process.platform == "win32" ? "a:" : "", p);
@@ -161,7 +140,7 @@ describe("SettingsService evaluate variables", () => {
       get: tracking,
     });
     await SettingsService.getCopybookLocalPath("PROGRAM", "COBOL");
-    expect(tracking).toBeCalledWith("paths-local");
+    expect(tracking).toHaveBeenCalledWith("paths-local");
   });
 
   test("Get local settings for dialect", async () => {
@@ -170,7 +149,7 @@ describe("SettingsService evaluate variables", () => {
       get: tracking,
     });
     await SettingsService.getCopybookLocalPath("PROGRAM", "MAID");
-    expect(tracking).toBeCalledWith("maid.paths-local");
+    expect(tracking).toHaveBeenCalledWith("maid.paths-local");
   });
 
   test("Get native build enable settings", () => {
@@ -179,24 +158,20 @@ describe("SettingsService evaluate variables", () => {
       get: tracking,
     });
     SettingsService.serverRuntime();
-    expect(tracking).toBeCalledWith("cobol-lsp.serverRuntime");
+    expect(tracking).toHaveBeenCalledWith("cobol-lsp.serverRuntime");
   });
 });
 
 test("getWorkspaceFoldersPath return an array of paths", () => {
-  (vscode.workspace.workspaceFolders as any) = [
-    { uri: { path: "/ws-vscode" } } as any,
+  asMutable(vscode.workspace).workspaceFolders = [
+    { uri: { path: "/ws-vscode" } } as vscode.WorkspaceFolder,
   ];
   const paths = SettingsUtils.getWorkspaceFoldersPath();
   expect(paths).toStrictEqual(["/ws-vscode"]);
 });
-test("json validation", () => {
-  expect(SettingsUtils.isValidJSON(undefined)).toBeFalsy();
-  expect(SettingsUtils.isValidJSON("{}")).toBeTruthy();
-});
 
 describe("SettingsService returns correct tab settings", () => {
-  test("Returns default tab settigs for boolean value", () => {
+  test("Returns default tab settings for boolean value", () => {
     vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
       get: jest.fn().mockReturnValue(true),
     });
@@ -205,7 +180,7 @@ describe("SettingsService returns correct tab settings", () => {
     expect(tabSettings.defaultRule.maxPosition).toBe(72);
   });
 
-  test("Max position is the last threashold position for array", () => {
+  test("Max position is the last threshold position for array", () => {
     vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
       get: jest.fn().mockReturnValue([1, 3, 5, 7, 25]),
     });
@@ -243,7 +218,7 @@ describe("SettingsService returns correct tab settings", () => {
 });
 
 describe("SettingsService returns correct Copybook Configuration Values", () => {
-  const mockConfigurationFetch = (settings: string, configuredValue: any) =>
+  const mockConfigurationFetch = (settings: string, configuredValue: unknown) =>
     jest.fn().mockReturnValue({
       get: (args: string) => {
         if (settings === args) {

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookResolveURITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookResolveURITest.spec.ts
@@ -11,11 +11,7 @@
  * Contributors:
  *   Broadcom, Inc. - initial API and implementation
  */
-jest.mock("glob");
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { globSync } from "glob";
-import { Uri } from "../../../__mocks__/UriMock";
+import * as glob from "glob";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as vscode from "vscode";
@@ -32,22 +28,6 @@ const copybookNameWithExtension: string = "NSTCOPY2.CPY";
 const CPY_FOLDER_NAME = ".cobcopy";
 const RELATIVE_CPY_FOLDER_NAME = "../relativeCobcopy";
 const folderPath = path.join(__dirname, CPY_FOLDER_NAME);
-
-jest.mock("vscode", () => {
-  const WS_URI = new Uri("/c:/my/workspace");
-  return {
-    Uri,
-    workspace: {
-      fs: {
-        readFile: jest.fn().mockImplementation(() => {
-          throw { code: "FileNotFound" };
-        }),
-      },
-      getWorkspaceFolder: () => ({ uri: WS_URI }),
-      workspaceFolders: [{ uri: WS_URI }],
-    },
-  };
-});
 
 SettingsUtils.getWorkspaceFoldersPath = jest.fn().mockReturnValue([__dirname]);
 vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
@@ -71,12 +51,12 @@ function removeFolder(targetPath: string) {
   return false;
 }
 
-async function buildResultArrayFrom(
+function buildResultArrayFrom(
   settingsMockValue: string[] | undefined,
   filename: string,
   profileName: string | undefined,
   ussPath: string[] = [],
-): Promise<number> {
+): number {
   vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
     get: jest.fn().mockReturnValueOnce(settingsMockValue),
   });
@@ -92,7 +72,7 @@ async function buildResultArrayFrom(
     filename,
     SettingsService.DEFAULT_DIALECT,
     path.join("downloadFolder", ZOWE_FOLDER),
-    {} as any as IApiRegisterClient,
+    {} as unknown as IApiRegisterClient,
   );
   return result.length;
 }
@@ -117,10 +97,9 @@ describe("Resolve local copybook against bad configuration of target folders", (
         __dirname,
       ),
     ).toBe(undefined);
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
   });
   test("given a folder that not contains copybooks, the target copybook is not retrieved", () => {
-    (globSync as any) = jest.fn().mockReturnValue([]);
+    jest.spyOn(glob, "globSync").mockImplementation(() => []);
     expect(
       fsUtils.searchCopybookInExtensionFolder(
         copybookName,
@@ -129,10 +108,9 @@ describe("Resolve local copybook against bad configuration of target folders", (
         __dirname,
       ),
     ).toBe(undefined);
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
   });
-  test("given a not empty folder, a copybook that is not present in that folder is not retrivied and the uri returned is undefined", () => {
-    (globSync as any) = jest.fn().mockReturnValue([]);
+  test("given a not empty folder, a copybook that is not present in that folder is not retrieved and the uri returned is undefined", () => {
+    jest.spyOn(glob, "globSync").mockImplementation(() => []);
     expect(
       fsUtils.searchCopybookInExtensionFolder(
         "NSTCPY2",
@@ -141,12 +119,11 @@ describe("Resolve local copybook against bad configuration of target folders", (
         __dirname,
       ),
     ).toBeUndefined();
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
   });
 });
 describe("Resolve local copybook present in one or more folders specified by the user", () => {
   test("given a folder that contains the target copybook, it is found and its uri is returned", () => {
-    (globSync as any) = jest.fn().mockReturnValue([copybookName]);
+    jest.spyOn(glob, "globSync").mockImplementation(() => [copybookName]);
     expect(
       fsUtils.searchCopybookInExtensionFolder(
         copybookName,
@@ -155,10 +132,9 @@ describe("Resolve local copybook present in one or more folders specified by the
         __dirname,
       ),
     ).toBeDefined();
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
   });
   test("given two times the same folder that contains the target copybook, one uri is still returned", () => {
-    (globSync as any) = jest.fn().mockReturnValue([copybookName]);
+    jest.spyOn(glob, "globSync").mockImplementation(() => [copybookName]);
     expect(
       fsUtils.searchCopybookInExtensionFolder(
         copybookName,
@@ -167,10 +143,9 @@ describe("Resolve local copybook present in one or more folders specified by the
         __dirname,
       ),
     ).toBeDefined();
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
   });
   test("Given a copybook with extension on filesystem, the uri is correctly returned", () => {
-    (globSync as any) = jest.fn().mockReturnValue(["NSTCOPY2.CPY"]);
+    jest.spyOn(glob, "globSync").mockImplementation(() => ["NSTCOPY2.CPY"]);
     expect(
       fsUtils.searchCopybookInExtensionFolder(
         "NSTCOPY2",
@@ -179,10 +154,9 @@ describe("Resolve local copybook present in one or more folders specified by the
         __dirname,
       ),
     ).toBeDefined();
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
   });
-  test("Given a valid relative path for copybook with extension on filesystem, the uri is correctly returned", () => {
-    (globSync as any) = jest.fn().mockReturnValue(["NSTCOPY2.CPY"]);
+  test("Given a valid relative path for copybook with extension on filesystem, the uri is correctly returned", async () => {
+    jest.spyOn(glob, "globSync").mockImplementation(() => ["NSTCOPY2.CPY"]);
     const dir = path.join(__dirname, RELATIVE_CPY_FOLDER_NAME);
     createDirectory(dir);
     createFile(copybookNameWithExtension, dir);
@@ -194,11 +168,10 @@ describe("Resolve local copybook present in one or more folders specified by the
         __dirname,
       ),
     ).toBeDefined();
-    removeFolder(dir);
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
+    await removeFolder(dir);
   });
   test("Given a valid absolute path for copybook with extension on filesystem, the uri is correctly returned", () => {
-    (globSync as any) = jest.fn().mockReturnValue(["NSTCOPY2.CPY"]);
+    jest.spyOn(glob, "globSync").mockImplementation(() => ["NSTCOPY2.CPY"]);
     expect(
       fsUtils.searchCopybookInExtensionFolder(
         "NSTCOPY2",
@@ -207,28 +180,27 @@ describe("Resolve local copybook present in one or more folders specified by the
         __dirname,
       ),
     ).toBeDefined();
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
   });
 });
 describe("With invalid input parameters, the list of URI that represent copybook downloaded are not generated", () => {
-  test("given a profile but no dataset, the result list returned is empty", async () => {
-    expect(await buildResultArrayFrom(undefined, "file", "PRF")).toBe(0);
+  test("given a profile but no dataset, the result list returned is empty", () => {
+    expect(buildResultArrayFrom(undefined, "file", "PRF")).toBe(0);
   });
-  test("given a list of dataset but no profile, the result list returned is empty", async () => {
+  test("given a list of dataset but no profile, the result list returned is empty", () => {
     expect(
-      await buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", undefined),
+      buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", undefined),
     ).toBe(0);
   });
 });
 describe("With allowed input parameters, the list of URI that represent copybook downloaded is correctly generated", () => {
-  test("given profile and dataset list with one element, the result list is correctly generated with size 1 ", async () => {
-    expect(
-      await buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", "PRF"),
-    ).toBe(1);
+  test("given profile and dataset list with one element, the result list is correctly generated with size 1 ", () => {
+    expect(buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", "PRF")).toBe(
+      1,
+    );
   });
-  test("given profile, dataset and USS path, list with one element each, the result list is correctly generated with size 2 ", async () => {
+  test("given profile, dataset and USS path, list with one element each, the result list is correctly generated with size 2 ", () => {
     expect(
-      await buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", "PRF", [
+      buildResultArrayFrom(["HLQ.DATASET1.DATASET2"], "file", "PRF", [
         "/test/uss/path",
       ]),
     ).toBe(2);
@@ -257,7 +229,7 @@ describe("Prioritize search criteria for copybooks test suite", () => {
     SettingsService.getCopybookExtension = jest
       .fn()
       .mockReturnValue(Promise.resolve([""]));
-    (globSync as any) = jest.fn().mockReturnValue([copybookName]);
+    jest.spyOn(glob, "globSync").mockImplementation(() => [copybookName]);
     const downloader = new CopybookDownloadService("/storagePath");
     const uri: string | undefined = await downloader.resolveCopybookHandler(
       copybookName,
@@ -265,11 +237,10 @@ describe("Prioritize search criteria for copybooks test suite", () => {
       "COBOL",
     );
     expect(uri).toMatch(CPY_FOLDER_NAME);
-    expect(spySearchInWorkspace).toBeCalledTimes(1);
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
+    expect(spySearchInWorkspace).toHaveBeenCalledTimes(1);
   });
   test("With no settings provided, two search strategies are applied and function return undefined", async () => {
-    (globSync as any) = jest.fn().mockReturnValue([]);
+    jest.spyOn(glob, "globSync").mockImplementation(() => []);
     provideMockValueForLocalAndDSN("", "");
     ProfileUtils.getProfileNameForCopybook = jest
       .fn()
@@ -287,10 +258,9 @@ describe("Prioritize search criteria for copybooks test suite", () => {
     expect(uri).toBe(undefined);
 
     expect(spySearchInWorkspace).toHaveBeenCalledTimes(7);
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
   });
   test("With both local and dsn references defined in the settings.json, the search is applied on local resources first", async () => {
-    (globSync as any) = jest.fn().mockReturnValue([copybookName]);
+    jest.spyOn(glob, "globSync").mockImplementation(() => [copybookName]);
     const downloader = new CopybookDownloadService("/storagePath");
 
     const uri: string | undefined = await downloader.resolveCopybookHandler(
@@ -300,14 +270,13 @@ describe("Prioritize search criteria for copybooks test suite", () => {
     );
     expect(uri).not.toBe("");
     expect(spySearchInWorkspace).toHaveBeenCalledTimes(7);
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
   });
   test("With only a local folder defined for the dialect in the settings.json, the search is applied locally", async () => {
     vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
       get: jest.fn().mockReturnValue([CPY_FOLDER_NAME]),
     });
 
-    (globSync as any) = jest.fn().mockReturnValue([copybookName]);
+    jest.spyOn(glob, "globSync").mockImplementation(() => [copybookName]);
     const downloader = new CopybookDownloadService("/storagePath");
     const uri: string | undefined = await downloader.resolveCopybookHandler(
       copybookName,
@@ -315,7 +284,6 @@ describe("Prioritize search criteria for copybooks test suite", () => {
       "DIALECT",
     );
     expect(uri).toMatch(CPY_FOLDER_NAME);
-    expect(spySearchInWorkspace).toBeCalledTimes(1);
-    (globSync as any) = jest.fn().mockReturnValue((x: any) => x);
+    expect(spySearchInWorkspace).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookURITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookURITest.spec.ts
@@ -15,6 +15,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { CopybookURI } from "../../../services/copybook/CopybookURI";
 import { Utils } from "../../../services/util/Utils";
+import { asMutable } from "../../../test/suite/testHelper";
 
 Utils.getZoweExplorerAPI = jest.fn();
 
@@ -22,7 +23,12 @@ describe("CopybooksPathGenerator tests", () => {
   const fsPath = "/projects";
   const profile = "profile";
   const dataset = "dataset";
-  (vscode.workspace.workspaceFolders as any) = [{ uri: { fsPath } } as any];
+
+  beforeEach(() => {
+    asMutable(vscode.workspace).workspaceFolders = [
+      { uri: { fsPath } } as unknown as vscode.WorkspaceFolder,
+    ];
+  });
 
   it("creates copybook path", () => {
     expect(

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybooksCodeActionProviderTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybooksCodeActionProviderTest.spec.ts
@@ -19,30 +19,20 @@ import { Utils } from "../../../services/util/Utils";
 
 describe("Test Copybook code action provider", () => {
   const copybooksCodeAction = new CopybooksCodeActionProvider();
-  const doc = { uri: { fsPath: "ws-path" }, fileName: "testFile" } as any;
-  const range = {
-    start: { line: 4, character: 5 },
-    end: { line: 4, character: 6 },
-  };
+  const doc = {
+    uri: vscode.Uri.file("ws-path"),
+    fileName: "testFile",
+  } as vscode.TextDocument;
+  const range = new vscode.Range(
+    new vscode.Position(4, 5),
+    new vscode.Position(4, 6),
+  );
   const token = {
     isCancellationRequested: false,
     onCancellationRequested: jest.fn(),
   };
 
   beforeAll(() => {
-    (vscode.extensions as any) = {
-      getExtension: jest.fn().mockReturnValue({
-        extensionPath: "/test",
-        packageJSON: {
-          version: 1,
-        },
-      }),
-    };
-
-    (vscode.CodeActionKind as any) = {
-      QuickFix: 1,
-    };
-    (vscode.CodeAction as any) = jest.fn();
     TelemetryService.registerEvent = jest.fn();
     Utils.getZoweExplorerAPI = jest.fn();
   });
@@ -51,21 +41,18 @@ describe("Test Copybook code action provider", () => {
     jest.clearAllMocks();
   });
 
-  test("code action is not triggred when diaognosis not completed", async () => {
-    const context = { triggerKind: {}, diagnostics: [], only: undefined };
+  test("code action is not triggered when diagnosis not completed", () => {
+    const context = {
+      triggerKind: {},
+      diagnostics: [],
+      only: undefined,
+    } as unknown as vscode.CodeActionContext;
     expect(
-      (
-        await copybooksCodeAction.provideCodeActions(
-          doc,
-          range as any,
-          context as any,
-          token,
-        )
-      ).length,
+      copybooksCodeAction.provideCodeActions(doc, range, context, token).length,
     ).toBe(0);
   });
 
-  test("code action is not triggred even if diaognosis is completed with code different then `missing copybook` ", async () => {
+  test("code action is not triggered even if diagnosis is completed with code different then `missing copybook` ", () => {
     const context = {
       triggerKind: {},
       diagnostics: [
@@ -78,20 +65,13 @@ describe("Test Copybook code action provider", () => {
         },
       ],
       only: undefined,
-    };
+    } as unknown as vscode.CodeActionContext;
     expect(
-      (
-        await copybooksCodeAction.provideCodeActions(
-          doc,
-          range as any,
-          context as any,
-          token,
-        )
-      ).length,
+      copybooksCodeAction.provideCodeActions(doc, range, context, token).length,
     ).toBe(0);
   });
 
-  test("code action is triggred when diaognosis completed and diaognis code is `missing copybook`", async () => {
+  test("code action is triggered when diagnosis completed and diagnosis code is `missing copybook`", () => {
     const context = {
       triggerKind: {},
       diagnostics: [
@@ -104,16 +84,9 @@ describe("Test Copybook code action provider", () => {
         },
       ],
       only: undefined,
-    };
+    } as unknown as vscode.CodeActionContext;
     expect(
-      (
-        await copybooksCodeAction.provideCodeActions(
-          doc,
-          range as any,
-          context as any,
-          token,
-        )
-      ).length,
+      copybooksCodeAction.provideCodeActions(doc, range, context, token).length,
     ).toBe(1);
     expect(TelemetryService.registerEvent).toHaveBeenCalledWith(
       "QuickFix for copybook activation",

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/E4ECopybookService.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/E4ECopybookService.spec.ts
@@ -33,12 +33,11 @@ describe("e4e copybook service tests", () => {
     const getExtension = jest.fn();
     const dispose = jest.fn();
     let changeCallback: unknown;
-    const onDidChange = jest.fn((fn) => {
+    vscode.extensions.getExtension = getExtension;
+    jest.spyOn(vscode.extensions, "onDidChange").mockImplementation((fn) => {
       changeCallback = fn;
       return { dispose };
     });
-    vscode.extensions.getExtension = getExtension;
-    (vscode.extensions as any).onDidChange = onDidChange;
 
     const api = await getE4EAPI();
     expect(api).toHaveProperty("futureApi");

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForDsnTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForDsnTest.spec.ts
@@ -23,19 +23,14 @@ import * as vscode from "vscode";
 import { TextEncoder } from "util";
 import { SettingsService } from "../../../../services/Settings";
 
-(vscode.workspace as any) = {
-  fs: {
-    readFile: jest
-      .fn()
-      .mockReturnValue(new TextEncoder().encode("copybook content")),
-    writeFile: jest.fn(),
-  },
-  workspaceFolders: [{ uri: { fsPath: "/projects" } } as any],
-};
-jest.mock("../../../../services/reporter/TelemetryService");
 describe("Tests Copybook download from DNS", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest
+      .spyOn(vscode.workspace.fs, "readFile")
+      .mockReturnValue(
+        Promise.resolve(new TextEncoder().encode("copybook content")),
+      );
   });
 
   describe("checks if the copybook is eligible to dowload passed on user settings", () => {
@@ -47,11 +42,11 @@ describe("Tests Copybook download from DNS", () => {
       jest.clearAllMocks();
     });
 
-    it("checks eligibility based on profile settings", async () => {
+    it("checks eligibility based on profile settings", () => {
       ProfileUtils.getProfileNameForCopybook = jest
         .fn()
         .mockReturnValue(undefined);
-      let isEligible = await downloader.isEligibleForDownload(
+      let isEligible = downloader.isEligibleForDownload(
         { name: "copybook-name", dialect: "COBOL" },
         "document-uri",
         "DNS.PATH",
@@ -60,7 +55,7 @@ describe("Tests Copybook download from DNS", () => {
       ProfileUtils.getProfileNameForCopybook = jest
         .fn()
         .mockReturnValue("test-profile");
-      isEligible = await downloader.isEligibleForDownload(
+      isEligible = downloader.isEligibleForDownload(
         { name: "copybook-name", dialect: "COBOL" },
         "document-uri",
         "DNS.PATH",
@@ -68,17 +63,17 @@ describe("Tests Copybook download from DNS", () => {
       expect(isEligible).toBeTruthy();
     });
 
-    it("checks eligibility based on DSN settings", async () => {
+    it("checks eligibility based on DSN settings", () => {
       ProfileUtils.getProfileNameForCopybook = jest
         .fn()
         .mockReturnValue("test-profile");
-      let isEligible = await downloader.isEligibleForDownload(
+      let isEligible = downloader.isEligibleForDownload(
         { name: "copybook-name", dialect: "COBOL" },
         "document-uri",
         undefined,
       );
       expect(isEligible).toBeFalsy();
-      isEligible = await downloader.isEligibleForDownload(
+      isEligible = downloader.isEligibleForDownload(
         { name: "copybook-name", dialect: "COBOL" },
         "document-uri",
         "DNS.PATH",
@@ -117,9 +112,6 @@ describe("Tests Copybook download from DNS", () => {
         .fn()
         .mockReturnValue("test-profile");
       downloader.isEligibleForDownload = jest.fn().mockReturnValue(true);
-      (downloader as any).checkForLockedProfile = jest
-        .fn()
-        .mockReturnValue(true);
       SettingsService.getCopybookFileEncoding = jest
         .fn()
         .mockReturnValue("utf8");

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForE4E.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForE4E.spec.ts
@@ -29,12 +29,15 @@ jest.mock("node:fs", () => ({
 }));
 
 describe("e4e copybook downloader tests", () => {
+  let e4e: E4E;
+
   beforeEach(() => {
-    jest.clearAllMocks();
+    e4e = {} as E4E;
   });
+
   it("checks copybook downloaded into correct path", () => {
     expect(
-      (CopybookDownloaderForE4E as any).getCopybookPath(
+      CopybookDownloaderForE4E["getCopybookPath"](
         "Instance.Instance",
         "pgm",
         "/storagePath",
@@ -56,13 +59,11 @@ describe("e4e copybook downloader tests", () => {
     );
   });
   it("checks not to try to download any if member or element not available in e4e", async () => {
-    const e4eDownloader = new CopybookDownloaderForE4E(
-      "/storagePath",
-      {} as any as E4E,
-    );
+    const e4eDownloader = new CopybookDownloaderForE4E("/storagePath", e4e);
     const spyDownloadDataset = jest.spyOn(e4eDownloader, "downloadDatasetE4E");
     const spyDownloadElement = jest.spyOn(e4eDownloader, "downloadElementE4E");
-    e4eDownloader.getE4EConfig = async () => e4eResponseEndevorFirst;
+    e4eDownloader.getE4EConfig = async () =>
+      Promise.resolve(e4eResponseEndevorFirst);
     await e4eDownloader.downloadCopybookE4E("uri", {
       name: "NoCopybook",
       dialect: "COBOL",
@@ -71,13 +72,11 @@ describe("e4e copybook downloader tests", () => {
     expect(spyDownloadElement).not.toHaveBeenCalled();
   });
   it("check download performed with respect to configuration order", async () => {
-    const e4eDownloader = new CopybookDownloaderForE4E(
-      "/storagePath",
-      {} as any as E4E,
-    );
+    const e4eDownloader = new CopybookDownloaderForE4E("/storagePath", e4e);
     const spyDownloadDataset = jest.spyOn(e4eDownloader, "downloadDatasetE4E");
     const spyDownloadElement = jest.spyOn(e4eDownloader, "downloadElementE4E");
-    e4eDownloader.getE4EConfig = async () => e4eResponseEndevorFirst;
+    e4eDownloader.getE4EConfig = async () =>
+      Promise.resolve(e4eResponseEndevorFirst);
     await e4eDownloader.downloadCopybookE4E("uri", {
       name: "copybook",
       dialect: "COBOL",
@@ -95,13 +94,11 @@ describe("e4e copybook downloader tests", () => {
     expect(spyDownloadDataset).not.toHaveBeenCalled();
   });
   it("check download performed only for element when no member matches", async () => {
-    const e4eDownloader = new CopybookDownloaderForE4E(
-      "/storagePath",
-      {} as any as E4E,
-    );
+    const e4eDownloader = new CopybookDownloaderForE4E("/storagePath", e4e);
     const spyDownloadDataset = jest.spyOn(e4eDownloader, "downloadDatasetE4E");
     const spyDownloadElement = jest.spyOn(e4eDownloader, "downloadElementE4E");
-    e4eDownloader.getE4EConfig = async () => e4eResponseEndevorFirst;
+    e4eDownloader.getE4EConfig = async () =>
+      Promise.resolve(e4eResponseEndevorFirst);
     await e4eDownloader.downloadCopybookE4E("uri", {
       name: "copybook",
       dialect: "COBOL",
@@ -119,11 +116,12 @@ describe("e4e copybook downloader tests", () => {
     expect(spyDownloadDataset).not.toHaveBeenCalled();
   });
   it("check downloadDatasetE4E does not perform IO in case of Error", async () => {
-    const getMember = jest.fn(async () => Error("failed"));
+    const getMember = jest.fn(() => Error("failed"));
     const e4eDownloader = new CopybookDownloaderForE4E("/storagePath", {
       getMember,
-    } as any as E4E);
-    e4eDownloader.getE4EConfig = async () => e4eResponseDatasetFirst;
+    } as unknown as E4E);
+    e4eDownloader.getE4EConfig = async () =>
+      await Promise.resolve(e4eResponseDatasetFirst);
     await e4eDownloader.downloadCopybookE4E("uri", {
       name: "copybook",
       dialect: "COBOL",
@@ -131,12 +129,14 @@ describe("e4e copybook downloader tests", () => {
     expect(getMember).toHaveBeenCalled();
     expect(fs.promises.writeFile).not.toHaveBeenCalled();
   });
+
   it("check downloadElementE4E does not perform IO in case of Error", async () => {
-    const getElement = jest.fn(async () => Error("failed"));
+    const getElement = jest.fn(() => Error("failed"));
     const e4eDownloader = new CopybookDownloaderForE4E("/storagePath", {
       getElement,
-    } as any as E4E);
-    e4eDownloader.getE4EConfig = async () => e4eResponseEndevorFirst;
+    } as unknown as E4E);
+    e4eDownloader.getE4EConfig = async () =>
+      Promise.resolve(e4eResponseEndevorFirst);
     await e4eDownloader.downloadCopybookE4E("uri", {
       name: "copybook",
       dialect: "COBOL",
@@ -144,12 +144,14 @@ describe("e4e copybook downloader tests", () => {
     expect(getElement).toHaveBeenCalled();
     expect(fs.promises.writeFile).not.toHaveBeenCalled();
   });
+
   it("check downloadDatasetE4E nominal performs writeFile with correct path and content", async () => {
-    const getMember = jest.fn(async () => "content");
+    const getMember = jest.fn(() => "content");
     const e4eDownloader = new CopybookDownloaderForE4E("/storagePath", {
       getMember,
-    } as any as E4E);
-    e4eDownloader.getE4EConfig = async () => e4eResponseDatasetFirst;
+    } as unknown as E4E);
+    e4eDownloader.getE4EConfig = async () =>
+      Promise.resolve(e4eResponseDatasetFirst);
     await e4eDownloader.downloadCopybookE4E("uri", {
       name: "copybook",
       dialect: "COBOL",

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForUssTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForUssTest.spec.ts
@@ -23,19 +23,14 @@ import { TextEncoder } from "util";
 import { SettingsService } from "../../../../services/Settings";
 import { CopybookDownloaderForUss } from "../../../../services/copybook/downloader/CopybookDownloaderForUss";
 
-(vscode.workspace as any) = {
-  fs: {
-    readFile: jest
-      .fn()
-      .mockReturnValue(new TextEncoder().encode("copybook content")),
-    writeFile: jest.fn(),
-  },
-  workspaceFolders: [{ uri: { fsPath: "/projects" } } as any],
-};
-jest.mock("../../../../services/reporter/TelemetryService");
 describe("Tests Copybook download from USS", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest
+      .spyOn(vscode.workspace.fs, "readFile")
+      .mockReturnValue(
+        Promise.resolve(new TextEncoder().encode("copybook content")),
+      );
   });
 
   describe("checks if the copybook is eligible to dowload passed on user settings", () => {
@@ -47,11 +42,11 @@ describe("Tests Copybook download from USS", () => {
       jest.clearAllMocks();
     });
 
-    it("checks eligibility based on profile settings", async () => {
+    it("checks eligibility based on profile settings", () => {
       ProfileUtils.getProfileNameForCopybook = jest
         .fn()
         .mockReturnValue(undefined);
-      let isEligible = await downloader.isEligibleForDownload(
+      let isEligible = downloader.isEligibleForDownload(
         { name: "copybook-name", dialect: "COBOL" },
         "document-uri",
         "DNS.PATH",
@@ -60,7 +55,7 @@ describe("Tests Copybook download from USS", () => {
       ProfileUtils.getProfileNameForCopybook = jest
         .fn()
         .mockReturnValue("test-profile");
-      isEligible = await downloader.isEligibleForDownload(
+      isEligible = downloader.isEligibleForDownload(
         { name: "copybook-name", dialect: "COBOL" },
         "document-uri",
         "DNS.PATH",
@@ -68,17 +63,17 @@ describe("Tests Copybook download from USS", () => {
       expect(isEligible).toBeTruthy();
     });
 
-    it("checks eligibility based on DSN settings", async () => {
+    it("checks eligibility based on DSN settings", () => {
       ProfileUtils.getProfileNameForCopybook = jest
         .fn()
         .mockReturnValue("test-profile");
-      let isEligible = await downloader.isEligibleForDownload(
+      let isEligible = downloader.isEligibleForDownload(
         { name: "copybook-name", dialect: "COBOL" },
         "document-uri",
         undefined,
       );
       expect(isEligible).toBeFalsy();
-      isEligible = await downloader.isEligibleForDownload(
+      isEligible = downloader.isEligibleForDownload(
         { name: "copybook-name", dialect: "COBOL" },
         "document-uri",
         "DNS.PATH",
@@ -117,9 +112,6 @@ describe("Tests Copybook download from USS", () => {
         .fn()
         .mockReturnValue("test-profile");
       downloader.isEligibleForDownload = jest.fn().mockReturnValue(true);
-      (downloader as any).checkForLockedProfile = jest
-        .fn()
-        .mockReturnValue(true);
       SettingsService.getCopybookFileEncoding = jest
         .fn()
         .mockReturnValue("utf8");

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/nativeLanguageClient/serverRuntimeCodeActionProvider.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/nativeLanguageClient/serverRuntimeCodeActionProvider.spec.ts
@@ -13,59 +13,62 @@
  */
 
 import * as vscode from "vscode";
-import { Range } from "../../../__mocks__/vscode";
 import { ServerRuntimeCodeActionProvider } from "../../../services/nativeLanguageClient/serverRuntimeCodeActionProvider";
 
 jest.mock("../../../services/reporter/TelemetryService");
 describe("Tests the server code actions", () => {
-  it("checks that no code action is provided when diagnostics is empty", async () => {
+  let range: vscode.Range;
+  beforeAll(() => {
+    range = new vscode.Range(
+      new vscode.Position(0, 0),
+      new vscode.Position(0, 0),
+    );
+  });
+
+  it("checks that no code action is provided when diagnostics is empty", () => {
     const codeActionProvider = new ServerRuntimeCodeActionProvider();
     const { doc, context, token } = getCodeactionMockObjects([]);
-    const codeActions = await codeActionProvider.provideCodeActions(
+    const codeActions = codeActionProvider.provideCodeActions(
       doc,
-      new Range(),
+      range,
       context,
       token,
     );
     expect(codeActions.length).toBe(0);
   });
 
-  it("checks that no code action is provided when diagnostics is a syntax error and not a setup  issue", async () => {
+  it("checks that no code action is provided when diagnostics is a syntax error and not a setup  issue", () => {
     const codeActionProvider = new ServerRuntimeCodeActionProvider();
     const { doc, context, token } = getCodeactionMockObjects([
       {
-        range: new Range(),
+        range,
         message: "some syntax error",
         severity: 0,
         code: "syntax error",
       },
     ]);
-    const codeActions = await codeActionProvider.provideCodeActions(
+    const codeActions = codeActionProvider.provideCodeActions(
       doc,
-      new Range(),
+      range,
       context,
       token,
     );
     expect(codeActions.length).toBe(0);
   });
 
-  it("checks that code actions are provided when the diagnostics are related to the server type configuration", async () => {
+  it("checks that code actions are provided when the diagnostics are related to the server type configuration", () => {
     const codeActionProvider = new ServerRuntimeCodeActionProvider();
     const { doc, context, token } = getCodeactionMockObjects([
       {
-        range: new Range(),
+        range,
         message: "server configuration error",
         severity: 0,
         code: "incompatible server type",
       },
     ]);
-    (vscode.CodeActionKind as any) = {
-      QuickFix: "quickfix",
-    };
-    (vscode.CodeAction as any) = jest.fn();
-    const codeActions = await codeActionProvider.provideCodeActions(
+    const codeActions = codeActionProvider.provideCodeActions(
       doc,
-      new Range(),
+      range,
       context,
       token,
     );
@@ -78,7 +81,7 @@ function getCodeactionMockObjects(diagnostics: vscode.Diagnostic[]) {
     uri: { fsPath: "ws-path" },
     fileName: "test-file",
     lineAt: jest.fn().mockReturnValue({ text: "" }),
-  } as any;
+  } as unknown as vscode.TextDocument;
   const context = {
     triggerKind: 1,
     diagnostics: diagnostics,

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/reporter/TelemetryServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/reporter/TelemetryServiceTest.spec.ts
@@ -27,8 +27,8 @@ const FAKE_ROOT_PATH: string = path.join(
   "folder2",
   "folder3",
 );
-let spySendTelemetry: any;
-let spySendExceptionTelemetry: any;
+let spySendTelemetry: jest.SpyInstance;
+let spySendExceptionTelemetry: jest.SpyInstance;
 jest.mock("@vscode/extension-telemetry");
 
 function runScenario(
@@ -46,18 +46,20 @@ function runScenario(
       undefined,
       telemetryMeasurements,
     );
-    expect(spySendTelemetry).toBeCalledTimes(expectedNumberOfCalls);
+    expect(spySendTelemetry).toHaveBeenCalledTimes(expectedNumberOfCalls);
   } else {
     TelemetryService.registerExceptionEvent(eventName, rootCause!, categories);
-    expect(spySendExceptionTelemetry).toBeCalledTimes(expectedNumberOfCalls);
+    expect(spySendExceptionTelemetry).toHaveBeenCalledTimes(
+      expectedNumberOfCalls,
+    );
   }
 }
 
 function setupScenario() {
-  (TelemetryReporterImpl as any).getTelemetryKeyId = jest
+  TelemetryReporterImpl["getTelemetryKeyId"] = jest
     .fn()
     .mockReturnValue("key_id_for_testing_purposes");
-  (TelemetryService as any).getUsername = jest.fn().mockReturnValue(USERNAME);
+  TelemetryService["getUsername"] = jest.fn().mockReturnValue(USERNAME);
   spySendTelemetry = jest.spyOn(
     TelemetryReporter.prototype,
     "sendTelemetryEvent",
@@ -86,7 +88,7 @@ describe("TelemetryService information are consistent before send them to the te
       "time elapsed": TelemetryService.calculateTimeElapsed(
         startTime - 100,
         startTime,
-      )!,
+      ),
     });
   });
 
@@ -96,7 +98,7 @@ describe("TelemetryService information are consistent before send them to the te
       "time elapsed": TelemetryService.calculateTimeElapsed(
         startTime + 100,
         startTime,
-      )!,
+      ),
     });
   });
 
@@ -123,7 +125,7 @@ describe("TelemetryService information are consistent before send them to the te
 
 describe("Anonymize content", () => {
   test("Given a verbose exception log content, then the information about the user is obfuscated", () => {
-    (TelemetryService as any).getUsername = jest.fn().mockReturnValue(USERNAME);
+    TelemetryService["getUsername"] = jest.fn().mockReturnValue(USERNAME);
 
     // construct a cross-platform example path to validate the anonymization functionality
     const fakePath: string = path.format({
@@ -165,7 +167,7 @@ describe("Anonymize content", () => {
       "\tat async Promise.all (index 0)\n";
 
     expect(
-      (TelemetryService as any).anonymizeContent(input).includes(USERNAME),
+      TelemetryService["anonymizeContent"](input).includes(USERNAME),
     ).toBeFalsy();
   });
 });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/snippets/SnippetTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/snippets/SnippetTest.spec.ts
@@ -18,10 +18,12 @@ import { DialectRegistry } from "../../../services/DialectRegistry";
 import path = require("path");
 import { createExtensionContextMock } from "../../../__mocks__/ExtensionContext.utility";
 
-jest.mock("vscode");
-
 describe("Test CompletionProvider", () => {
-  const context = { triggerKind: {}, diagnostics: [], only: undefined };
+  const context = {
+    triggerKind: {},
+    diagnostics: [],
+    only: undefined,
+  } as unknown as vscode.CompletionContext;
   const snippetcompletion = new SnippetCompletionProvider(
     createExtensionContextMock(),
   );
@@ -57,11 +59,8 @@ describe("Test CompletionProvider", () => {
       uri: { fsPath: "ws-path" },
       fileName: SNIPPET_CBL,
       lineAt: jest.fn().mockReturnValue({ text: "" }),
-    } as any;
-    const position = jest.fn().mockImplementation((line, character) => ({
-      line: line,
-      character: character,
-    }));
+    } as unknown as vscode.TextDocument;
+
     const token = {
       isCancellationRequested: false,
       onCancellationRequested: jest.fn(),
@@ -74,9 +73,9 @@ describe("Test CompletionProvider", () => {
       (
         await snippetcompletion.provideCompletionItems(
           doc,
-          position as any,
+          new vscode.Position(0, 0),
           token,
-          context as any,
+          context,
         )
       ).length,
     ).toBe(301);
@@ -86,11 +85,8 @@ describe("Test CompletionProvider", () => {
       uri: { fsPath: "ws-path" },
       fileName: SNIPPET_CBL,
       lineAt: jest.fn().mockReturnValue({ text: "" }),
-    } as any;
-    const position = jest.fn().mockImplementation((line, character) => ({
-      line: line,
-      character: character,
-    }));
+    } as unknown as vscode.TextDocument;
+
     const token = {
       isCancellationRequested: false,
       onCancellationRequested: jest.fn(),
@@ -103,9 +99,9 @@ describe("Test CompletionProvider", () => {
       (
         await snippetcompletion.provideCompletionItems(
           doc,
-          position as any,
+          new vscode.Position(0, 0),
           token,
-          context as any,
+          context,
         )
       ).length,
     ).toBe(232);
@@ -116,11 +112,8 @@ describe("Test CompletionProvider", () => {
       uri: { fsPath: "ws-path" },
       fileName: SNIPPET_CBL,
       lineAt: jest.fn().mockReturnValue({ text: "" }),
-    } as any;
-    const position = jest.fn().mockImplementation((line, character) => ({
-      line: line,
-      character: character,
-    }));
+    } as unknown as vscode.TextDocument;
+
     const token = {
       isCancellationRequested: false,
       onCancellationRequested: jest.fn(),
@@ -133,9 +126,9 @@ describe("Test CompletionProvider", () => {
       (
         await snippetcompletion.provideCompletionItems(
           doc,
-          position as any,
+          new vscode.Position(0, 0),
           token,
-          context as any,
+          context,
         )
       ).length,
     ).toBe(222);
@@ -146,11 +139,8 @@ describe("Test CompletionProvider", () => {
       uri: { fsPath: "ws-path" },
       fileName: SNIPPET_CBL,
       lineAt: jest.fn().mockReturnValue({ text: "" }),
-    } as any;
-    const position = jest.fn().mockImplementation((line, character) => ({
-      line: line,
-      character: character,
-    }));
+    } as unknown as vscode.TextDocument;
+
     const token = {
       isCancellationRequested: false,
       onCancellationRequested: jest.fn(),
@@ -163,9 +153,9 @@ describe("Test CompletionProvider", () => {
       (
         await snippetcompletion.provideCompletionItems(
           doc,
-          position as any,
+          new vscode.Position(0, 0),
           token,
-          context as any,
+          context,
         )
       ).length,
     ).toBe(311);
@@ -176,10 +166,8 @@ describe("Test CompletionProvider", () => {
       uri: { fsPath: "ws-path" },
       fileName: SNIPPET_CBL,
       lineAt: jest.fn().mockReturnValue({ text: "COPY" }),
-    } as any;
-    const position = jest
-      .fn()
-      .mockImplementation(() => ({ line: 0, character: 4 }));
+    } as unknown as vscode.TextDocument;
+
     const token = {
       isCancellationRequested: false,
       onCancellationRequested: jest.fn(),
@@ -192,9 +180,9 @@ describe("Test CompletionProvider", () => {
       (
         await snippetcompletion.provideCompletionItems(
           doc,
-          position as any,
+          new vscode.Position(0, 4),
           token,
-          context as any,
+          context,
         )
       ).length,
     ).toBe(1);
@@ -205,10 +193,7 @@ describe("Test CompletionProvider", () => {
       uri: { fsPath: "ws-path" },
       fileName: SNIPPET_CBL,
       lineAt: jest.fn().mockReturnValue({ text: "COPY" }),
-    } as any;
-    const position = jest
-      .fn()
-      .mockImplementation(() => ({ line: 0, character: 4 }));
+    } as unknown as vscode.TextDocument;
     const token = {
       isCancellationRequested: false,
       onCancellationRequested: jest.fn(),
@@ -219,9 +204,9 @@ describe("Test CompletionProvider", () => {
     });
     const completions = await snippetcompletion.provideCompletionItems(
       doc,
-      position as any,
+      new vscode.Position(0, 4),
       token,
-      context as any,
+      context,
     );
     expect(completions.length).toBe(7);
   });
@@ -231,10 +216,8 @@ describe("Test CompletionProvider", () => {
       uri: { fsPath: "ws-path" },
       fileName: "SNIPPET.cbl",
       lineAt: jest.fn().mockReturnValue({ text: "WRITE" }),
-    } as any;
-    const position = jest.fn().mockImplementation(() => {
-      return { line: 0, character: 4 };
-    });
+    } as unknown as vscode.TextDocument;
+
     const token = {
       isCancellationRequested: false,
       onCancellationRequested: jest.fn(),
@@ -247,9 +230,9 @@ describe("Test CompletionProvider", () => {
       (
         await snippetcompletion.provideCompletionItems(
           doc,
-          position as any,
+          new vscode.Position(0, 5),
           token,
-          context as any,
+          context,
         )
       ).length,
     ).toBe(1);
@@ -260,10 +243,7 @@ describe("Test CompletionProvider", () => {
       uri: { fsPath: "ws-path" },
       fileName: SNIPPET_CBL,
       lineAt: jest.fn().mockReturnValue({ text: "WRITE" }),
-    } as any;
-    const position = jest
-      .fn()
-      .mockImplementation(() => ({ line: 0, character: 4 }));
+    } as unknown as vscode.TextDocument;
     const token = {
       isCancellationRequested: false,
       onCancellationRequested: jest.fn(),
@@ -274,9 +254,9 @@ describe("Test CompletionProvider", () => {
     });
     const completions = await snippetcompletion.provideCompletionItems(
       doc,
-      position as any,
+      new vscode.Position(0, 5),
       token,
-      context as any,
+      context,
     );
     expect(completions.length).toBe(10);
   });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/ConfigurationWatcher.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/ConfigurationWatcher.spec.ts
@@ -48,9 +48,7 @@ describe("Tests ConfigurationWatcher utility", () => {
       .mockReturnValue("NATIVE");
     vscode.window.showInformationMessage = jest.fn().mockReturnValue("Ok");
     const configurationWatcher = new ConfigurationWatcher();
-    await (
-      configurationWatcher as any
-    ).handleServerRuntimeConfigurationChange();
+    await configurationWatcher["handleServerRuntimeConfigurationChange"]();
     expect(vscode.commands.executeCommand).toBeCalled();
   });
 
@@ -61,9 +59,7 @@ describe("Tests ConfigurationWatcher utility", () => {
       .mockReturnValue("JAVA");
     vscode.window.showInformationMessage = jest.fn().mockReturnValue("Ok");
     const configurationWatcher = new ConfigurationWatcher();
-    await (
-      configurationWatcher as any
-    ).handleServerRuntimeConfigurationChange();
+    await configurationWatcher["handleServerRuntimeConfigurationChange"]();
     expect(vscode.commands.executeCommand).not.toBeCalled();
   });
 });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts
@@ -13,7 +13,7 @@
  */
 
 import * as vscode from "vscode";
-import { searchCopybookInExtensionFolder } from "../../../services/util/FSUtils";
+import * as FSUtils from "../../../services/util/FSUtils";
 import { COBOL_EXT_ARRAY } from "../../../constants";
 import { resolveSubroutineURI } from "../../../services/util/SubroutineUtils";
 
@@ -23,13 +23,14 @@ describe("SubroutineUtils", () => {
     vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
       get: jest.fn().mockReturnValue(folders),
     });
-    (searchCopybookInExtensionFolder as any) = jest
-      .fn()
-      .mockReturnValue("theURI");
+    const mockUri = vscode.Uri.file("theURI");
+    const spy = jest
+      .spyOn(FSUtils, "searchCopybookInExtensionFolder")
+      .mockReturnValue(mockUri);
 
     const uri = resolveSubroutineURI("/storagePath", "name");
-    expect(uri).toBe("theURI");
-    expect(searchCopybookInExtensionFolder).toBeCalledWith(
+    expect(uri).toStrictEqual(mockUri);
+    expect(spy).toHaveBeenCalledWith(
       "name",
       folders,
       COBOL_EXT_ARRAY,

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/Utils.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/Utils.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+
+import { hasMember } from "../../../services/util/Utils";
+
+describe("Utils", () => {
+  describe("hasMember", () => {
+    test("should return true and narrow unknown type if member is available", () => {
+      const unknownObject: unknown = { member: "hello" };
+      const result = hasMember(unknownObject, "member");
+      if (result) {
+        expect(unknownObject.member).toEqual("hello");
+        // @ts-expect-error Property 'foo' does not exist on type { member: unknown }
+        expect(unknownObject.foo).toBeUndefined();
+      }
+      expect(result).toEqual(true);
+    });
+
+    test("should return false if member is not present", () => {
+      const unknownObject: unknown = {};
+      const result = hasMember(unknownObject, "member");
+      expect(result).toEqual(false);
+    });
+
+    test("should return false if object is null", () => {
+      const result = hasMember(null, "member");
+      expect(result).toEqual(false);
+    });
+
+    test("should return false if object is undefined", () => {
+      const result = hasMember(undefined, "member");
+      expect(result).toBeFalsy();
+    });
+  });
+});

--- a/clients/cobol-lsp-vscode-extension/src/commands/FetchCopybookCommand.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/FetchCopybookCommand.ts
@@ -17,7 +17,7 @@ import {
 } from "../services/copybook/CopybookDownloadService";
 import { TelemetryService } from "../services/reporter/TelemetryService";
 
-export function fetchCopybookCommand(
+export async function fetchCopybookCommand(
   copybook: string,
   downloader: CopybookDownloadService,
   programName: string,
@@ -27,7 +27,7 @@ export function fetchCopybookCommand(
     ["COBOL", "copybook", "quickfix"],
     "The user tries to resolve a copybook that is not currently found",
   );
-  downloader.downloadCopybooks(programName, [
+  await downloader.downloadCopybooks(programName, [
     new CopybookName(copybook, "COBOL"),
   ]);
 }

--- a/clients/cobol-lsp-vscode-extension/src/commands/RunAnalysisCLI.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/RunAnalysisCLI.ts
@@ -15,9 +15,10 @@
 import * as vscode from "vscode";
 import { Terminal } from "vscode";
 
-export interface AnalysisResults {
-  typeToRun: string;
-  copybookLocation: string;
+export interface AnalysisConfiguration {
+  typeToRun?: string;
+  copybookLocation?: string;
+  showDiagnosticsResult?: string;
 }
 
 /**
@@ -29,12 +30,14 @@ export class RunAnalysis {
   protected copybookConfigLocation: string;
   protected globalStorageUri: vscode.Uri;
   protected extensionUri: vscode.Uri;
+  protected showDiagnostics: boolean;
 
   constructor(globalStorageUri: vscode.Uri, extensionPath: vscode.Uri) {
     this.runNative = false;
     this.copybookConfigLocation = "";
     this.globalStorageUri = globalStorageUri;
     this.extensionUri = extensionPath;
+    this.showDiagnostics = false;
   }
 
   /**
@@ -46,24 +49,25 @@ export class RunAnalysis {
       return;
     }
 
-    const result = {} as Partial<AnalysisResults>;
-    await this.getVersionToRun(result);
-    this.getCopybookConfigLocation(result);
-    const showDiagnosticsResult = await this.getShowDiagnosticsChoice();
+    const result: AnalysisConfiguration = {
+      typeToRun: await this.getVersionToRun(),
+      copybookLocation: this.getCopybookConfigLocation(),
+      showDiagnosticsResult: await this.getShowDiagnosticsChoice(),
+    };
 
     if (
       result.typeToRun === undefined ||
       result.copybookLocation === undefined ||
-      showDiagnosticsResult === undefined
+      result.showDiagnosticsResult === undefined
     ) {
       return;
     }
 
     this.runNative = result.typeToRun === "Native";
     this.copybookConfigLocation = result.copybookLocation;
-    const showDiagnostics: boolean = showDiagnosticsResult === "Show";
+    this.showDiagnostics = result.showDiagnosticsResult === "Show";
 
-    const command = await this.buildCommand(showDiagnostics);
+    const command = await this.buildCommand();
     if (command !== "") {
       this.sendToTerminal(command);
     }
@@ -72,8 +76,8 @@ export class RunAnalysis {
   /**
    *  Prompt the user for whether to run the Java or Native version.
    */
-  public async getVersionToRun(result: Partial<AnalysisResults>) {
-    result.typeToRun = await vscode.window.showQuickPick(["Java", "Native"], {
+  public async getVersionToRun() {
+    return await vscode.window.showQuickPick(["Java", "Native"], {
       placeHolder: "Select Java or Native",
     });
   }
@@ -81,8 +85,8 @@ export class RunAnalysis {
   /**
    * Prompt the user for the location of the copybook config file.
    */
-  public getCopybookConfigLocation(result: Partial<AnalysisResults>) {
-    result.copybookLocation = "";
+  public getCopybookConfigLocation() {
+    return "";
   }
 
   public async getShowDiagnosticsChoice() {
@@ -96,21 +100,17 @@ export class RunAnalysis {
    * @param showDiagnostics - Option to show/hide diagnostics
    * @protected
    */
-  protected async buildCommand(showDiagnostics: boolean) {
+  protected async buildCommand() {
     const currentFileLocation = await this.getCurrentFileLocation();
     if (!currentFileLocation || currentFileLocation === "") {
       return "";
     }
 
     if (this.runNative) {
-      return this.buildNativeCommand(
-        currentFileLocation,
-        process.platform,
-        showDiagnostics,
-      );
+      return this.buildNativeCommand(currentFileLocation, process.platform);
     }
 
-    return this.buildJavaCommand(currentFileLocation, showDiagnostics);
+    return this.buildJavaCommand(currentFileLocation);
   }
 
   /**
@@ -120,11 +120,7 @@ export class RunAnalysis {
    * @param showDiagnostics - Option to show/hide diagnostics
    * @protected
    */
-  protected buildNativeCommand(
-    currentFileLocation: string,
-    platform: string,
-    showDiagnostics: boolean,
-  ) {
+  protected buildNativeCommand(currentFileLocation: string, platform: string) {
     const serverPath = this.extensionUri.fsPath + "/server/native";
     const result = this.getServerPath(serverPath, platform);
 
@@ -132,11 +128,7 @@ export class RunAnalysis {
       return "";
     }
 
-    return (
-      result +
-      " " +
-      this.buildAnalysisCommandPortion(currentFileLocation, showDiagnostics)
-    );
+    return result + " " + this.buildAnalysisCommandPortion(currentFileLocation);
   }
 
   protected getServerPath(serverPath: string, platform: string) {
@@ -158,10 +150,7 @@ export class RunAnalysis {
    * @param showDiagnostics - Option to show/hide diagnostics
    * @protected
    */
-  protected buildJavaCommand(
-    currentFileLocation: string,
-    showDiagnostics: boolean,
-  ) {
+  protected buildJavaCommand(currentFileLocation: string) {
     const extensionFolder: string | undefined =
       this.extensionUri.fsPath + "/server/jar/server.jar";
 
@@ -170,7 +159,7 @@ export class RunAnalysis {
         'java -jar "' +
         extensionFolder +
         '" ' +
-        this.buildAnalysisCommandPortion(currentFileLocation, showDiagnostics)
+        this.buildAnalysisCommandPortion(currentFileLocation)
       );
     }
 
@@ -184,10 +173,7 @@ export class RunAnalysis {
    * @param showDiagnostics - Option to show/hide diagnostics
    * @protected
    */
-  protected buildAnalysisCommandPortion(
-    currentFileLocation: string,
-    showDiagnostics: boolean,
-  ) {
+  protected buildAnalysisCommandPortion(currentFileLocation: string) {
     const copyBookCommand = `-cf=${
       this.copybookConfigLocation === ""
         ? "."
@@ -199,7 +185,7 @@ export class RunAnalysis {
       currentFileLocation +
       '" ' +
       copyBookCommand +
-      (showDiagnostics ? "" : " -nd")
+      (this.showDiagnostics ? "" : " -nd")
     );
   }
 

--- a/clients/cobol-lsp-vscode-extension/src/commands/RunAnalysisCLI.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/RunAnalysisCLI.ts
@@ -48,7 +48,7 @@ export class RunAnalysis {
 
     const result = {} as Partial<AnalysisResults>;
     await this.getVersionToRun(result);
-    await this.getCopybookConfigLocation(result);
+    this.getCopybookConfigLocation(result);
     const showDiagnosticsResult = await this.getShowDiagnosticsChoice();
 
     if (
@@ -81,7 +81,7 @@ export class RunAnalysis {
   /**
    * Prompt the user for the location of the copybook config file.
    */
-  public async getCopybookConfigLocation(result: Partial<AnalysisResults>) {
+  public getCopybookConfigLocation(result: Partial<AnalysisResults>) {
     result.copybookLocation = "";
   }
 

--- a/clients/cobol-lsp-vscode-extension/src/commands/SmartTabCommand.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/SmartTabCommand.ts
@@ -43,7 +43,7 @@ abstract class SmartCommandProvider {
         (
           editor: vscode.TextEditor,
           edit: vscode.TextEditorEdit,
-          ...args: any[]
+          ...args: unknown[]
         ) => {
           this.execute(editor, edit, args);
         },
@@ -60,7 +60,7 @@ abstract class SmartCommandProvider {
   public abstract execute(
     editor: vscode.TextEditor,
     edit: vscode.TextEditorEdit,
-    args: any[],
+    args: unknown[],
   ): void;
 }
 
@@ -290,11 +290,11 @@ export class RangeTabShiftStore {
     }
   }
 
-  static clearCache(key: any) {
+  static clearCache(key: vscode.Uri) {
     this.store.delete(key);
   }
 
-  static getCachedShifts(key: any) {
+  static getCachedShifts(key: vscode.Uri) {
     return this.store.get(key);
   }
 

--- a/clients/cobol-lsp-vscode-extension/src/services/BridgeForGitLoader.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/BridgeForGitLoader.ts
@@ -35,9 +35,7 @@ const B4GTypeMetadataModel = t.type({
 
 export type B4GTypeMetadata = t.TypeOf<typeof B4GTypeMetadataModel>;
 
-export function decodeBridgeJson(
-  json: unknown | undefined,
-): B4GTypeMetadata | undefined {
+export function decodeBridgeJson(json: unknown): B4GTypeMetadata | undefined {
   if (json === undefined) {
     return undefined;
   }
@@ -57,14 +55,19 @@ export function decodeBridgeJson(
 
 export async function loadBridgeJsonContent(
   documentUri: Uri,
-): Promise<unknown | undefined> {
+): Promise<unknown> {
   const b4gPath = Uri.joinPath(documentUri, "../.bridge.json");
   try {
     return JSON.parse(
       new TextDecoder().decode(await workspace.fs.readFile(b4gPath)),
     );
-  } catch (e: any) {
-    if (e.code !== "FileNotFound") {
+  } catch (e) {
+    if (
+      e &&
+      typeof e === "object" &&
+      "code" in e &&
+      e.code !== "FileNotFound"
+    ) {
       console.error(e);
     }
     return undefined;

--- a/clients/cobol-lsp-vscode-extension/src/services/DialectRegistry.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/DialectRegistry.ts
@@ -16,7 +16,7 @@ import { Uri } from "vscode";
 import * as vscode from "vscode";
 import { SETTINGS_DIALECT } from "../constants";
 
-export const DIALECT_REGISTRY_SECTION: string = "cobol-lsp.dialect.registry";
+export const DIALECT_REGISTRY_SECTION = "cobol-lsp.dialect.registry";
 
 /**
  * Holds information about registered dialect

--- a/clients/cobol-lsp-vscode-extension/src/services/JavaCheck.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/JavaCheck.ts
@@ -22,30 +22,34 @@ export class JavaCheck {
     return versionPattern.test(versionString);
   }
   public async isJavaInstalled() {
-    return new Promise<any>((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       let resolved = false;
       const ls = cp.spawn("java", ["-version"]);
-      ls.stderr.on("data", (data: any) => {
+      ls.stderr.on("data", (data: Buffer) => {
         if (JavaCheck.isJavaVersionSupported(data.toString())) {
           resolved = true;
           resolve(resolved);
         }
       });
-      ls.on("error", (code: any) => {
+      ls.on("error", (code) => {
         if ("Error: spawn java ENOENT" === code.toString()) {
-          reject("Java 8 not found. Switching to native builds");
+          reject(new Error("Java 8 not found. Switching to native builds"));
         }
         reject(code);
       });
       ls.on("close", (code: number) => {
         if (code !== 0) {
           reject(
-            "An error occurred when checking if Java was installed. Switching to native build.",
+            new Error(
+              "An error occurred when checking if Java was installed. Switching to native build.",
+            ),
           );
         }
         if (!resolved) {
           reject(
-            "Minimum expected Java version is 8. Switching to native builds",
+            new Error(
+              "Minimum expected Java version is 8. Switching to native builds",
+            ),
           );
         }
       });

--- a/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
@@ -96,7 +96,7 @@ export class LanguageClientService {
     uri: string,
     text: string,
     position: vscode.Position,
-  ): Promise<any> {
+  ) {
     const params = {
       uri,
       text,
@@ -107,11 +107,14 @@ export class LanguageClientService {
     return languageClient.sendRequest("extended/analysis", params);
   }
 
-  public invalidateConfiguration() {
+  public async invalidateConfiguration() {
     const languageClient = this.getLanguageClient();
-    languageClient.sendNotification(DidChangeConfigurationNotification.type, {
-      settings: null,
-    });
+    await languageClient.sendNotification(
+      DidChangeConfigurationNotification.type,
+      {
+        settings: null,
+      },
+    );
   }
 
   public async start() {

--- a/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
@@ -22,7 +22,7 @@ import {
   getVariablesFromUri,
   normalizePath,
 } from "./util/FSUtils";
-import { SettingsService } from "./Settings";
+import { DialectsConfiguration, SettingsService } from "./Settings";
 import {
   B4GTypeMetadata,
   decodeBridgeJson,
@@ -119,9 +119,9 @@ export async function loadProcessorGroupSqlBackendConfig(
 }
 
 export async function loadProcessorGroupDialectConfig(
-  item: { scopeUri: string; section: string },
-  configObject: unknown,
-): Promise<unknown> {
+  item: { scopeUri: string },
+  dialectConfig: DialectsConfiguration,
+) {
   try {
     const pgCfg = loadProcessorsConfigForDocument(
       item.scopeUri,
@@ -130,7 +130,7 @@ export async function loadProcessorGroupDialectConfig(
       decodeBridgeJson(await loadBridgeJsonContent(Uri.parse(item.scopeUri))),
     );
     if (pgCfg === undefined || pgCfg.preprocessor == undefined) {
-      return configObject;
+      return dialectConfig;
     }
 
     const dialects: Preprocessor[] = [];
@@ -149,10 +149,10 @@ export async function loadProcessorGroupDialectConfig(
 
     // "SQL" is not a real dialect, we will use it only to set up sql backend for now
     const result = dialects.filter((name) => name != "SQL");
-    return result.length > 0 ? result : configObject;
+    return result.length > 0 ? result : dialectConfig;
   } catch (e) {
     console.error(JSON.stringify(e));
-    return configObject;
+    return dialectConfig;
   }
 }
 

--- a/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroupsLoader.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroupsLoader.ts
@@ -75,7 +75,7 @@ export async function readProgramConfigFileContent(
   }
   const pgmCfgPath = Uri.joinPath(ws.uri, PG_FOLDER, PGR_PGM_FILE);
   try {
-    const json = JSON.parse(
+    const json: unknown = JSON.parse(
       new TextDecoder().decode(await workspace.fs.readFile(pgmCfgPath)),
     );
     const decoded = ProgramsConfigModel.decode(json);
@@ -85,8 +85,13 @@ export async function readProgramConfigFileContent(
       );
     }
     return decoded.right;
-  } catch (e: any) {
-    if (e.code !== "FileNotFound") {
+  } catch (e) {
+    if (
+      e &&
+      typeof e === "object" &&
+      "code" in e &&
+      e.code !== "FileNotFound"
+    ) {
       console.error(e);
     }
     return EMPTY;
@@ -106,7 +111,7 @@ export async function readProcessorGroupsFileContent(
     const ProcessorGrpupsModel = t.type({
       pgroups: t.array(ProcessorGroupModel),
     });
-    const json = JSON.parse(
+    const json: unknown = JSON.parse(
       new TextDecoder().decode(await workspace.fs.readFile(procCfgPath)),
     );
 
@@ -117,8 +122,13 @@ export async function readProcessorGroupsFileContent(
       );
     }
     return decoded.right.pgroups;
-  } catch (e: any) {
-    if (e.code !== "FileNotFound") {
+  } catch (e) {
+    if (
+      e &&
+      typeof e === "object" &&
+      "code" in e &&
+      e.code !== "FileNotFound"
+    ) {
       console.error(e);
     }
     return [];

--- a/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
@@ -77,7 +77,7 @@ async function handleProcessorGroupConfigurationRequest<Type, Output, R>(
     cfg: Type,
   ) => Promise<R>,
   item: Item,
-  result: unknown[],
+  result: R[],
 ) {
   if (item.scopeUri) {
     try {
@@ -98,7 +98,6 @@ async function handleProcessorGroupConfigurationRequest<Type, Output, R>(
       }
     } catch (err) {
       if (err instanceof DecodingError) {
-        console.log(`Invalid settings: ${item.section} - ${err.message}`);
         getChannel().appendLine(
           `Invalid settings: ${item.section} - ${err.message}`,
         );

--- a/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
@@ -45,63 +45,138 @@ import {
 } from "./ProcessorGroups";
 import { getVariablesFromUri, SupportedVariables } from "./util/FSUtils";
 import { SettingsUtils } from "./util/SettingsUtils";
+import { decodeUnknown, DecodingError } from "./util/decoder";
+import * as t from "io-ts";
+import { getChannel } from "../extension";
 
-export async function lspConfigHandler(request: any): Promise<Array<any>> {
-  const result = new Array<unknown>();
+interface Request {
+  items: Item[];
+}
+
+interface Item {
+  section: string;
+  scopeUri?: string;
+  dialect?: string;
+}
+
+const DialectsConfigurationCodec = t.array(t.string);
+export type DialectsConfiguration = t.TypeOf<typeof DialectsConfigurationCodec>;
+const CopybooksLocalPathsConfigurationCodec = t.array(t.string);
+export type CopybooksLocalPathsConfiguration = t.TypeOf<
+  typeof CopybooksLocalPathsConfigurationCodec
+>;
+const CopybookExtensionsConfigurationCodec = t.array(t.string);
+const TargetSQLBackendConfigurationCodec = t.string;
+const CopybookEncodingConfigurationCodec = t.string;
+const CompileOptionsConfigurationCodec = t.string;
+
+async function handleProcessorGroupConfigurationRequest<Type, Output, R>(
+  codec: t.Type<Type, Output, unknown>,
+  processorGroupLoader: (
+    requestItem: { section: string; scopeUri: string },
+    cfg: Type,
+  ) => Promise<R>,
+  item: Item,
+  result: unknown[],
+) {
+  if (item.scopeUri) {
+    try {
+      const configuration = vscode.workspace
+        .getConfiguration()
+        .get(item.section);
+      if (typeof configuration !== "undefined") {
+        const decodedConfiguration = decodeUnknown(codec, configuration);
+        const itemWithScope = {
+          scopeUri: item.scopeUri,
+          section: item.section,
+        };
+        const object = await processorGroupLoader(
+          itemWithScope,
+          decodedConfiguration,
+        );
+        result.push(object);
+      }
+    } catch (err) {
+      if (err instanceof DecodingError) {
+        console.log(`Invalid settings: ${item.section} - ${err.message}`);
+        getChannel().appendLine(
+          `Invalid settings: ${item.section} - ${err.message}`,
+        );
+      }
+    }
+  }
+}
+
+export async function lspConfigHandler(request: Request) {
+  const result: unknown[] = [];
   for (const item of request.items) {
     try {
-      if (item.section === DIALECT_REGISTRY_SECTION) {
-        const object = DialectRegistry.getDialects();
-        result.push(object);
-      } else if (item.scopeUri) {
-        const cfg = vscode.workspace.getConfiguration().get(item.section);
-        if (item.section === SETTINGS_DIALECT) {
-          const object = await loadProcessorGroupDialectConfig(item, cfg);
-          result.push(object);
-        } else if (item.section === SETTINGS_CPY_LOCAL_PATH) {
-          const object = await loadProcessorGroupCopybookPathsConfig(
+      switch (item.section) {
+        case DIALECT_REGISTRY_SECTION:
+          result.push(DialectRegistry.getDialects());
+          break;
+        case COBOL_PRGM_LAYOUT:
+          result.push(SettingsService.getCobolProgramLayout());
+          break;
+        case SETTINGS_DIALECT:
+          await handleProcessorGroupConfigurationRequest(
+            DialectsConfigurationCodec,
+            loadProcessorGroupDialectConfig,
             item,
-            cfg as string[],
+            result,
           );
-          result.push(object);
-        } else if (item.section === DIALECT_LIBS && !!item.dialect) {
-          const dialectLibs: string[] =
-            await SettingsService.getCopybookLocalPath(
+          break;
+        case SETTINGS_CPY_LOCAL_PATH:
+          await handleProcessorGroupConfigurationRequest(
+            CopybooksLocalPathsConfigurationCodec,
+            loadProcessorGroupCopybookPathsConfig,
+            item,
+            result,
+          );
+          break;
+        case SETTINGS_CPY_EXTENSIONS:
+          await handleProcessorGroupConfigurationRequest(
+            CopybookExtensionsConfigurationCodec,
+            loadProcessorGroupCopybookExtensionsConfig,
+            item,
+            result,
+          );
+          break;
+        case SETTINGS_SQL_BACKEND:
+          await handleProcessorGroupConfigurationRequest(
+            TargetSQLBackendConfigurationCodec,
+            loadProcessorGroupSqlBackendConfig,
+            item,
+            result,
+          );
+          break;
+        case SETTINGS_CPY_FILE_ENCODING:
+          await handleProcessorGroupConfigurationRequest(
+            CopybookEncodingConfigurationCodec,
+            loadProcessorGroupCopybookEncodingConfig,
+            item,
+            result,
+          );
+          break;
+        case SETTINGS_COMPILE_OPTIONS:
+          await handleProcessorGroupConfigurationRequest(
+            CompileOptionsConfigurationCodec,
+            loadProcessorGroupCompileOptionsConfig,
+            item,
+            result,
+          );
+          break;
+        case DIALECT_LIBS:
+          if (item.dialect && item.scopeUri) {
+            const dialectLibs = await SettingsService.getCopybookLocalPath(
               item.scopeUri,
               item.dialect,
             );
-          result.push(dialectLibs);
-        } else if (item.section === SETTINGS_CPY_EXTENSIONS) {
-          const object = await loadProcessorGroupCopybookExtensionsConfig(
-            item,
-            cfg as string[],
-          );
-          result.push(object);
-        } else if (item.section === SETTINGS_SQL_BACKEND) {
-          const object = await loadProcessorGroupSqlBackendConfig(
-            item,
-            cfg as string,
-          );
-          result.push(object);
-        } else if (item.section === SETTINGS_CPY_FILE_ENCODING) {
-          const object = await loadProcessorGroupCopybookEncodingConfig(
-            item,
-            cfg as string,
-          );
-          result.push(object);
-        } else if (item.section === SETTINGS_COMPILE_OPTIONS) {
-          const object = await loadProcessorGroupCompileOptionsConfig(
-            item,
-            cfg as string,
-          );
-          result.push(object);
-        } else {
-          result.push(cfg);
-        }
-      } else if (item.section === COBOL_PRGM_LAYOUT) {
-        result.push(SettingsService.getCobolProgramLayout());
-      } else {
-        result.push(vscode.workspace.getConfiguration().get(item.section));
+            result.push(dialectLibs);
+          }
+          break;
+        default:
+          result.push(vscode.workspace.getConfiguration().get(item.section));
       }
     } catch (error) {
       console.log(error);
@@ -111,7 +186,7 @@ export async function lspConfigHandler(request: any): Promise<Array<any>> {
 }
 
 /**
- * SettingsService provides read/write configurstion settings functionality
+ * SettingsService provides read/write configuration settings functionality
  */
 export class SettingsService {
   public static readonly DEFAULT_DIALECT = "COBOL";
@@ -248,15 +323,19 @@ export class SettingsService {
         .replace(/\${fileBasenameNoExtension}/g, vars.filename)
         .replace(/\${fileDirname}/g, vars.dirName)
         .replace(/\${fileDirnameBasename}/g, vars.dirBasename)
-        .replace(/\${workspaceFolder(:[^}]+)?}/g, (_, ws) => {
-          if (ws === undefined)
-            return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
-          ws = ws.substring(1);
-          return (
-            vscode.workspace.workspaceFolders?.find((x) => x.name === ws)?.uri
-              .fsPath ?? ""
-          );
-        }),
+        .replace(
+          /\${workspaceFolder(:[^}]+)?}/g,
+          (_, ws: string | undefined) => {
+            if (ws === undefined) {
+              return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
+            }
+            ws = ws.substring(1);
+            return (
+              vscode.workspace.workspaceFolders?.find((x) => x.name === ws)?.uri
+                .fsPath ?? ""
+            );
+          },
+        ),
     );
   }
 
@@ -292,7 +371,7 @@ export class SettingsService {
     return result;
   }
   /**
-   * Gives the configured endevor dependecy from settings.
+   * Gives the configured endevor dependency from settings.
    *
    * @returns returns configured endevor dependency
    */

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -30,6 +30,7 @@ import { searchCopybook } from "./CopybookMessageHandler";
 import { searchCopybookInExtensionFolder } from "../util/FSUtils";
 import { CopybookURI } from "./CopybookURI";
 import path = require("path");
+import { getErrorMessage } from "../util/ErrorsUtils";
 
 export class CopybookName {
   constructor(public name: string, public dialect: string) {}
@@ -252,7 +253,7 @@ export class CopybookDownloadService {
       }),
     ).catch((err) => {
       this.outputChannel?.appendLine(
-        `Error downloading copybooks : ${err.message}`,
+        `Error downloading copybooks : ${getErrorMessage(err)}`,
       );
     });
   }
@@ -289,7 +290,7 @@ export class CopybookDownloadService {
     return (
       !(await DownloadUtil.isProfileLocked(profile)) &&
       !(await DownloadUtil.checkForInvalidCredProfile(
-        profile!,
+        profile,
         this.explorerApi,
       ))
     );

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybooksCodeActionProvider.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybooksCodeActionProvider.ts
@@ -16,12 +16,12 @@ import { QUICKFIX_GOTOSETTINGS } from "../../constants";
 import { TelemetryService } from "../reporter/TelemetryService";
 
 export class CopybooksCodeActionProvider implements vscode.CodeActionProvider {
-  public async provideCodeActions(
+  public provideCodeActions(
     _doc: vscode.TextDocument,
     _range: vscode.Range | vscode.Selection,
     context: vscode.CodeActionContext,
     _token: vscode.CancellationToken,
-  ): Promise<Array<vscode.Command | vscode.CodeAction>> {
+  ): Array<vscode.Command | vscode.CodeAction> {
     if (!this.shouldHaveCodeAction(context)) {
       return [];
     }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/E4ECopybookService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/E4ECopybookService.ts
@@ -16,7 +16,7 @@ import { E4E } from "../../type/e4eApi.d";
 import { getExtensionApi } from "../util/Utils";
 
 const nameof = <T>(name: keyof T) => name;
-function validateE4E(e4e: any): e4e is E4E {
+function validateE4E(e4e: unknown): e4e is E4E {
   return (
     e4e instanceof Object &&
     nameof<E4E>("listElements") in e4e &&

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForDsn.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForDsn.ts
@@ -87,7 +87,7 @@ export class CopybookDownloaderForDsn extends ZoweExplorerDownloader {
     const response = await this.explorerAPI
       .getMvsApi(profile)
       .allMembers(dataset);
-    const members = response.apiResponse.items.map((item: any) => item.member);
+    const members = response.apiResponse.items.map((item) => item.member);
 
     this.memberListCache.set(id, members);
     return members;

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForUss.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForUss.ts
@@ -87,7 +87,7 @@ export class CopybookDownloaderForUss extends ZoweExplorerDownloader {
     const response = await this.explorerAPI
       .getUssApi(profile)
       .fileList(dataset);
-    const members = response.apiResponse.items.map((el: any) => el.name);
+    const members = response.apiResponse.items.map((el) => el.name);
 
     this.memberListCache.set(id, members);
     return members;

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
@@ -106,7 +106,7 @@ export class DownloadUtil {
       .loadNamedProfile(profileName);
   }
 
-  private static checkForInvalidCredentials(e: any, profileName: string) {
+  private static checkForInvalidCredentials(e: unknown, profileName: string) {
     if (this.isInvalidCredentials(e)) {
       ZoweExplorerDownloader.profileStore.set(profileName, "locked-profile");
       const errorMessage = INVALID_CREDENTIALS_ERROR_MSG.replace(
@@ -147,7 +147,7 @@ export class DownloadUtil {
    * checks if copybook download configurations are present
    * @param documentUri
    * @param copybookNames
-   * @returns true if if copybook download configurations are present, fasle otherwise
+   * @returns true if if copybook download configurations are present, false otherwise
    */
   public static areCopybookDownloadConfigurationsPresent(
     documentUri: string,
@@ -182,7 +182,15 @@ export class DownloadUtil {
     return action === UNLOCK_DOWNLOAD_QUEUE_MSG;
   }
 
-  private static isInvalidCredentials(e: any) {
-    return e?.mDetails?.errorCode === 401;
+  private static isInvalidCredentials(e: unknown) {
+    return (
+      e &&
+      typeof e === "object" &&
+      "mDetails" in e &&
+      e.mDetails &&
+      typeof e.mDetails === "object" &&
+      "errorCode" in e.mDetails &&
+      e.mDetails?.errorCode === 401
+    );
   }
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
@@ -22,6 +22,7 @@ import {
 import { ZoweExplorerDownloader } from "./ZoweExplorerDownloader";
 import { CopybookName } from "../CopybookDownloadService";
 import { SettingsService } from "../../Settings";
+import { hasMember } from "../../util/Utils";
 
 /**
  * Utility class for downloading copybooks
@@ -184,13 +185,9 @@ export class DownloadUtil {
 
   private static isInvalidCredentials(e: unknown) {
     return (
-      e &&
-      typeof e === "object" &&
-      "mDetails" in e &&
-      e.mDetails &&
-      typeof e.mDetails === "object" &&
-      "errorCode" in e.mDetails &&
-      e.mDetails?.errorCode === 401
+      hasMember(e, "mDetails") &&
+      hasMember(e.mDetails, "errorCode") &&
+      e.mDetails.errorCode === 401
     );
   }
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/ZoweExplorerDownloader.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/ZoweExplorerDownloader.ts
@@ -15,6 +15,7 @@ import * as vscode from "vscode";
 import * as iconv from "iconv-lite";
 import { SettingsService } from "../../Settings";
 import { CopybookURI } from "../CopybookURI";
+import { getErrorMessage } from "../../util/ErrorsUtils";
 
 export abstract class ZoweExplorerDownloader {
   public static profileStore: Map<string, "locked-profile" | "valid-profile"> =
@@ -95,8 +96,11 @@ export abstract class ZoweExplorerDownloader {
       return queueResponse;
     }
     const response = this.downloadCopybookContent(dataset, member, profileName)
-      .catch((err) => {
-        vscode.window.showErrorMessage(err.message);
+      .catch((err: unknown) => {
+        const message = getErrorMessage(err);
+        vscode.window.showErrorMessage(
+          message ?? "Unable to download copybook",
+        );
         return false;
       })
       .finally(() => this.ZoweDownloadQueue.delete(copybookPath));

--- a/clients/cobol-lsp-vscode-extension/src/services/nativeLanguageClient/serverRuntimeCodeActionProvider.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/nativeLanguageClient/serverRuntimeCodeActionProvider.ts
@@ -21,12 +21,12 @@ import { TelemetryService } from "../reporter/TelemetryService";
 export class ServerRuntimeCodeActionProvider
   implements vscode.CodeActionProvider
 {
-  public async provideCodeActions(
+  public provideCodeActions(
     _doc: vscode.TextDocument,
     _range: vscode.Range | vscode.Selection,
     context: vscode.CodeActionContext,
     _token: vscode.CancellationToken,
-  ): Promise<Array<vscode.Command | vscode.CodeAction>> {
+  ): Array<vscode.Command | vscode.CodeAction> {
     if (!this.shouldHaveCodeAction(context)) {
       return [];
     }

--- a/clients/cobol-lsp-vscode-extension/src/services/reporter/TelemetryReporterImpl.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/reporter/TelemetryReporterImpl.ts
@@ -76,8 +76,8 @@ export class TelemetryReporterImpl implements TelemetryReport {
     }
   }
 
-  public dispose(): any {
-    this.reporter.dispose();
+  public async dispose(): Promise<void> {
+    await this.reporter.dispose();
   }
 
   private isValidTelemetryKey(): boolean {

--- a/clients/cobol-lsp-vscode-extension/src/services/snippetcompletion/SnippetCompletionProvider.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/snippetcompletion/SnippetCompletionProvider.ts
@@ -36,12 +36,10 @@ export class SnippetCompletionProvider
   snippetsCompletionItems: vscode.CompletionItem[] | null = null;
 
   constructor(context: vscode.ExtensionContext) {
-    const disposable = vscode.workspace.onDidChangeConfiguration(
-      async (event) => {
-        if (event.affectsConfiguration(SETTINGS_DIALECT))
-          this.resetSnippetsCompletionItems();
-      },
-    );
+    const disposable = vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration(SETTINGS_DIALECT))
+        this.resetSnippetsCompletionItems();
+    });
     context.subscriptions.push(disposable);
   }
 

--- a/clients/cobol-lsp-vscode-extension/src/services/snippetcompletion/SnippetCompletionProvider.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/snippetcompletion/SnippetCompletionProvider.ts
@@ -187,7 +187,10 @@ function getCurrentLineText(
   document: vscode.TextDocument,
   position: vscode.Position,
 ) {
-  return document.lineAt(position).text.slice(0, position.character).trim();
+  return document
+    .lineAt(position.line)
+    .text.slice(0, position.character)
+    .trim();
 }
 
 function getMatchedWords(words1: string[], words2: string[]) {

--- a/clients/cobol-lsp-vscode-extension/src/services/util/ErrorsUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/ErrorsUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Broadcom.
+ * Copyright (c) 2024 Broadcom.
  * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
  *
  * This program and the accompanying materials are made
@@ -12,6 +12,14 @@
  *   Broadcom, Inc. - initial API and implementation
  */
 
-export const sync = (x: unknown) => [x];
-export const hasMagic = (x: string) => x.includes("*");
-export const globSync = (x: unknown) => [x];
+export function getErrorMessage(error: unknown) {
+  if (
+    !!error &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return JSON.stringify(error);
+}

--- a/clients/cobol-lsp-vscode-extension/src/services/util/SettingsUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/SettingsUtils.ts
@@ -14,10 +14,6 @@
 import * as vscode from "vscode";
 
 export class SettingsUtils {
-  public static isValidJSON(json: string | undefined): boolean {
-    return json !== undefined ? JSON.parse(json) : false;
-  }
-
   public static getWorkspaceFoldersPath(
     fsPath: boolean | undefined = undefined,
   ): string[] {

--- a/clients/cobol-lsp-vscode-extension/src/services/util/Utils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/Utils.ts
@@ -49,11 +49,11 @@ export async function getExtensionApi<T>(
   }
   return {
     futureApi: new Promise((res, _) => {
-      const extAdded = vscode.extensions.onDidChange(async () => {
+      const extAdded = vscode.extensions.onDidChange(() => {
         const ext = vscode.extensions.getExtension(extName);
         if (!ext) return;
         extAdded.dispose();
-        await extractApi<T>(ext, validate).then((api) => res(asAPI<T>(api)));
+        void extractApi<T>(ext, validate).then((api) => res(asAPI<T>(api)));
       });
     }),
   };

--- a/clients/cobol-lsp-vscode-extension/src/services/util/Utils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/Utils.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 import { ResolvedProfile } from "../../type/e4eApi";
 
-async function safeActivate(ext: vscode.Extension<any>) {
+async function safeActivate(ext: vscode.Extension<unknown>) {
   try {
     return await ext.activate();
   } catch (_) {
@@ -24,8 +24,8 @@ async function safeActivate(ext: vscode.Extension<any>) {
 }
 
 async function extractApi<T>(
-  ext: vscode.Extension<any>,
-  validate: (api: any) => api is T,
+  ext: vscode.Extension<unknown>,
+  validate: (api: unknown) => api is T,
 ): Promise<T | undefined> {
   const api = ext.isActive ? ext.exports : await safeActivate(ext);
   if (!validate(api)) return undefined;
@@ -39,7 +39,7 @@ function asAPI<T>(api: T | undefined) {
 
 export async function getExtensionApi<T>(
   extName: string,
-  validate: (api: any) => api is T,
+  validate: (api: unknown) => api is T,
 ): Promise<
   undefined | { api: T } | { futureApi: Promise<undefined | { api: T }> }
 > {
@@ -49,11 +49,11 @@ export async function getExtensionApi<T>(
   }
   return {
     futureApi: new Promise((res, _) => {
-      const extAdded = vscode.extensions.onDidChange(() => {
+      const extAdded = vscode.extensions.onDidChange(async () => {
         const ext = vscode.extensions.getExtension(extName);
         if (!ext) return;
         extAdded.dispose();
-        extractApi<T>(ext, validate).then((api) => res(asAPI<T>(api)));
+        await extractApi<T>(ext, validate).then((api) => res(asAPI<T>(api)));
       });
     }),
   };
@@ -84,7 +84,7 @@ export class Utils {
   public static async getZoweExplorerAPI() {
     return getExtensionApi<IApiRegisterClient>(
       "Zowe.vscode-extension-for-zowe",
-      (api: any): api is IApiRegisterClient => !!api,
+      (api: unknown): api is IApiRegisterClient => !!api,
     );
   }
 

--- a/clients/cobol-lsp-vscode-extension/src/services/util/Utils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/Utils.ts
@@ -101,3 +101,10 @@ export class Utils {
     return `${profile.instance}.${profile.profile}`;
   }
 }
+
+export function hasMember<
+  M extends PropertyKey,
+  T extends object = { [K in M]: unknown },
+>(e: unknown, m: M): e is T {
+  return typeof e === "object" && e !== null && m in e;
+}

--- a/clients/cobol-lsp-vscode-extension/src/test/runTest.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/runTest.ts
@@ -59,4 +59,4 @@ async function main() {
   }
 }
 
-main();
+void main();

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/cfast.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/cfast.spec.test.ts
@@ -15,6 +15,13 @@ import * as assert from "assert";
 import * as helper from "./testHelper";
 import * as vscode from "vscode";
 
+interface Extension {
+  analysis: (
+    uri: string,
+    text: string,
+  ) => Promise<{ controlFlowAST: { name: string }[] }>;
+}
+
 suite("Integration Test Suite: CFAST generation", function () {
   suiteSetup(async function () {
     this.timeout(0);
@@ -29,13 +36,14 @@ suite("Integration Test Suite: CFAST generation", function () {
   test("CFAST generation call", async () => {
     await helper.showDocument("CFAST.cbl");
     const editor = helper.getEditor("CFAST.cbl");
-    const cobolExtension = vscode.extensions.getExtension(
+    const cobolExtension = vscode.extensions.getExtension<Extension>(
       "broadcommfd.cobol-language-support",
     );
     if (cobolExtension === undefined) {
       assert.fail("can't find extension: broadcommfd.cobol-language-support");
     }
     helper.moveCursor(editor, new vscode.Position(1, 1));
+
     const result = await cobolExtension.exports.analysis(
       editor.document.uri.toString(),
       editor.document.getText(),
@@ -55,7 +63,7 @@ suite("Integration Test Suite: CFAST generation", function () {
   test("CFAST generation call for nested program", async () => {
     await helper.showDocument("CFAST.cbl");
     const editor = helper.getEditor("CFAST.cbl");
-    const cobolExtension = vscode.extensions.getExtension(
+    const cobolExtension = vscode.extensions.getExtension<Extension>(
       "broadcommfd.cobol-language-support",
     );
     if (cobolExtension === undefined) {
@@ -81,7 +89,7 @@ suite("Integration Test Suite: CFAST generation", function () {
   test("CFAST generation call for MAIN2 program", async () => {
     await helper.showDocument("CFAST.cbl");
     const editor = helper.getEditor("CFAST.cbl");
-    const cobolExtension = vscode.extensions.getExtension(
+    const cobolExtension = vscode.extensions.getExtension<Extension>(
       "broadcommfd.cobol-language-support",
     );
     if (cobolExtension === undefined) {
@@ -107,7 +115,7 @@ suite("Integration Test Suite: CFAST generation", function () {
   test("CFAST generation: MAIN program after nested click", async () => {
     await helper.showDocument("CFAST.cbl");
     const editor = helper.getEditor("CFAST.cbl");
-    const cobolExtension = vscode.extensions.getExtension(
+    const cobolExtension = vscode.extensions.getExtension<Extension>(
       "broadcommfd.cobol-language-support",
     );
     if (cobolExtension === undefined) {
@@ -133,7 +141,7 @@ suite("Integration Test Suite: CFAST generation", function () {
   test("CFAST generation: before MAIN program click", async () => {
     await helper.showDocument("CFAST.cbl");
     const editor = helper.getEditor("CFAST.cbl");
-    const cobolExtension = vscode.extensions.getExtension(
+    const cobolExtension = vscode.extensions.getExtension<Extension>(
       "broadcommfd.cobol-language-support",
     );
     if (cobolExtension === undefined) {
@@ -159,7 +167,7 @@ suite("Integration Test Suite: CFAST generation", function () {
   test("CFAST generation: before MAIN2 after MAIN programs click", async () => {
     await helper.showDocument("CFAST.cbl");
     const editor = helper.getEditor("CFAST.cbl");
-    const cobolExtension = vscode.extensions.getExtension(
+    const cobolExtension = vscode.extensions.getExtension<Extension>(
       "broadcommfd.cobol-language-support",
     );
     if (cobolExtension === undefined) {
@@ -185,7 +193,7 @@ suite("Integration Test Suite: CFAST generation", function () {
   test("CFAST generation: after MAIN2 programs click", async () => {
     await helper.showDocument("CFAST.cbl");
     const editor = helper.getEditor("CFAST.cbl");
-    const cobolExtension = vscode.extensions.getExtension(
+    const cobolExtension = vscode.extensions.getExtension<Extension>(
       "broadcommfd.cobol-language-support",
     );
     if (cobolExtension === undefined) {

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/index.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/index.ts
@@ -15,32 +15,34 @@
 import * as path from "path";
 import * as Mocha from "mocha";
 import { glob } from "glob";
+import type { Config, NYC } from "nyc";
 
 export async function run(): Promise<void> {
   const sourceRoot = path.join(__dirname, "..", "..");
 
   // initialize nyc code coverage
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const NYC = require("nyc");
-  const nyc = new NYC({
+  const NYC = (await import("nyc")) as new (cfg: Config) => NYC;
+  const config: Config = {
     cwd: path.join(sourceRoot, ".."),
     reporter: ["lcov"],
     hookRequire: true,
     exclude: ["**/test/**", ".vscode-test/**", ".vscode-test-web/**"],
-  });
+  };
+
+  const nyc = new NYC(config);
 
   // decache files on windows to be hookable by nyc
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const decache = require("decache");
+  const decache = (await import("decache")) as unknown as (f: string) => void;
   glob
     .sync("**/**.js", {
       cwd: sourceRoot,
     })
     .forEach((file) => {
+      console.log(`Decaching: ${file}`);
       decache(path.join(sourceRoot, file));
     });
 
-  nyc.createTempDirectory();
+  await nyc.createTempDirectory();
   nyc.wrap();
 
   // Create the mocha test
@@ -62,7 +64,7 @@ export async function run(): Promise<void> {
   });
 
   // report code coverage
-  nyc.writeCoverageFile();
+  await nyc.writeCoverageFile();
   await nyc.report();
   console.log("Report created");
 }

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/index.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/index.ts
@@ -38,7 +38,6 @@ export async function run(): Promise<void> {
       cwd: sourceRoot,
     })
     .forEach((file) => {
-      console.log(`Decaching: ${file}`);
       decache(path.join(sourceRoot, file));
     });
 

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.copybooks.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.copybooks.test.ts
@@ -170,7 +170,7 @@ suite("Integration Test Suite: Copybooks", function () {
     .timeout(helper.TEST_TIMEOUT)
     .slow(1000);
 
-  test("TC247497 - Local Copybooks - check hidden folders under c4z", async () => {
+  test("TC247497 - Local Copybooks - check hidden folders under c4z", () => {
     const extSrcPath = path.join(getWorkspacePath(), ".c4z", ".extsrcs");
     const extSrcUri = vscode.Uri.file(extSrcPath);
     const hiddenFolder = vscode.workspace.getWorkspaceFolder(extSrcUri);

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.copybooks.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.copybooks.test.ts
@@ -35,8 +35,7 @@ suite("Integration Test Suite: Copybooks", function () {
 
   test("TC174655: Copybook - Nominal", async () => {
     const editor = await helper.showDocument("USERC1N1.cbl");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(
       diagnostics[0].severity,
       vscode.DiagnosticSeverity.Error,
@@ -48,8 +47,7 @@ suite("Integration Test Suite: Copybooks", function () {
 
   test("TC174657: Copybook - not exist: no syntax ok message", async () => {
     const editor = await helper.showDocument("USERC1F.cbl");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(
       diagnostics[0].severity,
       vscode.DiagnosticSeverity.Error,
@@ -61,8 +59,7 @@ suite("Integration Test Suite: Copybooks", function () {
 
   test("TC174658, TC174658: Copybook - not exist: error underlying and detailed hint", async () => {
     const editor = await helper.showDocument("USERC1F.cbl");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 3);
     helper.assertRangeIsEqual(
       diagnostics[0].range,
@@ -75,8 +72,7 @@ suite("Integration Test Suite: Copybooks", function () {
 
   test("TC174916/TC174917 Copybook - recursive error and detailed hint", async () => {
     const editor = await helper.showDocument("USERC1R.cbl");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 3);
     helper.assertRangeIsEqual(
       diagnostics[0].range,
@@ -92,8 +88,7 @@ suite("Integration Test Suite: Copybooks", function () {
 
   test("TC174932/TC174933 Copybook - invalid definition and hint", async () => {
     const editor = await helper.showDocument("USERC1N2.cbl");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 4);
     helper.assertRangeIsEqual(
       diagnostics[3].range,
@@ -110,8 +105,7 @@ suite("Integration Test Suite: Copybooks", function () {
   test("TC174952 Copybook - not exist, but dynamically appears", async () => {
     await helper.showDocument("VAR.cbl");
     const editor = helper.getEditor("VAR.cbl");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 2);
     helper.assertRangeIsEqual(
       diagnostics[0].range,
@@ -136,8 +130,7 @@ suite("Integration Test Suite: Copybooks", function () {
   test("TC174952 / TC174953 Copybook - definition not exist, but dynamically appears", async () => {
     await helper.showDocument("USERC1F.cbl");
     const editor = helper.getEditor("USERC1F.cbl");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     helper.assertRangeIsEqual(
       diagnostics[2].range,
       new vscode.Range(pos(41, 29), pos(41, 46)),

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
@@ -178,15 +178,15 @@ suite("Integration Test Suite", function () {
     await helper.showDocument("ADSORT.cbl");
     const editor = helper.getEditor("ADSORT.cbl");
     await helper.waitFor(async () => {
-      helper.sleep(100);
-      const result: any[] = await vscode.commands.executeCommand(
+      await helper.sleep(100);
+      const result = await vscode.commands.executeCommand<vscode.Location[]>(
         "vscode.executeDefinitionProvider",
         editor.document.uri,
         pos(58, 36),
       );
       return result.length > 0;
     });
-    const result: any[] = await vscode.commands.executeCommand(
+    const result = await vscode.commands.executeCommand<vscode.Location[]>(
       "vscode.executeDefinitionProvider",
       editor.document.uri,
       pos(58, 36),

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
@@ -36,8 +36,7 @@ suite("Integration Test Suite", function () {
   test("TC152047, TC152052, TC152051, TC152050, TC152053: Error case - file has syntax errors and are marked with detailed hints", async () => {
     await helper.showDocument("USER2.cbl");
     const editor = helper.getEditor("USER2.cbl");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 1);
     const d0 = diagnostics[0];
     assert.strictEqual(d0.message, "Syntax error on 'Program1-id'");
@@ -47,8 +46,7 @@ suite("Integration Test Suite", function () {
   test("TC152050, TC152053: Error case - file has semantic errors and are marked with detailed hints", async () => {
     await helper.showDocument("REPLACING.CBL");
     const editor = helper.getEditor("REPLACING.CBL");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 1);
     const d0 = diagnostics[0];
 
@@ -90,8 +88,7 @@ suite("Integration Test Suite", function () {
       pos(34, 11),
       "           EXEC CICS XCTL PROGRAM (XCTL1) END-EXEC.",
     );
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 1);
     helper.assertRangeIsEqual(
       diagnostics[0].range,
@@ -252,8 +249,7 @@ suite("Integration Test Suite", function () {
   test("TC266094 Underline the entire incorrect variable structure", async () => {
     await helper.showDocument("VAR.cbl");
     const editor = helper.getEditor("VAR.cbl");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 2);
     helper.assertRangeIsEqual(
       diagnostics[0].range,
@@ -277,8 +273,7 @@ suite("Integration Test Suite", function () {
 
   test("Load resource file", async () => {
     const editor = await helper.showDocument("RES.cbl");
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
 
     assert.strictEqual(diagnostics.length, 1);
     assert.ok(
@@ -366,8 +361,7 @@ suite("Integration Test Suite", function () {
     await editor.edit((edit) => {
       edit.replace(range(pos(48, 30), pos(48, 32)), "1.");
     });
-    await helper.waitForDiagnostics(editor.document.uri);
-    const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
     assert.strictEqual(diagnostics.length, 1);
     assert.strictEqual(
       diagnostics[0].message,

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.user1.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.user1.test.ts
@@ -54,7 +54,7 @@ suite("Tests with USER1.cbl", function () {
     }
     let diagnostics: vscode.Diagnostic[] = [];
 
-    await helper.waitFor(async () => {
+    await helper.waitFor(() => {
       diagnostics = vscode.languages.getDiagnostics(
         vscode.window.activeTextEditor!.document.uri,
       );

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.user1.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.user1.test.ts
@@ -55,7 +55,7 @@ suite("Tests with USER1.cbl", function () {
     let diagnostics: vscode.Diagnostic[] = [];
 
     await helper.waitFor(async () => {
-      diagnostics = await vscode.languages.getDiagnostics(
+      diagnostics = vscode.languages.getDiagnostics(
         vscode.window.activeTextEditor!.document.uri,
       );
       return diagnostics.length === 0;
@@ -66,22 +66,33 @@ suite("Tests with USER1.cbl", function () {
     assert.strictEqual(diagnostics.length, 0, expectedMsg);
   });
 
+  async function executeProvider(
+    provider:
+      | "vscode.executeDefinitionProvider"
+      | "vscode.executeReferenceProvider",
+    line: number,
+    char: number,
+  ) {
+    let locations: vscode.Location[] = [];
+    await helper.waitFor(async () => {
+      locations = await vscode.commands.executeCommand(
+        provider,
+        editor.document.uri,
+        pos(line, char),
+      );
+
+      return locations.length > 0;
+    });
+    return locations;
+  }
+
   test("TC152049: Navigate through definitions", async () => {
-    await helper.waitFor(
-      async () =>
-        (
-          (await vscode.commands.executeCommand(
-            "vscode.executeDefinitionProvider",
-            editor.document.uri,
-            pos(28, 24),
-          )) as any[]
-        ).length > 0,
-    );
-    const result: any[] = await vscode.commands.executeCommand(
+    const result = await executeProvider(
       "vscode.executeDefinitionProvider",
-      editor.document.uri,
-      pos(28, 24),
+      28,
+      24,
     );
+
     assert.strictEqual(result.length, 1);
     assert.ok(
       result[0].uri.fsPath.includes(editor.document.fileName) &&
@@ -92,22 +103,12 @@ suite("Tests with USER1.cbl", function () {
   });
 
   test("TC152080: Find all references from the word middle", async () => {
-    await helper.waitFor(
-      async () =>
-        (
-          (await vscode.commands.executeCommand(
-            "vscode.executeReferenceProvider",
-            editor.document.uri,
-            pos(20, 15),
-          )) as any[]
-        ).length > 0,
+    const result = await executeProvider(
+      "vscode.executeReferenceProvider",
+      20,
+      15,
     );
 
-    const result: any[] = await vscode.commands.executeCommand(
-      "vscode.executeReferenceProvider",
-      editor.document.uri,
-      pos(20, 15),
-    );
     assert.strictEqual(result.length, 3, "Check references count");
     assert.ok(
       result[0].uri.fsPath.includes(editor.document.fileName),
@@ -132,22 +133,12 @@ suite("Tests with USER1.cbl", function () {
   });
 
   test("TC152080: Find all references from the word begin", async () => {
-    await helper.waitFor(
-      async () =>
-        (
-          (await vscode.commands.executeCommand(
-            "vscode.executeReferenceProvider",
-            editor.document.uri,
-            pos(20, 10),
-          )) as any[]
-        ).length > 0,
+    const result = await executeProvider(
+      "vscode.executeReferenceProvider",
+      20,
+      10,
     );
 
-    const result: any[] = await vscode.commands.executeCommand(
-      "vscode.executeReferenceProvider",
-      editor.document.uri,
-      pos(20, 10),
-    );
     assert.ok(
       result.length === 3 &&
         result[0].uri.fsPath.includes(editor.document.fileName) &&
@@ -174,7 +165,7 @@ suite("Tests with USER1.cbl", function () {
     await vscode.workspace
       .getConfiguration()
       .update("cobol-lsp.formatting", "None");
-    const result: any[] = await vscode.commands.executeCommand(
+    const result = await vscode.commands.executeCommand<vscode.TextEdit[]>(
       "vscode.executeFormatDocumentProvider",
       editor.document.uri,
       { tabSize: 4, insertSpaces: true },

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/testHelper.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/testHelper.ts
@@ -155,11 +155,16 @@ export async function waitForDiagnostics(
   uri: vscode.Uri,
   timeout: number = 50000,
 ) {
-  return waitFor(
-    () => vscode.languages.getDiagnostics(uri).length > 0,
+  let diagnostics: vscode.Diagnostic[] = [];
+  await waitFor(
+    () => {
+      diagnostics = vscode.languages.getDiagnostics(uri);
+      return diagnostics.length > 0;
+    },
     timeout,
     "diagnostics (" + path.basename(uri.fsPath) + ")",
   );
+  return diagnostics;
 }
 
 export async function waitFor(

--- a/clients/cobol-lsp-vscode-extension/src/type/nyc.d.ts
+++ b/clients/cobol-lsp-vscode-extension/src/type/nyc.d.ts
@@ -1,0 +1,32 @@
+declare module "nyc" {
+  namespace NYC {
+    interface Config {
+      tempDirectory?: string;
+      cache?: boolean;
+      cwd?: string;
+      exclude?: string | string[];
+      sourceMap?: boolean;
+      hookRequire?: boolean;
+      hookRunInContext?: boolean;
+      hookRunInThisContext?: boolean;
+      reporter?: string[];
+    }
+
+    interface NYC {
+      wrap: () => void;
+      createTempDirectory: () => Promise<void>;
+      writeCoverageFile: () => Promise<void>;
+      getCoverageMapFromAllCoverageFiles: (
+        baseDirectory: string,
+      ) => Promise<object>;
+      report: () => Promise<void>;
+    }
+  }
+
+  let NYC: {
+    new (config: NYC.Config): NYC.NYC;
+    name: string;
+  };
+
+  export = NYC;
+}

--- a/clients/cobol-lsp-vscode-extension/src/type/zoweApi.d.ts
+++ b/clients/cobol-lsp-vscode-extension/src/type/zoweApi.d.ts
@@ -38,13 +38,22 @@ interface ProfilesCache {
 }
 
 interface IUss {
-  getContents(dataSetName: string, options?: any): Promise<IZosFilesResponse>;
+  getContents(
+    dataSetName: string,
+    options?: unknown,
+  ): Promise<IZosFilesResponse>;
   fileList(ussFilePath: string): Promise<IZosFilesResponse>;
 }
 
 interface IMvs {
-  getContents(dataSetName: string, options?: any): Promise<IZosFilesResponse>;
-  allMembers(dataSetName: string, options?: any): Promise<IZosFilesResponse>;
+  getContents(
+    dataSetName: string,
+    options?: unknown,
+  ): Promise<IZosFilesResponse>;
+  allMembers(
+    dataSetName: string,
+    options?: unknown,
+  ): Promise<IZosFilesResponse>;
 }
 
 interface IProfileLoaded {

--- a/clients/cobol-lsp-vscode-extension/src/web/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/web/extension.ts
@@ -35,10 +35,13 @@ export function activate(context: ExtensionContext) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("cobol-lsp.snippets.insertSnippets", () => {
-      outputChannel.appendLine("Executing Insert Cobol Snippet command");
-      pickSnippet();
-    }),
+    vscode.commands.registerCommand(
+      "cobol-lsp.snippets.insertSnippets",
+      async () => {
+        outputChannel.appendLine("Executing Insert Cobol Snippet command");
+        await pickSnippet();
+      },
+    ),
   );
 
   initSmartTab(context);

--- a/clients/cobol-lsp-vscode-extension/src/web/test/suite/mochaTestRunner.ts
+++ b/clients/cobol-lsp-vscode-extension/src/web/test/suite/mochaTestRunner.ts
@@ -19,7 +19,7 @@ export function run(): Promise<void> {
       });
     } catch (err) {
       console.error(err);
-      e(err);
+      e(err as Error);
     }
   });
 }

--- a/clients/cobol-lsp-vscode-extension/tsconfig.json
+++ b/clients/cobol-lsp-vscode-extension/tsconfig.json
@@ -28,6 +28,7 @@
     "lib": ["es6", "es2020"],
     "module": "commonjs",
     "moduleResolution": "node",
+    "rootDir": "src",
     "outDir": "out",
     "sourceMap": true,
     "resolveJsonModule": true


### PR DESCRIPTION
## Changes
I replaced all usage of the `any` type in the code with correct typings and fix all other warnings reported by the ESLint.

I tried to improve mocking in the project. I removed a lot of unnecessary mock from unit tests and replaced them with global mocks from the `__mocks__` folder. But there is still opportunity for improvement. I would like to remove mocks like this one `vscode.window.showErrorMessage = jest.fn();`. I think we should avoid this kind of mocks as they are not restored by `jest.clearAllMocks();`, so I suggest to replace them with `jest.spyOn`. But I would do that in separate PR as this one is already quite big.

There should be no changes in business logic, only exception is in the `Settings` service where I refactored the `lspConfigHandler` function.

Sorry for a big PR 😞 

## How Has This Been Tested?

Unit and integration tests

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
