### PR TITLE
chore: fix cics dialect to reflect error in correct postion in case a…

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/implicitDialects/cics/CICSParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/implicitDialects/cics/CICSParser.g4
@@ -311,7 +311,7 @@ cics_delete_group_one:  (cics_file_name | TOKEN cics_data_area  | cics_keylength
 cics_delete_group_two:  ((CHANNEL | EVENT | TIMER) cics_data_value | cics_handle_response)+;
 
 // CICS Delete Group 3 (Container (BTS), Container (Channel))
-cics_delete_group_three:  ((CONTAINER | ACTIVITY | CHANNEL | RETCODE) cics_data_value | ACQACTIVITY | PROCESS | ACQPROCESS | cics_handle_response)+;
+cics_delete_group_three:  ((CONTAINER | ACTIVITY | CHANNEL) cics_data_value | ACQACTIVITY | PROCESS | ACQPROCESS | cics_handle_response)+;
 
 // CICS Delete Group 4 (Counter, Dcounter)
 cics_delete_group_four:  (cics_counter_dcounter | POOL cics_name | NOSUSPEND | cics_handle_response)+;

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/MessageServiceParser.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/MessageServiceParser.java
@@ -38,9 +38,6 @@ public abstract class MessageServiceParser extends Parser {
    * Extend the functionality of {@link org.eclipse.lsp.cobol.common.message.MessageService} for
    * {@link CICSParser}
    *
-   * <p>Example: notifyError("db2SqlParser.validValueMsg", input, value); would notify errorListener
-   * with the externalized messages.
-   *
    * @param messageId Unique ID for each message in externalized message file.
    * @param parameters Arguments referenced by the format specifiers in the format string in
    *     externalized message file.

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/nodes/ExecCicsHandleNode.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/nodes/ExecCicsHandleNode.java
@@ -21,7 +21,7 @@ import lombok.ToString;
 import org.eclipse.lsp.cobol.common.model.Locality;
 import org.eclipse.lsp.cobol.common.model.NodeType;
 import org.eclipse.lsp.cobol.common.model.tree.Node;
-import org.eclipse.lsp.cobol.implicitDialects.sql.Db2SqlDialect;
+import org.eclipse.lsp.cobol.implicitDialects.cics.CICSDialect;
 
 /** EXEC CICS HANDLE node */
 @ToString(callSuper = true)
@@ -42,7 +42,7 @@ public class ExecCicsHandleNode extends Node {
   private final HandleAbendType type;
 
   public ExecCicsHandleNode(Locality location, HandleAbendType type) {
-    super(location, NodeType.STATEMENT, Db2SqlDialect.DIALECT_NAME);
+    super(location, NodeType.STATEMENT, CICSDialect.DIALECT_NAME);
     this.type = type;
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/nodes/ExecCicsNode.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/nodes/ExecCicsNode.java
@@ -20,7 +20,7 @@ import lombok.ToString;
 import org.eclipse.lsp.cobol.common.model.Locality;
 import org.eclipse.lsp.cobol.common.model.NodeType;
 import org.eclipse.lsp.cobol.common.model.tree.Node;
-import org.eclipse.lsp.cobol.implicitDialects.sql.Db2SqlDialect;
+import org.eclipse.lsp.cobol.implicitDialects.cics.CICSDialect;
 
 /** EXEC CICS block node */
 @ToString(callSuper = true)
@@ -28,6 +28,6 @@ import org.eclipse.lsp.cobol.implicitDialects.sql.Db2SqlDialect;
 public class ExecCicsNode extends Node {
 
   public ExecCicsNode(Locality location) {
-    super(location, NodeType.STATEMENT, Db2SqlDialect.DIALECT_NAME);
+    super(location, NodeType.STATEMENT, CICSDialect.DIALECT_NAME);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/nodes/ExecCicsReturnNode.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/nodes/ExecCicsReturnNode.java
@@ -20,7 +20,7 @@ import lombok.ToString;
 import org.eclipse.lsp.cobol.common.model.Locality;
 import org.eclipse.lsp.cobol.common.model.NodeType;
 import org.eclipse.lsp.cobol.common.model.tree.Node;
-import org.eclipse.lsp.cobol.implicitDialects.sql.Db2SqlDialect;
+import org.eclipse.lsp.cobol.implicitDialects.cics.CICSDialect;
 
 /** EXEC CICS RETURN node */
 @ToString(callSuper = true)
@@ -28,6 +28,6 @@ import org.eclipse.lsp.cobol.implicitDialects.sql.Db2SqlDialect;
 public class ExecCicsReturnNode extends Node {
 
   public ExecCicsReturnNode(Locality location) {
-    super(location, NodeType.STATEMENT, Db2SqlDialect.DIALECT_NAME);
+    super(location, NodeType.STATEMENT, CICSDialect.DIALECT_NAME);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSDeleteOptionsCheckUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSDeleteOptionsCheckUtility.java
@@ -110,7 +110,6 @@ public class CICSDeleteOptionsCheckUtility extends CICSOptionsCheckBaseUtility {
   @SuppressWarnings("unchecked")
   private void checkDeleteGroupThree(CICSParser.Cics_delete_group_threeContext ctx) {
     checkHasMandatoryOptions(ctx.CONTAINER(), ctx, "CONTAINER");
-//    checkHasMandatoryOptions(ctx.RETCODE(), ctx, "RETCODE");
     checkHasMutuallyExclusiveOptions("ACTIVITY or ACQACTIVITY or PROCESS or ACQPROCESS or CHANNEL",
             ctx.ACTIVITY(), ctx.ACQACTIVITY(), ctx.PROCESS(), ctx.ACQPROCESS(), ctx.CHANNEL());
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSDeleteOptionsCheckUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSDeleteOptionsCheckUtility.java
@@ -110,7 +110,7 @@ public class CICSDeleteOptionsCheckUtility extends CICSOptionsCheckBaseUtility {
   @SuppressWarnings("unchecked")
   private void checkDeleteGroupThree(CICSParser.Cics_delete_group_threeContext ctx) {
     checkHasMandatoryOptions(ctx.CONTAINER(), ctx, "CONTAINER");
-    checkHasMandatoryOptions(ctx.RETCODE(), ctx, "RETCODE");
+//    checkHasMandatoryOptions(ctx.RETCODE(), ctx, "RETCODE");
     checkHasMutuallyExclusiveOptions("ACTIVITY or ACQACTIVITY or PROCESS or ACQPROCESS or CHANNEL",
             ctx.ACTIVITY(), ctx.ACQACTIVITY(), ctx.PROCESS(), ctx.ACQPROCESS(), ctx.CHANNEL());
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/VisitorUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/VisitorUtility.java
@@ -19,7 +19,6 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp.cobol.common.dialects.DialectProcessingContext;
 import org.eclipse.lsp.cobol.common.model.Locality;
-import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 
@@ -29,27 +28,25 @@ import org.eclipse.lsp4j.Range;
 @UtilityClass
 public class VisitorUtility {
   /**
-   * Construct locality
+   * Construct locality in extended document
    *
    * @param ctx
    * @param context
    * @return locality
    */
   public Locality constructLocality(ParserRuleContext ctx, DialectProcessingContext context) {
-    Location location = context.getExtendedDocument().mapLocation(constructRange(ctx));
-    return Locality.builder().uri(location.getUri()).range(location.getRange()).build();
+    return Locality.builder().uri(context.getExtendedDocument().getUri()).range(constructRange(ctx)).build();
   }
 
   /**
-   * Construct Locality from a Terminal Node
+   * Construct Locality from a Terminal Node in extended document
    *
    * @param node
    * @param context
    * @return locality
    */
   public Locality constructLocality(TerminalNode node, DialectProcessingContext context) {
-    Location location = context.getExtendedDocument().mapLocation(constructRange(node));
-    return Locality.builder().uri(location.getUri()).range(location.getRange()).build();
+    return Locality.builder().uri(context.getExtendedDocument().getUri()).range(constructRange(node)).build();
   }
 
   /**

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCicsDelete.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCicsDelete.java
@@ -80,17 +80,17 @@ public class TestCicsDelete {
 
   private static final String GROUP_TWO_TIMER_VALID = "DELETE TIMER({$varFour})";
 
-  private static final String GROUP_THREE_CONTAINER_BTS_VALID = "DELETE CONTAINER({$varFour}) RETCODE({$varOne})";
+  private static final String GROUP_THREE_CONTAINER_BTS_VALID = "DELETE CONTAINER({$varFour})";
 
-  private static final String GROUP_THREE_CONTAINER_BTS_ACTIVITY_VALID = "DELETE CONTAINER({$varFour}) ACTIVITY({$varFive}) RETCODE({$varOne})";
+  private static final String GROUP_THREE_CONTAINER_BTS_ACTIVITY_VALID = "DELETE CONTAINER({$varFour}) ACTIVITY({$varFive})";
 
-  private static final String GROUP_THREE_CONTAINER_BTS_ACQACTIVITY_VALID = "DELETE CONTAINER({$varFour}) ACQACTIVITY RETCODE({$varOne})";
+  private static final String GROUP_THREE_CONTAINER_BTS_ACQACTIVITY_VALID = "DELETE CONTAINER({$varFour}) ACQACTIVITY";
 
-  private static final String GROUP_THREE_CONTAINER_BTS_PROCESS_VALID = "DELETE CONTAINER({$varFour}) PROCESS RETCODE({$varOne})";
+  private static final String GROUP_THREE_CONTAINER_BTS_PROCESS_VALID = "DELETE CONTAINER({$varFour}) PROCESS";
 
-  private static final String GROUP_THREE_CONTAINER_BTS_ACQPROCESS_VALID = "DELETE CONTAINER({$varFour}) ACQPROCESS RETCODE({$varOne})";
+  private static final String GROUP_THREE_CONTAINER_BTS_ACQPROCESS_VALID = "DELETE CONTAINER({$varFour}) ACQPROCESS ";
 
-  private static final String GROUP_THREE_CONTAINER_CHANNEL_VALID = "DELETE CONTAINER({$varFour}) CHANNEL({$varSix}) RETCODE({$varOne})";
+  private static final String GROUP_THREE_CONTAINER_CHANNEL_VALID = "DELETE CONTAINER({$varFour}) CHANNEL({$varSix})";
 
   private static final String GROUP_FOUR_DELETE_COUNTER_VALID = "DELETE COUNTER({$varFour})";
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCicsDelete.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCicsDelete.java
@@ -72,7 +72,7 @@ public class TestCicsDelete {
 
   private static final String GROUP_ONE_PARTIAL_OPTIONS_VALID_TEN = "DELETE FILE({$varFour}) NOSUSPEND RRN";
 
-  private static final String GROUP_TWO_ACTIVITY_INVALID = "DELETE {ACTIVITY(123)|error1|error2}";
+  private static final String GROUP_TWO_ACTIVITY_INVALID = "DELETE {ACTIVITY(123)|error1}";
 
   private static final String GROUP_TWO_CHANNEL_VALID = "DELETE CHANNEL({$varFour})";
 
@@ -254,12 +254,6 @@ public class TestCicsDelete {
                             new Range(),
                             "Missing required option: CONTAINER",
                             DiagnosticSeverity.Error,
-                            ErrorSource.PARSING.getText()),
-                    "error2",
-                    new Diagnostic(
-                            new Range(),
-                            "Missing required option: RETCODE",
-                            DiagnosticSeverity.Error,
                             ErrorSource.PARSING.getText()));
     CICSTestUtils.errorTest(GROUP_TWO_ACTIVITY_INVALID, expectedDiagnostic);
   }
@@ -390,7 +384,7 @@ public class TestCicsDelete {
             + "       WORKING-STORAGE SECTION.\n"
             + "       copy {~abc}.\n"
             + "       PROCEDURE DIVISION.\n"
-            + "           EXEC CICS DELETE {_CONTAINER({$VARFOUR})|error1_}\n"
+            + "           EXEC CICS DELETE {_ACTIVITY(123)|error1_}\n"
             + "           END-EXEC.";
     String copybookText =
         "       01 {$*varOne}   PIC S9 VALUE +10.\n"
@@ -405,7 +399,7 @@ public class TestCicsDelete {
         ImmutableMap.of("error1",
                 new Diagnostic(
                         new Range(),
-                        "Missing required option: RETCODE",
+                        "Missing required option: CONTAINER",
                         DiagnosticSeverity.Error,
                         ErrorSource.PARSING.getText())));
   }
@@ -428,7 +422,7 @@ public class TestCicsDelete {
                     + "       01 {$*varFive}  PIC X VALUE 'NAME_TWO'.\n"
                     + "       01 {$*varSix}   PIC X VALUE 'NAME_THREE'.";
 
-    String execTextInCopybook = "           EXEC CICS DELETE {_CONTAINER({$VARFOUR})|error1_}\n"
+    String execTextInCopybook = "           EXEC CICS DELETE {_ACTIVITY(123)|error1_}\n"
             + "           END-EXEC.";
     UseCaseEngine.runTest(
             text,
@@ -442,7 +436,7 @@ public class TestCicsDelete {
                     "error1",
                     new Diagnostic(
                             new Range(),
-                            "Missing required option: RETCODE",
+                            "Missing required option: CONTAINER",
                             DiagnosticSeverity.Error,
                             ErrorSource.PARSING.getText())));
   }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestExecCicsContainerStatementsArgumentsOrder.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestExecCicsContainerStatementsArgumentsOrder.java
@@ -74,7 +74,6 @@ class TestExecCicsContainerStatementsArgumentsOrder {
           + "           END-EXEC\n"
           + "           exec cics delete container({$xml-cont})\n"
               + "                     channel({$outbound-channel})\n"
-              + "                     retcode({$RESULT-LENGTH})\n"
           + "                         resp({$command-resp})\n"
           + "                         resp2({$command-resp2})\n"
           + "           end-exec.\n"


### PR DESCRIPTION
Issue is we try to adjust the dialect diagnostics . So these locality need not be adjusted.
But we don't seems to do the same on the dialect Nodes, which looks wrong. 
Plan to add that change is a different PR. This PR is to just make sure that we don't break previous cases
https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/blob/f79f54352c8f271d2255d495d2ae4e57539fa554/server/engine/src/main/java/org/eclipse/lsp/cobol/dialects/ibm/ImplicitDialectProcessingStage.java#L84
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test diagnostics for below code is at right location
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. ABCDEF.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       copy abc.
       PROCEDURE DIVISION.
       copy abcd.
``` 
ABC.cpy
```cobol
       01 varOne   PIC S9 VALUE +10.
       01 varTwo   PIC S9 VALUE +100.
       01 varThree PIC S9 VALUE +1000.
       01 varFour  PIC X VALUE 'NAME_ONE'.
       01 varFive  PIC X VALUE 'NAME_TWO'.
       01 varSix   PIC X VALUE 'NAME_THREE'.
``` 

ABCD.cpy
```cobol
           EXEC CICS DELETE CONTAINER(VARFOUR)
           END-EXEC.
``` 
- [x] Test RETCODE is no more a mandatory option for CICS DELETE command.
check below sysprint 
```
   000160                PROCEDURE DIVISION using dfheiblk dfhcommarea.                            127 159
   000161               *EXEC CICS DELETE CONTAINER(PROCESS-NAME)
   000162               *                 PROCESS
   000163               *                 RESP(RESP-AREA)
   000164               *                 RESP2(RESP2-AREA)
   000165               *END-EXEC.
   000166                    Call 'DFHEI1' using by content x'3412200027201000000000000000         EXT
   000167               -    '00f0f0f0f1f9404040' by content x'0000' by content x'0000' by
1PP 5655-EC6 IBM Enterprise COBOL for z/OS  6.3.0 P240628       DFH0SAL2  Date 11/27/2024  Time 07:06:57   Page     6
   LineID  PL SL  ----+-*A-1-B--+----2----+----3----+----4----+----5----+----6----+----7-|--+----8 Map and Cross Reference
0  000168                     reference PROCESS-NAME end-call                                      10
   000169                     Move eibresp to RESP-AREA                                            156 7
   000170                     Move eibresp2 to RESP2-AREA.                                         157 8
1PP 5655-EC6 IBM Enterprise COBOL for z/OS  6.3.0 P240628       DFH0SAL2  Date 11/27/2024  Time 07:06:57   Page     7
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
