### PR TITLE
fix: Use real copybook location from configuration to check credentials

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/getZoweExplorerMock.utility.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/getZoweExplorerMock.utility.ts
@@ -29,25 +29,43 @@ class MemberError extends Error {
     errorCode: number;
   };
 
-  constructor(message: string) {
+  constructor(message: string, errorCode: number) {
     super(message);
     this.mDetails = {
-      errorCode: 401,
+      errorCode,
     };
   }
 }
-const error = new MemberError("Error");
 
-export const allMemberErrorMock = jest.fn().mockRejectedValue(error);
-export const mvsApiMock = jest.fn().mockReturnValue({
-  allMembers: allMemberMock,
-  getContents: getContentMock,
-});
+export const unauthorizedErrorMock = jest
+  .fn()
+  .mockRejectedValue(
+    new MemberError(
+      "Rest API failure with HTTP(S) status 401\nThis operation requires authentication.\nToken is not valid or expired.",
+      401,
+    ),
+  );
+export const notFoundErrorMock = jest
+  .fn()
+  .mockRejectedValue(
+    new MemberError(
+      "Rest API failure with HTTP(S) status 404\nISRZ002 Data set not cataloged",
+      404,
+    ),
+  );
+export const permissionsErrorMock = jest.fn().mockRejectedValue(
+  new MemberError(
+    `Rest API failure with HTTP(S) status 500
+ISRZ002 Authorization failed - You may not use this protected data set. Open 913 abend.`,
+    500,
+  ),
+);
 
-export const mvsApiMockWithError = jest.fn().mockReturnValue({
-  allMembers: allMemberErrorMock,
-  getContents: getContentMock,
-});
+export const mvsApiMock = (allMembers = allMemberMock) =>
+  jest.fn().mockReturnValue({
+    allMembers,
+    getContents: getContentMock,
+  });
 
 export const allUSSFilemembers = jest.fn().mockReturnValue({
   apiResponse: {
@@ -58,28 +76,17 @@ export const allUSSFilemembers = jest.fn().mockReturnValue({
     ],
   },
 });
-export const ussApiMock = jest.fn().mockReturnValue({
-  fileList: allUSSFilemembers,
-  getContents: getUSSContentsMock,
-});
-const ussApiMockWithError = jest.fn().mockReturnValue({
-  fileList: allMemberErrorMock,
-  getContents: getUSSContentsMock,
-});
-export const zoweExplorerMock: IApiRegisterClient = {
-  getExplorerExtenderApi: jest.fn().mockReturnValue({
-    getProfilesCache: jest.fn().mockReturnValue({
-      loadNamedProfile: jest.fn().mockReturnValue({
-        profile: { encoding: undefined, name: "profile" },
-      }),
-    }),
-  }),
-  getMvsApi: mvsApiMock,
-  getUssApi: ussApiMock,
-  registeredApiTypes: jest.fn().mockReturnValue([]),
-};
 
-export const zoweExplorerErrorMock = {
+export const ussApiMock = (fileList = allUSSFilemembers) =>
+  jest.fn().mockReturnValue({
+    fileList,
+    getContents: getUSSContentsMock,
+  });
+
+export const createZoweExplorerMock = (
+  allMembers = allMemberMock,
+  fileList = allUSSFilemembers,
+): IApiRegisterClient => ({
   getExplorerExtenderApi: jest.fn().mockReturnValue({
     getProfilesCache: jest.fn().mockReturnValue({
       loadNamedProfile: jest.fn().mockReturnValue({
@@ -87,7 +94,7 @@ export const zoweExplorerErrorMock = {
       }),
     }),
   }),
-  getMvsApi: mvsApiMockWithError,
-  getUssApi: ussApiMockWithError,
+  getMvsApi: mvsApiMock(allMembers),
+  getUssApi: ussApiMock(fileList),
   registeredApiTypes: jest.fn().mockReturnValue([]),
-};
+});

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
@@ -109,7 +109,11 @@ export namespace window {
     find: jest.fn(),
   };
   export const visibleTextEditors = [];
-  export const withProgress = jest.fn();
+  export const withProgress = jest
+    .fn()
+    .mockImplementation((_options, task: () => void) => {
+      task();
+    });
 }
 export enum StatusBarAlignment {
   Right,

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
@@ -109,6 +109,7 @@ export namespace window {
     find: jest.fn(),
   };
   export const visibleTextEditors = [];
+  export const withProgress = jest.fn();
 }
 export enum StatusBarAlignment {
   Right,

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -24,9 +24,10 @@ import { ProfileUtils } from "../../../services/util/ProfileUtils";
 import { Utils } from "../../../services/util/Utils";
 import * as vscode from "vscode";
 import {
-  allMemberErrorMock,
-  zoweExplorerErrorMock,
-  zoweExplorerMock,
+  notFoundErrorMock,
+  permissionsErrorMock,
+  unauthorizedErrorMock,
+  createZoweExplorerMock,
 } from "../../../__mocks__/getZoweExplorerMock.utility";
 import { DownloadUtil } from "../../../services/copybook/downloader/DownloadUtil";
 import { SettingsService } from "../../../services/Settings";
@@ -34,13 +35,31 @@ import { E4E } from "../../../type/e4eApi";
 import { e4eMock } from "../../../__mocks__/getE4EMock.utility";
 
 jest.mock("../../../services/reporter");
-Utils.getZoweExplorerAPI = jest.fn().mockReturnValue({ api: zoweExplorerMock });
+Utils.getZoweExplorerAPI = jest
+  .fn()
+  .mockReturnValue({ api: createZoweExplorerMock });
 
 describe("Tests copybook download service", () => {
   let downloadService: CopybookDownloadService;
 
   let workspaceConfigurationMock: Record<string, string[] | undefined>;
   let profileName: string;
+
+  let zoweExplorerMock: IApiRegisterClient;
+  let zoweMockUnauthorizedError: IApiRegisterClient;
+  let zoweMockNotFoundError: IApiRegisterClient;
+
+  beforeAll(() => {
+    zoweExplorerMock = createZoweExplorerMock();
+    zoweMockUnauthorizedError = createZoweExplorerMock(
+      unauthorizedErrorMock,
+      unauthorizedErrorMock,
+    );
+    zoweMockNotFoundError = createZoweExplorerMock(
+      notFoundErrorMock,
+      notFoundErrorMock,
+    );
+  });
 
   beforeEach(() => {
     downloadService = new CopybookDownloadService(
@@ -103,60 +122,106 @@ describe("Tests copybook download service", () => {
       });
     });
 
-    describe("invalid credentials", () => {
-      beforeEach(() => {
-        downloadService = new CopybookDownloadService(
-          "storage-path",
-          zoweExplorerErrorMock,
-        );
-        downloadService["processDownloadError"] = jest.fn();
-      });
-
-      describe("uss configuration", () => {
+    describe("credentials check", () => {
+      describe("invalid credentials", () => {
         beforeEach(() => {
-          workspaceConfigurationMock[PATHS_DSN] = undefined;
-          workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
-        });
-
-        it("checks profile with invalid credentials do not trigger download", async () => {
-          await downloadService.downloadCopybooks("document-uri", [
-            { name: "copybook-name", dialect: DEFAULT_DIALECT },
-          ]);
-
-          expect(allMemberErrorMock).toHaveBeenCalledWith("/u/test/copybooks");
-          expect(zoweExplorerErrorMock.getUssApi).toHaveBeenCalled();
-          expect(zoweExplorerErrorMock.getMvsApi).not.toHaveBeenCalled();
-
-          expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-            "Incorrect credentials in Zowe profile profile.",
+          downloadService = new CopybookDownloadService(
+            "storage-path",
+            zoweMockUnauthorizedError,
           );
+          downloadService["processDownloadError"] = jest.fn();
+        });
+
+        describe("uss configuration", () => {
+          beforeEach(() => {
+            workspaceConfigurationMock[PATHS_DSN] = undefined;
+            workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
+          });
+
+          it("checks profile with invalid credentials do not trigger download", async () => {
+            await downloadService.downloadCopybooks("document-uri", [
+              { name: "copybook-name", dialect: DEFAULT_DIALECT },
+            ]);
+
+            expect(unauthorizedErrorMock).toHaveBeenCalledWith(
+              "/u/test/copybooks",
+            );
+            expect(zoweMockUnauthorizedError.getUssApi).toHaveBeenCalled();
+            expect(zoweMockUnauthorizedError.getMvsApi).not.toHaveBeenCalled();
+
+            expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+              "Incorrect credentials in Zowe profile profile.",
+            );
+          });
+        });
+
+        describe("mvs configuration", () => {
+          beforeEach(() => {
+            workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOKS"];
+            workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
+          });
+
+          it("checks profile with invalid credentials do not trigger download", async () => {
+            await downloadService.downloadCopybooks("document-uri", [
+              { name: "copybook-name", dialect: DEFAULT_DIALECT },
+            ]);
+
+            expect(unauthorizedErrorMock).toHaveBeenCalledWith(
+              "TEST.COBOL.COPYBOOKS",
+            );
+            expect(zoweMockUnauthorizedError.getUssApi).not.toHaveBeenCalled();
+            expect(zoweMockUnauthorizedError.getMvsApi).toHaveBeenCalled();
+
+            expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+              "Incorrect credentials in Zowe profile profile.",
+            );
+          });
         });
       });
 
-      describe("mvs configuration", () => {
+      describe("credentials are valid but copybook dataset doesn't exists", () => {
         beforeEach(() => {
+          downloadService = new CopybookDownloadService(
+            "storage-path",
+            zoweMockNotFoundError,
+          );
           workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOKS"];
           workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
+
+          downloadService.downloadCopybook = jest.fn().mockResolvedValue(true);
         });
 
-        it("checks profile with invalid credentials do not trigger download", async () => {
+        it("credentials are considered valid, copybooks can be downloaded", async () => {
           await downloadService.downloadCopybooks("document-uri", [
             { name: "copybook-name", dialect: DEFAULT_DIALECT },
           ]);
 
-          expect(allMemberErrorMock).toHaveBeenCalledWith(
-            "TEST.COBOL.COPYBOOKS",
-          );
-          expect(zoweExplorerErrorMock.getUssApi).not.toHaveBeenCalled();
-          expect(zoweExplorerErrorMock.getMvsApi).toHaveBeenCalled();
+          expect(vscode.window.withProgress).toHaveBeenCalled();
+        });
+      });
 
-          expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-            "Incorrect credentials in Zowe profile profile.",
+      describe("credentials are valid and dataset exists, but user doesn't have permissions for the dataset", () => {
+        beforeEach(() => {
+          downloadService = new CopybookDownloadService(
+            "storage-path",
+            createZoweExplorerMock(permissionsErrorMock),
           );
+          workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOKS"];
+          workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
+
+          downloadService.downloadCopybook = jest.fn().mockResolvedValue(true);
+        });
+
+        it("credentials are considered valid, copybooks can be downloaded", async () => {
+          await downloadService.downloadCopybooks("document-uri", [
+            { name: "copybook-name", dialect: DEFAULT_DIALECT },
+          ]);
+
+          expect(downloadService.downloadCopybook).toHaveBeenCalled();
+          expect(vscode.window.withProgress).toHaveBeenCalled();
         });
       });
     });
-
     describe("if user is able to list the configured copybook dataset, credentials are considered as valid", () => {
       beforeEach(() => {
         downloadService = new CopybookDownloadService(
@@ -180,7 +245,7 @@ describe("Tests copybook download service", () => {
       vscode.window.showErrorMessage = jest.fn();
       const downloadService = new CopybookDownloadService(
         "storage-path",
-        zoweExplorerErrorMock,
+        zoweExplorerMock,
       );
       ProfileUtils.getAvailableProfiles = jest.fn().mockReturnValue("profile");
       downloadService["processDownloadError"] = jest.fn();
@@ -199,7 +264,7 @@ describe("Tests copybook download service", () => {
     it("checks locked profile do not trigger download", async () => {
       const downloadService = new CopybookDownloadService(
         "storage-path",
-        zoweExplorerErrorMock,
+        zoweExplorerMock,
       );
       ProfileUtils.getAvailableProfiles = jest.fn().mockReturnValue("profile");
       DownloadUtil.isProfileLocked = jest.fn().mockReturnValue(true);

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -15,6 +15,8 @@
 import {
   DEFAULT_DIALECT,
   ENDEVOR_PROCESSOR,
+  PATHS_DSN,
+  PATHS_USS,
   PROVIDE_PROFILE_MSG,
 } from "../../../constants";
 import { CopybookDownloadService } from "../../../services/copybook/CopybookDownloadService";
@@ -22,6 +24,7 @@ import { ProfileUtils } from "../../../services/util/ProfileUtils";
 import { Utils } from "../../../services/util/Utils";
 import * as vscode from "vscode";
 import {
+  allMemberErrorMock,
   zoweExplorerErrorMock,
   zoweExplorerMock,
 } from "../../../__mocks__/getZoweExplorerMock.utility";
@@ -36,26 +39,43 @@ Utils.getZoweExplorerAPI = jest.fn().mockReturnValue({ api: zoweExplorerMock });
 describe("Tests copybook download service", () => {
   let downloadService: CopybookDownloadService;
 
+  let workspaceConfigurationMock: Record<string, unknown>;
+  let profileName: string;
+
   beforeEach(() => {
     downloadService = new CopybookDownloadService(
       "storage-path",
       {} as unknown as IApiRegisterClient,
     );
     downloadService["processDownloadError"] = jest.fn();
-    jest
-      .spyOn(DownloadUtil, "areCopybookDownloadConfigurationsPresent")
-      .mockReturnValue(true);
+
+    workspaceConfigurationMock = {
+      "paths-dsn": ["TESTUSER.COPYBOOKS", "TESTUSER.COPYBKS2"],
+      "paths-uss": ["/u/test/copybooks"],
+    };
+    jest.spyOn(vscode.workspace, "getConfiguration").mockImplementation(
+      () =>
+        ({
+          get: (key: string) => workspaceConfigurationMock[key],
+        } as unknown as vscode.WorkspaceConfiguration),
+    );
+
     jest
       .spyOn(ProfileUtils, "getAvailableProfiles")
       .mockReturnValue(["profile"]);
+
+    profileName = "profile";
+    jest
+      .spyOn(ProfileUtils, "getProfileNameForCopybook")
+      .mockImplementation(() => profileName);
+
+    jest.clearAllMocks();
   });
 
   describe("checks the prerequisites are checked before invoking download", () => {
     describe("unknown-profile", () => {
       beforeEach(() => {
-        jest
-          .spyOn(ProfileUtils, "getProfileNameForCopybook")
-          .mockReturnValue("unknown-profile");
+        profileName = "unknown-profile";
       });
 
       it("checks download fails when provided profile is not a valid profile", async () => {
@@ -70,9 +90,7 @@ describe("Tests copybook download service", () => {
 
     describe("profile not profiled", () => {
       beforeEach(() => {
-        jest
-          .spyOn(ProfileUtils, "getProfileNameForCopybook")
-          .mockReturnValue("");
+        profileName = "";
       });
 
       it("checks download fails when provided profile is not provided", async () => {
@@ -87,42 +105,89 @@ describe("Tests copybook download service", () => {
 
     describe("invalid credentials", () => {
       beforeEach(() => {
-        jest
-          .spyOn(ProfileUtils, "getProfileNameForCopybook")
-          .mockReturnValue("profile");
-        jest.spyOn(DownloadUtil, "isProfileLocked").mockResolvedValue(false);
-
         downloadService = new CopybookDownloadService(
           "storage-path",
           zoweExplorerErrorMock,
         );
         downloadService["processDownloadError"] = jest.fn();
+        jest.clearAllMocks();
       });
+
+      describe("uss configuration", () => {
+        beforeEach(() => {
+          workspaceConfigurationMock[PATHS_DSN] = undefined;
+          workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
+        });
+
+        it("checks profile with invalid credentials do not trigger download", async () => {
+          await downloadService.downloadCopybooks("document-uri", [
+            { name: "copybook-name", dialect: DEFAULT_DIALECT },
+          ]);
+
+          expect(allMemberErrorMock).toHaveBeenCalledWith("/u/test/copybooks");
+          expect(zoweExplorerErrorMock.getUssApi).toHaveBeenCalled();
+          expect(zoweExplorerErrorMock.getMvsApi).not.toHaveBeenCalled();
+
+          expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            "Incorrect credentials in Zowe profile profile.",
+          );
+        });
+      });
+
+      describe("mvs configuration", () => {
+        beforeEach(() => {
+          workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOKS"];
+          workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
+        });
+
+        it("checks profile with invalid credentials do not trigger download", async () => {
+          await downloadService.downloadCopybooks("document-uri", [
+            { name: "copybook-name", dialect: DEFAULT_DIALECT },
+          ]);
+
+          expect(allMemberErrorMock).toHaveBeenCalledWith(
+            "TEST.COBOL.COPYBOOKS",
+          );
+          expect(zoweExplorerErrorMock.getUssApi).not.toHaveBeenCalled();
+          expect(zoweExplorerErrorMock.getMvsApi).toHaveBeenCalled();
+
+          expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            "Incorrect credentials in Zowe profile profile.",
+          );
+        });
+      });
+    });
+
+    describe("if user is able to list the configured copybook dataset, credentials are considered as valid", () => {
+      beforeEach(() => {
+        downloadService = new CopybookDownloadService(
+          "storage-path",
+          zoweExplorerMock,
+        );
+        // jest.clearAllMocks();
+      });
+
       it("checks profile with invalid credentials do not trigger download", async () => {
         await downloadService.downloadCopybooks("document-uri", [
           { name: "copybook-name", dialect: DEFAULT_DIALECT },
         ]);
-        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+
+        expect(vscode.window.showErrorMessage).not.toHaveBeenCalledWith(
           "Incorrect credentials in Zowe profile profile.",
         );
       });
     });
 
-    describe("no download configurations", () => {});
     it("checks no profile checks are done when download configurations are not configured", async () => {
       vscode.window.showErrorMessage = jest.fn();
       const downloadService = new CopybookDownloadService(
         "storage-path",
         zoweExplorerErrorMock,
       );
-      ProfileUtils.getProfileNameForCopybook = jest
-        .fn()
-        .mockReturnValue("profile");
       ProfileUtils.getAvailableProfiles = jest.fn().mockReturnValue("profile");
       downloadService["processDownloadError"] = jest.fn();
-      DownloadUtil.areCopybookDownloadConfigurationsPresent = jest
-        .fn()
-        .mockReturnValue(false);
+      workspaceConfigurationMock[PATHS_DSN] = undefined;
+      workspaceConfigurationMock[PATHS_USS] = undefined;
       expect(
         await downloadService.downloadCopybooks("document-uri", [
           { name: "copybook-name", dialect: DEFAULT_DIALECT },
@@ -138,9 +203,6 @@ describe("Tests copybook download service", () => {
         "storage-path",
         zoweExplorerErrorMock,
       );
-      ProfileUtils.getProfileNameForCopybook = jest
-        .fn()
-        .mockReturnValue("profile");
       ProfileUtils.getAvailableProfiles = jest.fn().mockReturnValue("profile");
       DownloadUtil.isProfileLocked = jest.fn().mockReturnValue(true);
       downloadService["processDownloadError"] = jest.fn();
@@ -153,9 +215,6 @@ describe("Tests copybook download service", () => {
   });
 
   it("checks download resolver is invoked with right parameters", async () => {
-    ProfileUtils.getProfileNameForCopybook = jest
-      .fn()
-      .mockReturnValue("profile");
     ProfileUtils.getAvailableProfiles = jest.fn().mockReturnValue("profile");
     DownloadUtil.isProfileLocked = jest.fn().mockReturnValue(false);
     DownloadUtil.checkForInvalidCredProfile = jest.fn().mockReturnValue(false);
@@ -207,9 +266,6 @@ describe("Tests copybook download service", () => {
   });
 
   describe("checks order of resolution [E4E, DSN and USS order]", () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
     it("checks the order of copybook resolution - DSN followed by USS)", async () => {
       const downloader = new CopybookDownloadService(
         "storage-path",
@@ -220,8 +276,6 @@ describe("Tests copybook download service", () => {
         .fn()
         .mockReturnValue(false);
       downloader["ussDownloader"]!.downloadCopybook = jest.fn();
-      SettingsService.getDsnPath = jest.fn().mockReturnValue(["dsn"]);
-      SettingsService.getUssPath = jest.fn().mockReturnValue(["uss"]);
       await downloader.downloadCopybook(
         { name: "copybook", dialect: "COBOL" },
         "document-uri",
@@ -231,14 +285,14 @@ describe("Tests copybook download service", () => {
       ).toHaveBeenCalledWith(
         { name: "copybook", dialect: "COBOL" },
         "document-uri",
-        "dsn",
+        "TESTUSER.COPYBOOKS",
       );
       expect(
         downloader["ussDownloader"]!.downloadCopybook,
       ).toHaveBeenCalledWith(
         { name: "copybook", dialect: "COBOL" },
         "document-uri",
-        "uss",
+        "/u/test/copybooks",
       );
     });
 
@@ -252,8 +306,6 @@ describe("Tests copybook download service", () => {
         .fn()
         .mockReturnValue(true);
       downloader["ussDownloader"]!.downloadCopybook = jest.fn();
-      SettingsService.getDsnPath = jest.fn().mockReturnValue(["dsn"]);
-      SettingsService.getUssPath = jest.fn().mockReturnValue(["uss"]);
       await downloader.downloadCopybook(
         { name: "copybook", dialect: "COBOL" },
         "document-uri",
@@ -263,7 +315,7 @@ describe("Tests copybook download service", () => {
       ).toHaveBeenCalledWith(
         { name: "copybook", dialect: "COBOL" },
         "document-uri",
-        "dsn",
+        "TESTUSER.COPYBOOKS",
       );
       expect(
         downloader["ussDownloader"]!.downloadCopybook,
@@ -319,8 +371,6 @@ describe("Tests copybook download service", () => {
       .mockReturnValueOnce(false)
       .mockReturnValue(true);
     downloader["ussDownloader"]!.downloadCopybook = jest.fn();
-    SettingsService.getDsnPath = jest.fn().mockReturnValue(["dsn", "dsn-2"]);
-    SettingsService.getUssPath = jest.fn().mockReturnValue(["uss"]);
     await downloader.downloadCopybook(
       { name: "copybook", dialect: "COBOL" },
       "document-uri",
@@ -328,12 +378,12 @@ describe("Tests copybook download service", () => {
     expect(downloader["dsnDownloader"]!.downloadCopybook).toHaveBeenCalledWith(
       { name: "copybook", dialect: "COBOL" },
       "document-uri",
-      "dsn",
+      "TESTUSER.COPYBOOKS",
     );
     expect(downloader["dsnDownloader"]!.downloadCopybook).toHaveBeenCalledWith(
       { name: "copybook", dialect: "COBOL" },
       "document-uri",
-      "dsn-2",
+      "TESTUSER.COPYBKS2",
     );
   });
 

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -57,7 +57,7 @@ describe("Tests copybook download service", () => {
       () =>
         ({
           get: (key: string) => workspaceConfigurationMock[key],
-        } as unknown as vscode.WorkspaceConfiguration),
+        }) as unknown as vscode.WorkspaceConfiguration,
     );
 
     jest

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -69,7 +69,7 @@ describe("Tests copybook download service", () => {
     downloadService["processDownloadError"] = jest.fn();
 
     workspaceConfigurationMock = {
-      "paths-dsn": ["TESTUSER.COPYBOOKS", "TESTUSER.COPYBKS2"],
+      "paths-dsn": ["TESTUSER.COPYBOOK", "TESTUSER.COPYBKS2"],
       "paths-uss": ["/u/test/copybooks"],
     };
     jest.spyOn(vscode.workspace, "getConfiguration").mockImplementation(
@@ -157,7 +157,7 @@ describe("Tests copybook download service", () => {
 
         describe("mvs configuration", () => {
           beforeEach(() => {
-            workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOKS"];
+            workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOK"];
             workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
           });
 
@@ -167,7 +167,7 @@ describe("Tests copybook download service", () => {
             ]);
 
             expect(unauthorizedErrorMock).toHaveBeenCalledWith(
-              "TEST.COBOL.COPYBOOKS",
+              "TEST.COBOL.COPYBOOK",
             );
             expect(zoweMockUnauthorizedError.getUssApi).not.toHaveBeenCalled();
             expect(zoweMockUnauthorizedError.getMvsApi).toHaveBeenCalled();
@@ -185,7 +185,7 @@ describe("Tests copybook download service", () => {
             "storage-path",
             zoweMockNotFoundError,
           );
-          workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOKS"];
+          workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOK"];
           workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
 
           downloadService.downloadCopybook = jest.fn().mockResolvedValue(true);
@@ -210,7 +210,7 @@ describe("Tests copybook download service", () => {
             "storage-path",
             createZoweExplorerMock(permissionsErrorMock),
           );
-          workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOKS"];
+          workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOK"];
           workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
 
           downloadService.downloadCopybook = jest.fn().mockResolvedValue(true);
@@ -355,7 +355,7 @@ describe("Tests copybook download service", () => {
       ).toHaveBeenCalledWith(
         { name: "copybook", dialect: "COBOL" },
         "document-uri",
-        "TESTUSER.COPYBOOKS",
+        "TESTUSER.COPYBOOK",
       );
       expect(
         downloader["ussDownloader"]!.downloadCopybook,
@@ -385,7 +385,7 @@ describe("Tests copybook download service", () => {
       ).toHaveBeenCalledWith(
         { name: "copybook", dialect: "COBOL" },
         "document-uri",
-        "TESTUSER.COPYBOOKS",
+        "TESTUSER.COPYBOOK",
       );
       expect(
         downloader["ussDownloader"]!.downloadCopybook,
@@ -448,7 +448,7 @@ describe("Tests copybook download service", () => {
     expect(downloader["dsnDownloader"]!.downloadCopybook).toHaveBeenCalledWith(
       { name: "copybook", dialect: "COBOL" },
       "document-uri",
-      "TESTUSER.COPYBOOKS",
+      "TESTUSER.COPYBOOK",
     );
     expect(downloader["dsnDownloader"]!.downloadCopybook).toHaveBeenCalledWith(
       { name: "copybook", dialect: "COBOL" },

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -196,7 +196,11 @@ describe("Tests copybook download service", () => {
             { name: "copybook-name", dialect: DEFAULT_DIALECT },
           ]);
 
-          expect(vscode.window.withProgress).toHaveBeenCalled();
+          expect(vscode.window.showErrorMessage).not.toHaveBeenCalledWith(
+            "Incorrect credentials in Zowe profile profile.",
+          );
+
+          expect(downloadService.downloadCopybook).toHaveBeenCalled();
         });
       });
 
@@ -217,8 +221,11 @@ describe("Tests copybook download service", () => {
             { name: "copybook-name", dialect: DEFAULT_DIALECT },
           ]);
 
+          expect(vscode.window.showErrorMessage).not.toHaveBeenCalledWith(
+            "Incorrect credentials in Zowe profile profile.",
+          );
+
           expect(downloadService.downloadCopybook).toHaveBeenCalled();
-          expect(vscode.window.withProgress).toHaveBeenCalled();
         });
       });
     });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -39,7 +39,7 @@ Utils.getZoweExplorerAPI = jest.fn().mockReturnValue({ api: zoweExplorerMock });
 describe("Tests copybook download service", () => {
   let downloadService: CopybookDownloadService;
 
-  let workspaceConfigurationMock: Record<string, unknown>;
+  let workspaceConfigurationMock: Record<string, string[] | undefined>;
   let profileName: string;
 
   beforeEach(() => {
@@ -110,7 +110,6 @@ describe("Tests copybook download service", () => {
           zoweExplorerErrorMock,
         );
         downloadService["processDownloadError"] = jest.fn();
-        jest.clearAllMocks();
       });
 
       describe("uss configuration", () => {
@@ -164,7 +163,6 @@ describe("Tests copybook download service", () => {
           "storage-path",
           zoweExplorerMock,
         );
-        // jest.clearAllMocks();
       });
 
       it("checks profile with invalid credentials do not trigger download", async () => {

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForDsnTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForDsnTest.spec.ts
@@ -15,7 +15,7 @@
 import { CopybookDownloaderForDsn } from "../../../../services/copybook/downloader/CopybookDownloaderForDsn";
 import { ProfileUtils } from "../../../../services/util/ProfileUtils";
 import {
-  zoweExplorerMock,
+  createZoweExplorerMock,
   allMemberMock,
   getContentMock,
 } from "../../../../__mocks__/getZoweExplorerMock.utility";
@@ -36,7 +36,7 @@ describe("Tests Copybook download from DNS", () => {
   describe("checks if the copybook is eligible to dowload passed on user settings", () => {
     const downloader = new CopybookDownloaderForDsn(
       "storage-path",
-      zoweExplorerMock,
+      createZoweExplorerMock(),
     );
     beforeEach(() => {
       jest.clearAllMocks();
@@ -85,7 +85,7 @@ describe("Tests Copybook download from DNS", () => {
   describe("checks the copybook download using ZE DSN API's", () => {
     const downloader = new CopybookDownloaderForDsn(
       "storage-path",
-      zoweExplorerMock,
+      createZoweExplorerMock(),
     );
     it("checks not eligible copybook are not downloaded", async () => {
       downloader.isEligibleForDownload = jest.fn().mockReturnValue(false);

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForUssTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForUssTest.spec.ts
@@ -14,7 +14,7 @@
 
 import { ProfileUtils } from "../../../../services/util/ProfileUtils";
 import {
-  zoweExplorerMock,
+  createZoweExplorerMock,
   allUSSFilemembers,
   getUSSContentsMock,
 } from "../../../../__mocks__/getZoweExplorerMock.utility";
@@ -36,7 +36,7 @@ describe("Tests Copybook download from USS", () => {
   describe("checks if the copybook is eligible to dowload passed on user settings", () => {
     const downloader = new CopybookDownloaderForUss(
       "storage-path",
-      zoweExplorerMock,
+      createZoweExplorerMock(),
     );
     beforeEach(() => {
       jest.clearAllMocks();
@@ -85,7 +85,7 @@ describe("Tests Copybook download from USS", () => {
   describe("checks the copybook download using ZE USS API's", () => {
     const downloader = new CopybookDownloaderForUss(
       "storage-path",
-      zoweExplorerMock,
+      createZoweExplorerMock(),
     );
     it("checks not eligible copybook are not downloaded", async () => {
       downloader.isEligibleForDownload = jest.fn().mockReturnValue(false);

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -268,13 +268,6 @@ export class CopybookDownloadService {
     if (this.handleAsEndevorElement(documentUri)) {
       return !!(await this.e4eDownloader?.getE4EConfig(documentUri));
     }
-    if (
-      !DownloadUtil.areCopybookDownloadConfigurationsPresent(
-        documentUri,
-        copybookNames,
-      )
-    )
-      return false;
     if (!this.explorerApi) return false;
     const profile = ProfileUtils.getProfileNameForCopybook(
       documentUri,
@@ -295,6 +288,8 @@ export class CopybookDownloadService {
       !(await DownloadUtil.checkForInvalidCredProfile(
         profile,
         this.explorerApi,
+        documentUri,
+        copybookNames,
       ))
     );
   }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
@@ -81,7 +81,6 @@ export class DownloadUtil {
       return false;
     }
 
-    // get remote location of copybooks from settings
     const copybookLocation = this.areCopybookDownloadConfigurationsPresent(
       documentUri,
       copybookNames,

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
@@ -98,8 +98,9 @@ export class DownloadUtil {
         await explorerAPI.getMvsApi(profile).allMembers(copybookLocation.dsn);
       }
     } catch (error) {
-      this.checkForInvalidCredentials(error, profileName);
-      return true;
+      if (this.checkForInvalidCredentials(error, profileName)) {
+        return true;
+      }
     }
 
     ZoweExplorerDownloader.profileStore.set(profileName, "valid-profile");
@@ -122,7 +123,15 @@ export class DownloadUtil {
       .loadNamedProfile(profileName);
   }
 
-  private static checkForInvalidCredentials(e: unknown, profileName: string) {
+  private static checkForInvalidCredentials(
+    e: unknown,
+    profileName: string,
+  ): boolean {
+    if (this.isNotFoundError(e) || this.isPermissionError(e)) {
+      // Cannot access the dataset, but credentials are working fine
+      return false;
+    }
+
     if (this.isInvalidCredentials(e)) {
       ZoweExplorerDownloader.profileStore.set(profileName, "locked-profile");
       const errorMessage = INVALID_CREDENTIALS_ERROR_MSG.replace(
@@ -130,6 +139,7 @@ export class DownloadUtil {
         profileName,
       );
       vscode.window.showErrorMessage(errorMessage);
+      return true;
     }
 
     registerExceptionEvent(
@@ -138,6 +148,7 @@ export class DownloadUtil {
       ["copybook", "COBOL", "invalid-credentials-check"],
       "There is an issue with zowe api layer",
     );
+    return true;
   }
 
   /**
@@ -201,11 +212,45 @@ export class DownloadUtil {
     return action === UNLOCK_DOWNLOAD_QUEUE_MSG;
   }
 
+  /**
+   * Checks if the error returned by Zowe Explorer is caused
+   * by invalid credentials. Error with status code 401 is returned
+   * in that case.
+   */
   private static isInvalidCredentials(e: unknown) {
     return (
       hasMember(e, "mDetails") &&
       hasMember(e.mDetails, "errorCode") &&
       e.mDetails.errorCode === 401
+    );
+  }
+
+  /**
+   * Returns true if provided credentials are correct but user doesn't
+   * have permission to access selected dataset (ISRZ002)
+   * or uss directory (EDC5111I).
+   */
+  private static isPermissionError(e: unknown) {
+    return (
+      hasMember(e, "mDetails") &&
+      hasMember(e.mDetails, "errorCode") &&
+      e.mDetails.errorCode === 500 &&
+      hasMember(e, "message") &&
+      typeof e.message === "string" &&
+      (e.message.includes("EDC5111I Permission denied") ||
+        e.message.includes("ISRZ002 Authorization failed"))
+    );
+  }
+
+  /**
+   * Returns true if provided credentials are correct but
+   * selected dataset or uss folder doesn't exist.
+   */
+  private static isNotFoundError(e: unknown) {
+    return (
+      hasMember(e, "mDetails") &&
+      hasMember(e.mDetails, "errorCode") &&
+      e.mDetails.errorCode === 404
     );
   }
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
@@ -72,6 +72,8 @@ export class DownloadUtil {
   public static async checkForInvalidCredProfile(
     profileName: string,
     explorerAPI: IApiRegisterClient,
+    documentUri: string,
+    copybookNames: CopybookName[],
   ): Promise<boolean> {
     if (
       ZoweExplorerDownloader.profileStore.get(profileName) === "valid-profile"
@@ -79,9 +81,23 @@ export class DownloadUtil {
       return false;
     }
 
+    // get remote location of copybooks from settings
+    const copybookLocation = this.areCopybookDownloadConfigurationsPresent(
+      documentUri,
+      copybookNames,
+    );
+
+    if (!copybookLocation) {
+      return true;
+    }
+
     try {
       const profile = this.loadProfile(profileName, explorerAPI);
-      await explorerAPI.getUssApi(profile).fileList("/");
+      if (copybookLocation.uss) {
+        await explorerAPI.getUssApi(profile).fileList(copybookLocation.uss);
+      } else if (copybookLocation.dsn) {
+        await explorerAPI.getMvsApi(profile).allMembers(copybookLocation.dsn);
+      }
     } catch (error) {
       this.checkForInvalidCredentials(error, profileName);
       return true;
@@ -148,12 +164,12 @@ export class DownloadUtil {
    * checks if copybook download configurations are present
    * @param documentUri
    * @param copybookNames
-   * @returns true if if copybook download configurations are present, false otherwise
+   * @returns copybook location if if copybook download configurations are present, null otherwise
    */
   public static areCopybookDownloadConfigurationsPresent(
     documentUri: string,
     copybookNames: CopybookName[],
-  ): boolean {
+  ) {
     const dialects = new Set(
       copybookNames.map((n) => n.dialect?.toLocaleUpperCase()).filter(Boolean),
     );
@@ -161,12 +177,15 @@ export class DownloadUtil {
     for (const dialect of dialects) {
       const dsnPath = SettingsService.getDsnPath(documentUri, dialect);
       const ussPath = SettingsService.getUssPath(documentUri, dialect);
-      if ((dsnPath?.length ?? 0) > 0 || (ussPath?.length ?? 0) > 0) {
-        return true;
+      if ((dsnPath?.length ?? 0) > 0) {
+        return { dsn: dsnPath[0] };
+      }
+      if ((ussPath?.length ?? 0) > 0) {
+        return { uss: ussPath[0] };
       }
     }
 
-    return false;
+    return null;
   }
 
   private static async showQueueLockedDialog(

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
@@ -133,9 +133,9 @@ export class DownloadUtil {
     }
 
     registerExceptionEvent(
-      undefined,
+      "InvalidCredentialsException",
       JSON.stringify(e),
-      ["copybook", "COBOL", "experiment-tag"],
+      ["copybook", "COBOL", "invalid-credentials-check"],
       "There is an issue with zowe api layer",
     );
   }


### PR DESCRIPTION
Before copybooks are fetched from mainframe, credentials in the Zowe profile are checked. It used to be done by listing `/` USS path. As user might not have permission to list `/`, it's not working for everybody. This PR changes the test location to be the first dataset or USS path specified in the extension configuration. 

I'm still waiting to get access to the telemetry data to see if the problem was really in the listing of the `/` directory

## How Has This Been Tested?

Updated `CopybookDownloadServiceTest.spec.ts` unit test.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
