### PR TITLE
chore: update surefire plugin to use junit5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
           cache: 'maven'
       - name: Generate assisted configuration for GraalVM native build
         working-directory: server
-        run: mvn -e -B -Pnative -Dagent=true -Dtest=\!PositiveTest* -DfailIfNoTests=false test
+        run: mvn -e -B -Pnative -Dagent=true -Dtest=\!PositiveTest -Dsurefire.failIfNoSpecifiedTests=false  test
       - name: Upload native build configuration
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
           cache: 'maven'
       - name: Generate assisted configuration for GraalVM native build
         working-directory: server
-        run: mvn -e -B -Pnative -Dagent=true -Dtest=\!PositiveTest -Dsurefire.failIfNoSpecifiedTests=false  test
+        run: mvn -e -B -Pnative -DskipNativeTests -Dagent=true -Dtest=\!PositiveTest -Dsurefire.failIfNoSpecifiedTests=false test
       - name: Upload native build configuration
         uses: actions/upload-artifact@v4
         with:

--- a/server/common/pom.xml
+++ b/server/common/pom.xml
@@ -33,10 +33,9 @@
         <logback.classic.version>1.3.14</logback.classic.version>
         <lsp4j.version>0.14.0</lsp4j.version>
         <commons.lang.version>3.12.0</commons.lang.version>
-        <junit-jupiter.version>5.6.0</junit-jupiter.version>
-        <junit.platform.version>1.6.0</junit.platform.version>
+        <junit-jupiter.version>5.11.0-M2</junit-jupiter.version>
         <mockito.core.version>5.14.2</mockito.core.version>
-        <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
         <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -169,27 +168,9 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit-jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <version>${junit.platform.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -218,9 +199,21 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                     <parallel>all</parallel>
                     <systemPropertyVariables>
                         <property>

--- a/server/dialect-daco/pom.xml
+++ b/server/dialect-daco/pom.xml
@@ -36,13 +36,13 @@
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
-        <junit-jupiter.version>5.6.0</junit-jupiter.version>
+        <junit-jupiter.version>5.11.0-M2</junit-jupiter.version>
         <junit.platform.version>1.6.0</junit.platform.version>
         <mockito.core.version>5.14.2</mockito.core.version>
         <maven.cobertura.plugin.version>2.7</maven.cobertura.plugin.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -154,9 +154,21 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                     <parallel>all</parallel>
                     <systemPropertyVariables>
                         <property>

--- a/server/dialect-idms/pom.xml
+++ b/server/dialect-idms/pom.xml
@@ -36,12 +36,12 @@
         <lombok.version>1.18.36</lombok.version>
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
-        <junit-jupiter.version>5.6.0</junit-jupiter.version>
+        <junit-jupiter.version>5.11.0-M2</junit-jupiter.version>
         <junit.platform.version>1.6.0</junit.platform.version>
         <mockito.core.version>5.14.2</mockito.core.version>
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -179,9 +179,21 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                     <parallel>all</parallel>
                     <systemPropertyVariables>
                         <property>

--- a/server/engine/pom.xml
+++ b/server/engine/pom.xml
@@ -41,8 +41,7 @@
         <exclude.tests>nothing.to.exclude</exclude.tests>
         <google.guava.version>33.2.1-jre</google.guava.version>
         <guice.version>4.2.2</guice.version>
-        <junit-jupiter.version>5.6.0</junit-jupiter.version>
-        <junit.platform.version>1.6.0</junit.platform.version>
+        <junit-jupiter.version>5.11.0-M2</junit-jupiter.version>
         <logback.classic.version>1.3.14</logback.classic.version>
         <lombok.version>1.18.36</lombok.version>
         <lsp4j.version>0.14.0</lsp4j.version>
@@ -52,7 +51,7 @@
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
         <mockito.core.version>5.14.2</mockito.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -61,6 +60,12 @@
         <filesToTestPath>${project.basedir}${file.separator}..${file.separator}..${file.separator}tests${file.separator}test_files</filesToTestPath>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.lsp.cobol</groupId>
             <artifactId>common</artifactId>
@@ -279,7 +284,7 @@
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
                     <parallel>all</parallel>
-                    <argLine>${argLine} -Dperformance.log.path=${project.build.directory}/perf.csv</argLine>
+                    <argLine>${argLine} -Dperformance.log.path=${project.build.directory}/perf.csv -javaagent:${org.mockito:mockito-core:jar}</argLine>
                     <systemPropertyVariables>
                         <property>
                             <name>filesToTestPath</name>
@@ -300,6 +305,17 @@
                         <exclude>**/org/eclipse/lsp/cobol/dialects/**/*</exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/server/engine/pom.xml
+++ b/server/engine/pom.xml
@@ -474,8 +474,9 @@
                             </buildArgs>
                             <agent>
                                 <options>
-                                    <option>access-filter-file=${basedir}/src/test/resources/access-filter.json</option>
-                                    <option>experimental-class-loader-support</option>
+                                    <accessFilterFiles>
+                                        <filterFile>${basedir}/src/test/resources/access-filter.json</filterFile>
+                                    </accessFilterFiles>
                                 </options>
                             </agent>
                         </configuration>
@@ -490,7 +491,7 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
-                        <version>0.9.13</version>
+                        <version>0.10.3</version>
                         <extensions>true</extensions>
                         <executions>
                             <execution>
@@ -514,8 +515,9 @@
                             </buildArgs>
                             <agent>
                                 <options>
-                                    <option>access-filter-file=${basedir}/src/test/resources/access-filter.json</option>
-                                    <option>experimental-class-loader-support</option>
+                                    <accessFilterFiles>
+                                        <filterFile>${basedir}/src/test/resources/access-filter.json</filterFile>
+                                    </accessFilterFiles>
                                 </options>
                             </agent>
                         </configuration>

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/implicitDialects/cics/processor/CICSImplicitVariablesProcessorTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/implicitDialects/cics/processor/CICSImplicitVariablesProcessorTest.java
@@ -23,25 +23,28 @@ import org.eclipse.lsp.cobol.common.processor.ProcessingContext;
 import org.eclipse.lsp.cobol.common.symbols.VariableAccumulator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
  * Test for CICSImplicitVariablesProcessor
  */
+@ExtendWith(MockitoExtension.class)
 class CICSImplicitVariablesProcessorTest {
   private static final int CICS_INTRODUCED_REGISTERS_COUNT = 72;
+  @Mock
   private ProcessingContext processingContext;
-  private VariableAccumulator variableAccumulator;
+  @Mock private VariableAccumulator variableAccumulator;
   CICSImplicitVariablesProcessor processor;
 
   @BeforeEach
   void init() {
-    processingContext = mock(ProcessingContext.class);
-    variableAccumulator = mock(VariableAccumulator.class);
-
-    when(processingContext.getVariableAccumulator()).thenReturn(variableAccumulator);
     processor = new CICSImplicitVariablesProcessor();
   }
 
@@ -49,17 +52,22 @@ class CICSImplicitVariablesProcessorTest {
   void testLinkageSectionWhenCicsTranslateEnabled() {
     SectionNode sectionNode = new SectionNode(Locality.builder().build(), SectionType.LINKAGE);
     sectionNode.setParent(new ProgramNode(Locality.builder().build(), ProgramSubtype.Program, 0));
-
+    when(processingContext.getVariableAccumulator()).thenReturn(variableAccumulator);
+    assertNotNull(processingContext.getVariableAccumulator());
+    assertEquals(variableAccumulator, processingContext.getVariableAccumulator());
     processor.accept(sectionNode, processingContext);
     verify(variableAccumulator, times(33)).addVariableDefinition(any(), any());
   }
 
   @Test
   void testWorkingSectionWhenCicsTranslateEnabled() {
+    when(processingContext.getVariableAccumulator()).thenReturn(variableAccumulator);
     SectionNode sectionNode =
             new SectionNode(Locality.builder().build(), SectionType.WORKING_STORAGE);
     sectionNode.setParent(new ProgramNode(Locality.builder().build(), ProgramSubtype.Program, 0));
 
+    assertNotNull(processingContext.getVariableAccumulator());
+    assertEquals(variableAccumulator, processingContext.getVariableAccumulator());
     processor.accept(sectionNode, processingContext);
     verify(variableAccumulator, times(CICS_INTRODUCED_REGISTERS_COUNT))
             .addVariableDefinition(any(), any());

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/implicitDialects/cics/processor/CICSImplicitVariablesProcessorTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/implicitDialects/cics/processor/CICSImplicitVariablesProcessorTest.java
@@ -61,7 +61,7 @@ class CICSImplicitVariablesProcessorTest {
 
   @Test
   void testWorkingSectionWhenCicsTranslateEnabled() {
-    when(processingContext.getVariableAccumulator()).thenReturn(variableAccumulator);
+    doReturn(variableAccumulator).when(processingContext).getVariableAccumulator();
     SectionNode sectionNode =
             new SectionNode(Locality.builder().build(), SectionType.WORKING_STORAGE);
     sectionNode.setParent(new ProgramNode(Locality.builder().build(), ProgramSubtype.Program, 0));

--- a/server/engine/src/test/resources/access-filter.json
+++ b/server/engine/src/test/resources/access-filter.json
@@ -1,15 +1,17 @@
 { "rules": [
-  {"excludeClasses": "org.eclipse.lsp.cobol.usecases.**"},
-  {"excludeClasses": "net.bytebuddy.implementation.**"},
-  {"excludeClasses": "net.bytebuddy.description.**"},
-  {"excludeClasses": "net.bytebuddy.asm.**"},
-  {"excludeClasses": "net.bytebuddy.agent.**"},
-  {"excludeClasses": "java.lang.instrument.Instrumentation"},
-  {"excludeClasses": "net.bytebuddy.utility.**"},
-  {"excludeClasses": "org.apache.maven.surefire.**"},
-  {"excludeClasses": "org.antlr.v4.runtime.**"},
-  {"excludeClasses": "org.slf4j.impl.**"},
-  {"excludeClasses": "org.mockito.**"},
-  {"excludeClasses": "java.nio.file.**"}
-]
+  {"excludeClasses": "java.lang.instrument.Instrumentation"}
+],
+  "regexRules": [
+    {"excludeClasses": "org.slf4j.impl.*"},
+    {"excludeClasses": "org.mockito.*"},
+    {"excludeClasses": "java.nio.file.*"},
+    {"excludeClasses": "net.bytebuddy.utility.*"},
+    {"excludeClasses": "org.apache.maven.surefire.*"},
+    {"excludeClasses": "org.antlr.v4.runtime.*"},
+    {"excludeClasses": "org.eclipse.lsp.cobol.usecases.*"},
+    {"excludeClasses": "net.bytebuddy.implementation.*"},
+    {"excludeClasses": "net.bytebuddy.description.*"},
+    {"excludeClasses": "net.bytebuddy.asm.*"},
+    {"excludeClasses": "net.bytebuddy.agent.*"}
+  ]
 }

--- a/server/test/pom.xml
+++ b/server/test/pom.xml
@@ -20,11 +20,10 @@
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
-        <junit-jupiter.version>5.6.0</junit-jupiter.version>
-        <junit.platform.version>1.6.0</junit.platform.version>
+        <junit-jupiter.version>5.11.0-M2</junit-jupiter.version>
         <mockito.core.version>5.14.2</mockito.core.version>
         <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
         <guice.version>4.2.2</guice.version>
         <autoservice.version>1.0.1</autoservice.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -98,27 +97,10 @@
             <artifactId>auto-service</artifactId>
             <version>${autoservice.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${junit-jupiter.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit-jupiter.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <version>${junit.platform.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -168,9 +150,21 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                     <parallel>all</parallel>
                     <systemPropertyVariables>
                         <property>


### PR DESCRIPTION
chore: update surefire plugin to use junit5

update surefire plugin to use junit5 runner. And update the mockito configs as per the below docs
https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3