### PR TITLE
chore: Add build number to version identifier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,7 +372,7 @@ jobs:
           name: lib
           path: clients/cobol-dialect-api
       - name: update version with PR or build number
-        if: github.event.inputs.include_build_number == 'true'
+        if: github.event_name == 'pull_request' || github.event.inputs.include_build_number == 'true'
         working-directory: clients/cobol-lsp-vscode-extension
         env:
           BUILD_ID: ${{github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,11 +367,12 @@ jobs:
         with:
           name: lib
           path: clients/cobol-dialect-api
-      - name: update version for PR
+      - name: update version with PR or build number
         working-directory: clients/cobol-lsp-vscode-extension
-        if: github.event_name == 'pull_request'
+        env:
+          BUILD_ID: ${{github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_number }}
         run: |
-          node -e "const fs=require('fs');const fileName='./package.json';var content=require(fileName);content.version=content.version+'\+pr-'+${{ github.event.pull_request.number }};fs.writeFileSync(fileName,JSON.stringify(content,null,2));"
+          node -e "const fs=require('fs');const fileName='./package.json';var content=require(fileName);content.version=content.version+'\+'+'${{ env.BUILD_ID }}';fs.writeFileSync(fileName,JSON.stringify(content,null,2));"
       - name: Build COBOL LS extension 
         run: npm ci
         working-directory: clients/cobol-lsp-vscode-extension

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ on:
         description: "Skip UI tests"
         required: true
         default: 'false'
+      include_build_number:
+        description: "Include build number"
+        required: false
+        default: 'true'
   pull_request:
     branches:
       - development
@@ -368,6 +372,7 @@ jobs:
           name: lib
           path: clients/cobol-dialect-api
       - name: update version with PR or build number
+        if: github.event.inputs.include_build_number == 'true'
         working-directory: clients/cobol-lsp-vscode-extension
         env:
           BUILD_ID: ${{github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_number }}


### PR DESCRIPTION
Add build number to the version identifier. 
For PR builds, the PR # is used, prefixed with `pr-#` as before = `cobol-language-support-darwin-arm64-2.3.0+pr-2605.vsix`
For other builds, the run number of build action is used = `cobol-language-support-darwin-arm64-2.3.0+3231.vsix`

## How Has This Been Tested?
I checked that the generated build artifact contains correct build number.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
