### PR TITLE
fix: Clear copybook cache command should not fail if cache directory doesn't exist

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
@@ -192,3 +192,17 @@ export const languages = {
   registerCodeActionsProvider: jest.fn(),
   registerCompletionItemProvider: jest.fn(),
 };
+
+class FileNotFound extends Error {
+  code: string;
+  constructor() {
+    super();
+    this.code = "FileNotFound";
+  }
+}
+
+export const FileSystemError = {
+  FileNotFound: () => {
+    return new FileNotFound();
+  },
+};

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/ClearCopybookCacheCommand.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/ClearCopybookCacheCommand.spec.ts
@@ -43,4 +43,18 @@ describe("Tests downloaded copybook cache clear", () => {
       { recursive: true, useTrash: false },
     );
   });
+
+  describe("Cache clear errors", () => {
+    beforeAll(() => {
+      jest
+        .spyOn(vscode.workspace.fs, "readDirectory")
+        .mockImplementation(() => {
+          throw vscode.FileSystemError.FileNotFound();
+        });
+    });
+
+    it("doesn't fail if cache folder doesn't exist", async () => {
+      await clearCache(vscode.Uri.file("/storagePath"));
+    });
+  });
 });

--- a/clients/cobol-lsp-vscode-extension/src/commands/ClearCopybookCacheCommand.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/ClearCopybookCacheCommand.ts
@@ -20,6 +20,7 @@ import {
   E4E_FOLDER,
   ZOWE_FOLDER,
 } from "../constants";
+import { hasMember } from "../services/util/Utils";
 
 /**
  * Clears the downloaded copybook cache folder ({globalStoragePath}/zowe/copybooks).
@@ -45,7 +46,17 @@ export function clearCache(uri: vscode.Uri) {
 }
 
 async function deleteFolderContent(fileUri: vscode.Uri) {
-  const files = await vscode.workspace.fs.readDirectory(fileUri);
+  let files: [string, vscode.FileType][] = [];
+  try {
+    files = await vscode.workspace.fs.readDirectory(fileUri);
+  } catch (err) {
+    if (hasMember(err, "code") && err.code === "FileNotFound") {
+      // directory doesn't exists - ignore
+    } else {
+      throw err;
+    }
+  }
+
   return files.map(([name, _]) =>
     vscode.workspace.fs.delete(vscode.Uri.joinPath(fileUri, name), {
       recursive: true,


### PR DESCRIPTION
Fixes issue when the clear copybook cache command fails with the "unable to resolve file" error when the cache directory doesn't exists (for example E4E extension is not installed).

## How Has This Been Tested?

I was able to reproduce the issue and test the fix manually and added new unit test.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
