### PR TITLE
fix: moved setTrace method to correct class

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.user1.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.user1.test.ts
@@ -52,9 +52,15 @@ suite("Tests with USER1.cbl", function () {
     if (vscode.window.activeTextEditor === undefined) {
       assert.fail("activeTextEditor in undefined");
     }
-    const diagnostics = vscode.languages.getDiagnostics(
-      vscode.window.activeTextEditor.document.uri,
-    );
+    let diagnostics: vscode.Diagnostic[] = [];
+
+    await helper.waitFor(async () => {
+      diagnostics = await vscode.languages.getDiagnostics(
+        vscode.window.activeTextEditor!.document.uri,
+      );
+      return diagnostics.length === 0;
+    });
+
     const expectedMsg =
       "Checks that when opening Cobol file with correct syntax there is an appropriate message is shown";
     assert.strictEqual(diagnostics.length, 0, expectedMsg);

--- a/server/engine/src/main/resources/META-INF/native-image/basic/reflect-config.json
+++ b/server/engine/src/main/resources/META-INF/native-image/basic/reflect-config.json
@@ -3,14 +3,22 @@
     "name": "[Ljava.lang.Object;"
   },
   {
-    "name":"[Ljava.lang.String;"
+    "name": "[Ljava.lang.String;"
   },
   {
-    "name":"ch.qos.logback.core.ConsoleAppender",
-    "queryAllPublicMethods":true,
-    "methods":[
-      {"name":"<init>","parameterTypes":[] },
-      {"name":"setTarget","parameterTypes":["java.lang.String"] }
+    "name": "ch.qos.logback.core.ConsoleAppender",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setTarget",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
     ]
   },
   {
@@ -3756,6 +3764,12 @@
       {
         "name": "shutdown",
         "parameterTypes": []
+      },
+      {
+        "name": "setTrace",
+        "parameterTypes": [
+          "org.eclipse.lsp4j.SetTraceParams"
+        ]
       }
     ]
   },
@@ -3931,13 +3945,17 @@
     ]
   },
   {
-    "name":"org.eclipse.lsp4j.SetTraceParams",
-    "allDeclaredFields":true,
-    "methods":[{"name":"<init>","parameterTypes":[] }]
+    "name": "org.eclipse.lsp4j.SetTraceParams",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   },
-  {"name":"setTrace","parameterTypes":["org.eclipse.lsp4j.SetTraceParams"] },
   {
-    "name":"org.eclipse.lsp.cobol.common.copybook.CopyBookDTO",
-    "allDeclaredFields":true
+    "name": "org.eclipse.lsp.cobol.common.copybook.CopyBookDTO",
+    "allDeclaredFields": true
   }
 ]


### PR DESCRIPTION
Moved setTrace method in `reflect-config.json` into `LanguageServer` class, where it belongs.
Changed how `lsp.spec.user1.test.ts` so it passes in CI. It seems like it was broken in #2563 as CI pipeline fails for all builds since it was merged.

## How Has This Been Tested?
I manually tested the updated binary and I no longer receive the reflection errors.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
