### PR TITLE
Fix: Subroutines resolving

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
@@ -216,3 +216,7 @@ export const FileSystemError = {
     return new FileNotFound();
   },
 };
+
+export const RelativePattern = jest
+  .fn()
+  .mockImplementation((base: string, pattern: string) => ({ base, pattern }));

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
@@ -51,6 +51,7 @@ export namespace workspace {
   export function onDidChangeConfiguration() {}
   export const textDocuments = [];
   export function getWorkspaceFolder() {}
+  export async function findFiles() {}
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/SettingsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/SettingsTest.spec.ts
@@ -23,7 +23,11 @@ import {
 } from "../../services/DialectRegistry";
 
 import { asMutable } from "../../test/suite/testHelper";
-import { SETTINGS_CPY_LOCAL_PATH } from "../../constants";
+import {
+  SETTINGS_COMPILE_OPTIONS,
+  SETTINGS_CPY_LOCAL_PATH,
+  SETTINGS_DIALECT,
+} from "../../constants";
 import * as extension from "../../extension";
 
 function makefsPath(p: string): string {
@@ -284,7 +288,7 @@ describe("SettingsService prepares local search folders", () => {
 });
 
 describe("SettingService lspConfigHandler", () => {
-  describe("dialects configuration", () => {
+  describe("dialects registry configuration", () => {
     const dialect: DialectInfo = {
       name: "testDialect",
       uri: vscode.Uri.file(""),
@@ -313,6 +317,43 @@ describe("SettingService lspConfigHandler", () => {
       });
 
       expect(result).toEqual(expect.arrayContaining([[dialect]]));
+    });
+  });
+
+  describe("enabled dialects section", () => {
+    beforeAll(() => {
+      jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+        get: () => [],
+      } as unknown as vscode.WorkspaceConfiguration);
+    });
+
+    test("return empty array in default configuration", async () => {
+      const result = await lspConfigHandler({
+        items: [{ section: SETTINGS_DIALECT }],
+      });
+
+      expect(result).toEqual(expect.arrayContaining([[]]));
+    });
+  });
+
+  describe("compiler options section", () => {
+    beforeAll(() => {
+      jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+        get: () => undefined,
+      } as unknown as vscode.WorkspaceConfiguration);
+    });
+
+    test("returns undefined in default configuration", async () => {
+      const result = await lspConfigHandler({
+        items: [
+          {
+            section: SETTINGS_COMPILE_OPTIONS,
+            scopeUri: "file:///workspace/program.cob",
+          },
+        ],
+      });
+
+      expect(result).toEqual(expect.arrayContaining([undefined]));
     });
   });
 

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts
@@ -13,28 +13,31 @@
  */
 
 import * as vscode from "vscode";
-import * as FSUtils from "../../../services/util/FSUtils";
-import { COBOL_EXT_ARRAY } from "../../../constants";
 import { resolveSubroutineURI } from "../../../services/util/SubroutineUtils";
 
 describe("SubroutineUtils", () => {
-  it("search in workspace by name", () => {
-    const folders = ["folder"];
-    vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
-      get: jest.fn().mockReturnValue(folders),
-    });
-    const mockUri = vscode.Uri.file("theURI");
-    const spy = jest
-      .spyOn(FSUtils, "searchCopybookInExtensionFolder")
-      .mockReturnValue(mockUri);
+  beforeEach(() => {
+    jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+      get: () => ["subroutines", "more-subroutines"],
+    } as unknown as vscode.WorkspaceConfiguration);
+  });
 
-    const uri = resolveSubroutineURI("/storagePath", "name");
-    expect(uri).toStrictEqual(mockUri);
-    expect(spy).toHaveBeenCalledWith(
-      "name",
-      folders,
-      COBOL_EXT_ARRAY,
-      "/storagePath",
-    );
+  let findFilesSpy: jest.SpyInstance;
+  describe("subroutine file exists in workspace", () => {
+    findFilesSpy = jest
+      .spyOn(vscode.workspace, "findFiles")
+      .mockResolvedValue([
+        vscode.Uri.file("/coding/cobol/subroutines/SUB1.cob"),
+      ]);
+
+    it("finds subroutine file in workspace folder by name", async () => {
+      const uri = await resolveSubroutineURI("SUB1");
+      expect(uri).toEqual("file:///coding/cobol/subroutines/SUB1.cob");
+      expect(findFilesSpy).toHaveBeenCalledWith(
+        "{subroutines,more-subroutines}/**/SUB1{.CBL,.COB,.COBOL,.cbl,.cob,.cobol}",
+        null,
+        1,
+      );
+    });
   });
 });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts
@@ -16,28 +16,58 @@ import * as vscode from "vscode";
 import { resolveSubroutineURI } from "../../../services/util/SubroutineUtils";
 
 describe("SubroutineUtils", () => {
-  beforeEach(() => {
-    jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
-      get: () => ["subroutines", "more-subroutines"],
-    } as unknown as vscode.WorkspaceConfiguration);
+  describe("Subroutines configuration exists", () => {
+    beforeEach(() => {
+      jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+        get: () => ["subroutines", "more-subroutines"],
+      } as unknown as vscode.WorkspaceConfiguration);
+    });
+
+    let findFilesSpy: jest.SpyInstance;
+    describe("subroutine file exists in workspace", () => {
+      beforeEach(() => {
+        findFilesSpy = jest
+          .spyOn(vscode.workspace, "findFiles")
+          .mockResolvedValue([
+            vscode.Uri.file("/coding/cobol/subroutines/SUB1.cob"),
+          ]);
+      });
+
+      it("finds subroutine file in workspace folder by name and returns full path", async () => {
+        const uri = await resolveSubroutineURI("SUB1");
+        expect(uri).toEqual("file:///coding/cobol/subroutines/SUB1.cob");
+        expect(findFilesSpy).toHaveBeenCalledWith(
+          "{subroutines,more-subroutines}/**/SUB1{.CBL,.COB,.COBOL,.cbl,.cob,.cobol}",
+          null,
+          1,
+        );
+      });
+    });
+
+    describe("subroutine file doesn't exist in the subroutines folders", () => {
+      beforeEach(() => {
+        findFilesSpy = jest
+          .spyOn(vscode.workspace, "findFiles")
+          .mockResolvedValue([]);
+      });
+
+      it("returns undefined", async () => {
+        const uri = await resolveSubroutineURI("SUB1");
+        expect(uri).toBeUndefined();
+      });
+    });
   });
 
-  let findFilesSpy: jest.SpyInstance;
-  describe("subroutine file exists in workspace", () => {
-    findFilesSpy = jest
-      .spyOn(vscode.workspace, "findFiles")
-      .mockResolvedValue([
-        vscode.Uri.file("/coding/cobol/subroutines/SUB1.cob"),
-      ]);
+  describe("No subroutines folders are configured", () => {
+    beforeEach(() => {
+      jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+        get: () => undefined,
+      } as unknown as vscode.WorkspaceConfiguration);
+    });
 
-    it("finds subroutine file in workspace folder by name", async () => {
+    it("subroutine path is resolved as undefined", async () => {
       const uri = await resolveSubroutineURI("SUB1");
-      expect(uri).toEqual("file:///coding/cobol/subroutines/SUB1.cob");
-      expect(findFilesSpy).toHaveBeenCalledWith(
-        "{subroutines,more-subroutines}/**/SUB1{.CBL,.COB,.COBOL,.cbl,.cob,.cobol}",
-        null,
-        1,
-      );
+      expect(uri).toBeUndefined();
     });
   });
 });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts
@@ -16,6 +16,10 @@ import * as vscode from "vscode";
 import { resolveSubroutineURI } from "../../../services/util/SubroutineUtils";
 
 describe("SubroutineUtils", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe("Subroutines configuration exists", () => {
     beforeEach(() => {
       jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
@@ -37,7 +41,7 @@ describe("SubroutineUtils", () => {
         const uri = await resolveSubroutineURI("SUB1");
         expect(uri).toEqual("file:///coding/cobol/subroutines/SUB1.cob");
         expect(findFilesSpy).toHaveBeenCalledWith(
-          "{subroutines,more-subroutines}/**/SUB1{.CBL,.COB,.COBOL,.cbl,.cob,.cobol}",
+          "subroutines/**/SUB1{.CBL,.COB,.COBOL,.cbl,.cob,.cobol}",
           null,
           1,
         );
@@ -68,6 +72,34 @@ describe("SubroutineUtils", () => {
     it("subroutine path is resolved as undefined", async () => {
       const uri = await resolveSubroutineURI("SUB1");
       expect(uri).toBeUndefined();
+    });
+  });
+
+  describe("Absolute subroutines folders are configured", () => {
+    beforeEach(() => {
+      jest.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+        get: () => ["/absolute/subroutines"],
+      } as unknown as vscode.WorkspaceConfiguration);
+    });
+
+    let findFilesSpy: jest.SpyInstance;
+    beforeEach(() => {
+      findFilesSpy = jest
+        .spyOn(vscode.workspace, "findFiles")
+        .mockResolvedValue([vscode.Uri.file("/absolute/subroutines/SUB1.cob")]);
+    });
+
+    it("subroutine path is resolved", async () => {
+      const uri = await resolveSubroutineURI("SUB1");
+      expect(uri).toEqual("file:///absolute/subroutines/SUB1.cob");
+      expect(findFilesSpy).toHaveBeenCalledWith(
+        {
+          base: "/absolute/subroutines",
+          pattern: "**/SUB1{.CBL,.COB,.COBOL,.cbl,.cob,.cobol}",
+        },
+        null,
+        1,
+      );
     });
   });
 });

--- a/clients/cobol-lsp-vscode-extension/src/constants.ts
+++ b/clients/cobol-lsp-vscode-extension/src/constants.ts
@@ -57,6 +57,10 @@ export const COBOL_CBL_EXT = ".CBL";
 export const COBOL_COB_EXT = ".COB";
 export const COBOL_COBOL_EXT = ".COBOL";
 export const COBOL_EXT_ARRAY = [COBOL_CBL_EXT, COBOL_COB_EXT, COBOL_COBOL_EXT];
+export const COBOL_EXT_ARRAY_CASE_INSENSITIVE = [
+  ...COBOL_EXT_ARRAY,
+  ...COBOL_EXT_ARRAY.map((s) => s.toLowerCase()),
+];
 export const COPYBOOK_CPY_EXT = ".CPY";
 export const COPYBOOK_EXTENSIONS = "copybook-extensions";
 export const COPYBOOK_EXT_ARRAY = [COPYBOOK_CPY_EXT];

--- a/clients/cobol-lsp-vscode-extension/src/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/extension.ts
@@ -156,7 +156,7 @@ export async function activate(
   // Custom client handlers
   languageClientService.addRequestHandler(
     "cobol/resolveSubroutine",
-    resolveSubroutineURI.bind(undefined, context.globalStorageUri.fsPath),
+    resolveSubroutineURI,
   );
   languageClientService.addRequestHandler(
     "copybook/resolve",

--- a/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
@@ -77,7 +77,7 @@ async function handleProcessorGroupConfigurationRequest<Type, Output, R>(
     cfg: Type,
   ) => Promise<R>,
   item: Item,
-  result: unknown[],
+  result: (R | undefined)[],
 ) {
   if (item.scopeUri) {
     try {
@@ -96,7 +96,7 @@ async function handleProcessorGroupConfigurationRequest<Type, Output, R>(
         );
         result.push(object);
       } else {
-        result.push(undefined);
+        result.push(configuration);
       }
     } catch (err) {
       if (err instanceof DecodingError) {

--- a/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
@@ -55,7 +55,7 @@ interface Request {
 
 interface Item {
   section: string;
-  scopeUri: string;
+  scopeUri?: string;
   dialect?: string;
 }
 
@@ -77,7 +77,7 @@ async function handleProcessorGroupConfigurationRequest<Type, Output, R>(
     cfg: Type,
   ) => Promise<R>,
   item: Item,
-  result: R[],
+  result: unknown[],
 ) {
   if (item.scopeUri) {
     try {
@@ -96,7 +96,7 @@ async function handleProcessorGroupConfigurationRequest<Type, Output, R>(
         );
         result.push(object);
       } else {
-        result.push(undefined as R);
+        result.push(undefined);
       }
     } catch (err) {
       if (err instanceof DecodingError) {
@@ -106,91 +106,11 @@ async function handleProcessorGroupConfigurationRequest<Type, Output, R>(
       }
     }
   } else {
-    const x = vscode.workspace.getConfiguration().get(item.section);
-    result.push(x as R);
+    result.push(vscode.workspace.getConfiguration().get(item.section));
   }
 }
 
-export async function lspConfigHandlerOriginal(
-  request: Request,
-): Promise<Array<unknown>> {
-  const result = new Array<unknown>();
-  for (const item of request.items) {
-    try {
-      if (item.section === DIALECT_REGISTRY_SECTION) {
-        const object = DialectRegistry.getDialects();
-        result.push(object);
-      } else if (item.scopeUri) {
-        const cfg = vscode.workspace.getConfiguration().get(item.section);
-        if (item.section === SETTINGS_DIALECT) {
-          const object = await loadProcessorGroupDialectConfig(
-            item,
-            cfg as string[],
-          );
-          result.push(object);
-        } else if (item.section === SETTINGS_CPY_LOCAL_PATH) {
-          const object = await loadProcessorGroupCopybookPathsConfig(
-            item,
-            cfg as string[],
-          );
-          result.push(object);
-        } else if (item.section === DIALECT_LIBS && !!item.dialect) {
-          const dialectLibs: string[] =
-            await SettingsService.getCopybookLocalPath(
-              item.scopeUri,
-              item.dialect,
-            );
-          result.push(dialectLibs);
-        } else if (item.section === SETTINGS_CPY_EXTENSIONS) {
-          const object = await loadProcessorGroupCopybookExtensionsConfig(
-            item,
-            cfg as string[],
-          );
-          result.push(object);
-        } else if (item.section === SETTINGS_SQL_BACKEND) {
-          const object = await loadProcessorGroupSqlBackendConfig(
-            item,
-            cfg as string,
-          );
-          result.push(object);
-        } else if (item.section === SETTINGS_CPY_FILE_ENCODING) {
-          const object = await loadProcessorGroupCopybookEncodingConfig(
-            item,
-            cfg as string,
-          );
-          result.push(object);
-        } else if (item.section === SETTINGS_COMPILE_OPTIONS) {
-          const object = await loadProcessorGroupCompileOptionsConfig(
-            item,
-            cfg as string,
-          );
-          result.push(object);
-        } else {
-          result.push(cfg);
-        }
-      } else if (item.section === COBOL_PRGM_LAYOUT) {
-        result.push(SettingsService.getCobolProgramLayout());
-      } else {
-        result.push(vscode.workspace.getConfiguration().get(item.section));
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  }
-  return result;
-}
 export async function lspConfigHandler(request: Request) {
-  const myResult = await lspConfigHandlerMy(request);
-  const originalResult = await lspConfigHandlerOriginal(request);
-
-  if (JSON.stringify(myResult) === JSON.stringify(originalResult)) {
-    return myResult;
-  } else {
-    return originalResult;
-  }
-}
-
-export async function lspConfigHandlerMy(request: Request) {
   const result: unknown[] = [];
   for (const item of request.items) {
     try {

--- a/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
@@ -55,7 +55,7 @@ interface Request {
 
 interface Item {
   section: string;
-  scopeUri?: string;
+  scopeUri: string;
   dialect?: string;
 }
 
@@ -95,6 +95,8 @@ async function handleProcessorGroupConfigurationRequest<Type, Output, R>(
           decodedConfiguration,
         );
         result.push(object);
+      } else {
+        result.push(undefined as R);
       }
     } catch (err) {
       if (err instanceof DecodingError) {
@@ -103,10 +105,92 @@ async function handleProcessorGroupConfigurationRequest<Type, Output, R>(
         );
       }
     }
+  } else {
+    const x = vscode.workspace.getConfiguration().get(item.section);
+    result.push(x as R);
   }
 }
 
+export async function lspConfigHandlerOriginal(
+  request: Request,
+): Promise<Array<unknown>> {
+  const result = new Array<unknown>();
+  for (const item of request.items) {
+    try {
+      if (item.section === DIALECT_REGISTRY_SECTION) {
+        const object = DialectRegistry.getDialects();
+        result.push(object);
+      } else if (item.scopeUri) {
+        const cfg = vscode.workspace.getConfiguration().get(item.section);
+        if (item.section === SETTINGS_DIALECT) {
+          const object = await loadProcessorGroupDialectConfig(
+            item,
+            cfg as string[],
+          );
+          result.push(object);
+        } else if (item.section === SETTINGS_CPY_LOCAL_PATH) {
+          const object = await loadProcessorGroupCopybookPathsConfig(
+            item,
+            cfg as string[],
+          );
+          result.push(object);
+        } else if (item.section === DIALECT_LIBS && !!item.dialect) {
+          const dialectLibs: string[] =
+            await SettingsService.getCopybookLocalPath(
+              item.scopeUri,
+              item.dialect,
+            );
+          result.push(dialectLibs);
+        } else if (item.section === SETTINGS_CPY_EXTENSIONS) {
+          const object = await loadProcessorGroupCopybookExtensionsConfig(
+            item,
+            cfg as string[],
+          );
+          result.push(object);
+        } else if (item.section === SETTINGS_SQL_BACKEND) {
+          const object = await loadProcessorGroupSqlBackendConfig(
+            item,
+            cfg as string,
+          );
+          result.push(object);
+        } else if (item.section === SETTINGS_CPY_FILE_ENCODING) {
+          const object = await loadProcessorGroupCopybookEncodingConfig(
+            item,
+            cfg as string,
+          );
+          result.push(object);
+        } else if (item.section === SETTINGS_COMPILE_OPTIONS) {
+          const object = await loadProcessorGroupCompileOptionsConfig(
+            item,
+            cfg as string,
+          );
+          result.push(object);
+        } else {
+          result.push(cfg);
+        }
+      } else if (item.section === COBOL_PRGM_LAYOUT) {
+        result.push(SettingsService.getCobolProgramLayout());
+      } else {
+        result.push(vscode.workspace.getConfiguration().get(item.section));
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }
+  return result;
+}
 export async function lspConfigHandler(request: Request) {
+  const myResult = await lspConfigHandlerMy(request);
+  const originalResult = await lspConfigHandlerOriginal(request);
+
+  if (JSON.stringify(myResult) === JSON.stringify(originalResult)) {
+    return myResult;
+  } else {
+    return originalResult;
+  }
+}
+
+export async function lspConfigHandlerMy(request: Request) {
   const result: unknown[] = [];
   for (const item of request.items) {
     try {

--- a/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
@@ -11,36 +11,25 @@
  * Contributors:
  *   Broadcom, Inc. - initial API and implementation
  */
-import { searchCopybookInExtensionFolder } from "./FSUtils";
-import { COBOL_EXT_ARRAY } from "../../constants";
+import { COBOL_EXT_ARRAY_CASE_INSENSITIVE } from "../../constants";
 import { SettingsService } from "../Settings";
-import { getChannel } from "../../extension";
-import { SettingsUtils } from "./SettingsUtils";
-
+import * as vscode from "vscode";
 /**
- * This function try to resolve a given subroutine by searching COBOL source file with the same name
- * in local file system in directories specified in settings.
+ * This function try to resolve a given subroutine by searching COBOL source file
+ * with the same name in local workspace directories specified in settings.
  * @param name the name of subroutine
  * @return subroutine file URI if it was found or undefined otherwise
  */
-export function resolveSubroutineURI(
-  storagePath: string,
-  name: string,
-): string {
+export async function resolveSubroutineURI(name: string) {
   const folders: string[] | undefined =
     SettingsService.getSubroutineLocalPath();
-  const workspacePath = SettingsUtils.getWorkspaceFoldersPath(true);
-  getChannel().appendLine(
-    `Resolving subroutine - ${storagePath} [${workspacePath.join(", ")}] ${name} [${folders?.join(", ")}]`,
-  );
-  const uri = searchCopybookInExtensionFolder(
-    name,
-    folders,
-    COBOL_EXT_ARRAY,
-    workspacePath[0],
-  )!;
 
-  getChannel().appendLine(`Subroutine resolved - ${name} = ${uri.toString()}`);
+  const pattern = `{${folders?.join(",")}}/**/${name}{${COBOL_EXT_ARRAY_CASE_INSENSITIVE.join(",")}}`;
+  const uris = await vscode.workspace.findFiles(pattern, null, 1);
 
-  return uri.toString();
+  if (uris.length > 0) {
+    return uris[0].toString();
+  }
+
+  return undefined;
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
@@ -14,7 +14,6 @@
 import { searchCopybookInExtensionFolder } from "./FSUtils";
 import { COBOL_EXT_ARRAY } from "../../constants";
 import { SettingsService } from "../Settings";
-import { Uri } from "vscode";
 import { getChannel } from "../../extension";
 import { SettingsUtils } from "./SettingsUtils";
 
@@ -24,7 +23,10 @@ import { SettingsUtils } from "./SettingsUtils";
  * @param name the name of subroutine
  * @return subroutine file URI if it was found or undefined otherwise
  */
-export function resolveSubroutineURI(storagePath: string, name: string): Uri {
+export function resolveSubroutineURI(
+  storagePath: string,
+  name: string,
+): string {
   const folders: string[] | undefined =
     SettingsService.getSubroutineLocalPath();
   const workspacePath = SettingsUtils.getWorkspaceFoldersPath(true);
@@ -40,5 +42,5 @@ export function resolveSubroutineURI(storagePath: string, name: string): Uri {
 
   getChannel().appendLine(`Subroutine resolved - ${name} = ${uri.toString()}`);
 
-  return uri;
+  return uri.toString();
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
@@ -15,6 +15,8 @@ import { searchCopybookInExtensionFolder } from "./FSUtils";
 import { COBOL_EXT_ARRAY } from "../../constants";
 import { SettingsService } from "../Settings";
 import { Uri } from "vscode";
+import { getChannel } from "../../extension";
+import { SettingsUtils } from "./SettingsUtils";
 
 /**
  * This function try to resolve a given subroutine by searching COBOL source file with the same name
@@ -25,10 +27,18 @@ import { Uri } from "vscode";
 export function resolveSubroutineURI(storagePath: string, name: string): Uri {
   const folders: string[] | undefined =
     SettingsService.getSubroutineLocalPath();
-  return searchCopybookInExtensionFolder(
+  const workspacePath = SettingsUtils.getWorkspaceFoldersPath(true);
+  getChannel().appendLine(
+    `Resolving subroutine - ${storagePath} [${workspacePath.join(", ")}] ${name} [${folders?.join(", ")}]`,
+  );
+  const uri = searchCopybookInExtensionFolder(
     name,
     folders,
     COBOL_EXT_ARRAY,
-    storagePath,
+    workspacePath[0],
   )!;
+
+  getChannel().appendLine(`Subroutine resolved - ${name} = ${uri.toString()}`);
+
+  return uri;
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
@@ -21,14 +21,15 @@ import * as vscode from "vscode";
  * @return subroutine file URI if it was found or undefined otherwise
  */
 export async function resolveSubroutineURI(name: string) {
-  const folders: string[] | undefined =
-    SettingsService.getSubroutineLocalPath();
+  const subroutinePaths = SettingsService.getSubroutineLocalPath();
 
-  const pattern = `{${folders?.join(",")}}/**/${name}{${COBOL_EXT_ARRAY_CASE_INSENSITIVE.join(",")}}`;
-  const uris = await vscode.workspace.findFiles(pattern, null, 1);
+  if (subroutinePaths && subroutinePaths.length > 0) {
+    const pattern = `{${subroutinePaths.join(",")}}/**/${name}{${COBOL_EXT_ARRAY_CASE_INSENSITIVE.join(",")}}`;
+    const uris = await vscode.workspace.findFiles(pattern, null, 1);
 
-  if (uris.length > 0) {
-    return uris[0].toString();
+    if (uris.length > 0) {
+      return uris[0].toString();
+    }
   }
 
   return undefined;

--- a/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
@@ -11,6 +11,7 @@
  * Contributors:
  *   Broadcom, Inc. - initial API and implementation
  */
+import { isAbsolute } from "path";
 import { COBOL_EXT_ARRAY_CASE_INSENSITIVE } from "../../constants";
 import { SettingsService } from "../Settings";
 import * as vscode from "vscode";
@@ -23,12 +24,23 @@ import * as vscode from "vscode";
 export async function resolveSubroutineURI(name: string) {
   const subroutinePaths = SettingsService.getSubroutineLocalPath();
 
-  if (subroutinePaths && subroutinePaths.length > 0) {
-    const pattern = `{${subroutinePaths.join(",")}}/**/${name}{${COBOL_EXT_ARRAY_CASE_INSENSITIVE.join(",")}}`;
-    const uris = await vscode.workspace.findFiles(pattern, null, 1);
+  if (subroutinePaths) {
+    for (const subroutinePath of subroutinePaths) {
+      let pattern: vscode.RelativePattern | string;
+      if (isAbsolute(subroutinePath)) {
+        pattern = new vscode.RelativePattern(
+          subroutinePath,
+          `**/${name}{${COBOL_EXT_ARRAY_CASE_INSENSITIVE.join(",")}}`,
+        );
+      } else {
+        pattern = `${subroutinePath}/**/${name}{${COBOL_EXT_ARRAY_CASE_INSENSITIVE.join(",")}}`;
+      }
 
-    if (uris.length > 0) {
-      return uris[0].toString();
+      const uris = await vscode.workspace.findFiles(pattern, null, 1);
+
+      if (uris.length > 0) {
+        return uris[0].toString();
+      }
     }
   }
 

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/subroutines.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/subroutines.spec.test.ts
@@ -17,7 +17,7 @@ import * as assert from "assert";
 
 suite("Integration Test Suite: Subroutines resolving", () => {
   suiteSetup(async function () {
-    this.timeout(0);
+    this.timeout(helper.TEST_TIMEOUT);
     await helper.updateConfig("subroutines.json");
     await helper.activate();
   });

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/subroutines.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/subroutines.spec.test.ts
@@ -1,0 +1,18 @@
+import * as helper from "./testHelper";
+import * as assert from "assert";
+
+suite("Integration Test Suite: Subroutines resolving", () => {
+  suiteSetup(async function () {
+    this.timeout(0);
+    await helper.updateConfig("subroutines.json");
+    await helper.activate();
+  });
+
+  test("Diagnostics report missing subroutine", async function () {
+    await helper.showDocument("CALL.cbl");
+    const editor = helper.getEditor("CALL.cbl");
+    const diagnostics = await helper.waitForDiagnostics(editor.document.uri);
+    assert.strictEqual(diagnostics.length, 1);
+    assert.strictEqual(diagnostics[0].message, "SUB2: Subroutine not found");
+  });
+});

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/subroutines.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/subroutines.spec.test.ts
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2024 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+
 import * as helper from "./testHelper";
 import * as assert from "assert";
 

--- a/clients/cobol-lsp-vscode-extension/src/test/suite/subroutines.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/subroutines.spec.test.ts
@@ -23,6 +23,7 @@ suite("Integration Test Suite: Subroutines resolving", () => {
   });
 
   test("Diagnostics report missing subroutine", async function () {
+    this.timeout(helper.TEST_TIMEOUT);
     await helper.showDocument("CALL.cbl");
     const editor = helper.getEditor("CALL.cbl");
     const diagnostics = await helper.waitForDiagnostics(editor.document.uri);

--- a/tests/test_files/project/settings/subroutines.json
+++ b/tests/test_files/project/settings/subroutines.json
@@ -1,3 +1,6 @@
 {
-    "cobol-lsp.subroutine-manager.paths-local": ["subroutines"]
+    "cobol-lsp.subroutine-manager.paths-local": [
+        "nonexisting/subroutines/folder",
+        "subroutines"
+    ]
 }


### PR DESCRIPTION
There were 3 problems that prevented subroutines resolution to work correctly:
### Issue 1 - subroutines were searched in global storage instead of workspace folder
This got broken when the downloaded copybooks were moved from workspace to global storage, as subroutines resolution shared code with it.
I refactored the subroutines resolution to use VSCode API to find subroutines files in the workspace folders.

### Issue 2 - configuration was passed incorrectly from client to server
During the recent refactoring of the Settings service the incompatibility with the previous version was introduced - nothing was returned instead of `undefined` as server is expecting.

### Issue 3 - just string path should be returned instead of whole URI object
Server expects subroutines to be resolved as a  string path, but at some point client started to return whole URI object instead.

## How Has This Been Tested?

I manually tested it works and added new unit and integration tests:
`clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts`
`clients/cobol-lsp-vscode-extension/src/test/suite/subroutines.spec.test.ts`

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
