### PR TITLE
fix: remove argument from DBCONN and MQCONN

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/implicitDialects/cics/CICSParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/implicitDialects/cics/CICSParser.g4
@@ -317,9 +317,10 @@ cics_deq_cmds : (RESOURCE cics_data_area | LENGTH cics_data_value | MAXLIFETIME 
 
 /** DISCARD System Commands **/
 cics_discard: DISCARD cics_discard_body;
-cics_discard_body: cics_handle_response* (ATOMSERVICE | AUTINSTMODEL | BUNDLE | CONNECTION | DB2CONN | DB2ENTRY | DB2TRAN | DOCTEMPLATE |
-                   ENQMODEL | FILE | IPCONN | JOURNALMODEL | JOURNALNAME | JVMSERVER | LIBRARY | MQCONN | MQMONITOR | PARTNER | PIPELINE |
-                   PROCESSTYPE | PROFILE | PROGRAM | TCPIPSERVICE | TDQUEUE | TERMINAL | TRANCLASS | TRANSACTION | TSMODEL | URIMAP | WEBSERVICE) cics_data_value cics_handle_response*;
+cics_discard_body: cics_handle_response* ((ATOMSERVICE | AUTINSTMODEL | BUNDLE | CONNECTION | DB2ENTRY | DB2TRAN | DOCTEMPLATE |
+                   ENQMODEL | FILE | IPCONN | JOURNALMODEL | JOURNALNAME | JVMSERVER | LIBRARY | MQMONITOR | PARTNER | PIPELINE |
+                   PROCESSTYPE | PROFILE | PROGRAM | TCPIPSERVICE | TDQUEUE | TERMINAL | TRANCLASS | TRANSACTION | TSMODEL | URIMAP | WEBSERVICE) cics_data_value |
+                   DB2CONN | MQCONN) cics_handle_response*;
 
 /** DOCUMENT CREATE / DELETE / INSERT / RETRIEVE / SET */
 cics_document: DOCUMENT (cics_document_create | DELETE DOCTOKEN cics_data_area | cics_document_insert |

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSDiscardOptionsUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSDiscardOptionsUtility.java
@@ -38,7 +38,7 @@ public class CICSDiscardOptionsUtility extends CICSOptionsCheckBaseUtility {
                     put(CICSLexer.AUTINSTMODEL, ErrorSeverity.ERROR);
                     put(CICSLexer.BUNDLE, ErrorSeverity.ERROR);
                     put(CICSLexer.CONNECTION, ErrorSeverity.ERROR);
-                    put(CICSLexer.DB2CONN, ErrorSeverity.ERROR);
+                    put(CICSLexer.DB2CONN, ErrorSeverity.WARNING);
                     put(CICSLexer.DB2ENTRY, ErrorSeverity.ERROR);
                     put(CICSLexer.DB2TRAN, ErrorSeverity.ERROR);
                     put(CICSLexer.DOCTEMPLATE, ErrorSeverity.ERROR);
@@ -49,7 +49,7 @@ public class CICSDiscardOptionsUtility extends CICSOptionsCheckBaseUtility {
                     put(CICSLexer.JOURNALNAME, ErrorSeverity.ERROR);
                     put(CICSLexer.JVMSERVER, ErrorSeverity.ERROR);
                     put(CICSLexer.LIBRARY, ErrorSeverity.ERROR);
-                    put(CICSLexer.MQCONN, ErrorSeverity.ERROR);
+                    put(CICSLexer.MQCONN, ErrorSeverity.WARNING);
                     put(CICSLexer.MQMONITOR, ErrorSeverity.ERROR);
                     put(CICSLexer.PARTNER, ErrorSeverity.ERROR);
                     put(CICSLexer.PIPELINE, ErrorSeverity.ERROR);

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCicsDiscard.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestCicsDiscard.java
@@ -35,7 +35,7 @@ public class TestCicsDiscard {
   private static final String DISCARD_AUTINSTMODEL_VALID = "DISCARD AUTINSTMODEL({$varFour}) RESP({$varOne})";
   private static final String DISCARD_BUNDLE_VALID = "DISCARD BUNDLE({$varFour})";
   private static final String DISCARD_CONNECTION_VALID = "DISCARD RESP({$varOne}) CONNECTION({$varFour})";
-  private static final String DISCARD_DB2CONN_VALID = "DISCARD DB2CONN({$varFour})";
+  private static final String DISCARD_DB2CONN_VALID = "DISCARD DB2CONN";
   private static final String DISCARD_DB2ENTRY_VALID = "DISCARD DB2ENTRY({$varFour}) NOHANDLE";
   private static final String DISCARD_DB2TRAN_VALID = "DISCARD DB2TRAN({$varFour})";
   private static final String DISCARD_DOCTEMPLATE_VALID = "DISCARD NOHANDLE DOCTEMPLATE({$varFour}) RESP({$varOne})";
@@ -46,7 +46,7 @@ public class TestCicsDiscard {
   private static final String DISCARD_JOURNALNAME_VALID = "DISCARD JOURNALNAME({$varFour})";
   private static final String DISCARD_JVMSERVER_VALID = "DISCARD NOHANDLE JVMSERVER({$varFour})";
   private static final String DISCARD_LIBRARY_VALID = "DISCARD LIBRARY({$varFour})";
-  private static final String DISCARD_MQCONN_VALID = "DISCARD MQCONN({$varFour}) RESP({$varOne})";
+  private static final String DISCARD_MQCONN_VALID = "DISCARD MQCONN RESP({$varOne})";
   private static final String DISCARD_MQMONITOR_VALID = "DISCARD MQMONITOR({$varFour})";
   private static final String DISCARD_PARTNER_VALID = "DISCARD PARTNER({$varFour})";
   private static final String DISCARD_PIPELINE_VALID = "DISCARD RESP({$varOne}) PIPELINE({$varFour})";


### PR DESCRIPTION
## How Has This Been Tested?

Verified via updated unit tests (Documentation is incorrect on db2conn argument)

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
