### PR TITLE
fix: Fix CFAST json representation

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliCFAST.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliCFAST.java
@@ -14,9 +14,9 @@
  */
 package org.eclipse.lsp.cobol.cli.command;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.lsp.cobol.cfg.CFASTBuilder;
@@ -25,6 +25,7 @@ import org.eclipse.lsp.cobol.common.dialects.CobolLanguageId;
 import org.eclipse.lsp.cobol.common.model.tree.ProgramNode;
 import org.eclipse.lsp.cobol.common.pipeline.StageResult;
 import org.eclipse.lsp.cobol.dialects.ibm.ProcessingResult;
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
 import picocli.CommandLine;
 
 import java.io.File;
@@ -61,11 +62,11 @@ public class CliCFAST  implements Callable<Integer> {
           throw new Exception("Cannot find folder: " + workspace.toFile().getAbsolutePath());
         }
 
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        MessageJsonHandler handler = new MessageJsonHandler(ImmutableMap.of());
 
         Arrays.stream(paths)
             .filter(CliCFAST::isCobolFile)
-            .forEach(file -> generateCFAST(file, builder, gson, diCtx));
+            .forEach(file -> generateCFAST(file, builder, handler.getGson(), diCtx));
       }
     } catch (Exception e) {
       System.out.println("Failed to generate CFAST: " + e.getMessage());

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/extendedapi/InlinePerform.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/extendedapi/InlinePerform.java
@@ -17,14 +17,18 @@ package org.eclipse.lsp.cobol.core.model.extendedapi;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
+import java.util.Optional;
+
 /** Data transport object of CF AST. InlinePerform type represents PERFORM UNTIL COBOL statement */
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class InlinePerform extends CFASTNode {
-  PerformUntilType performUntilType;
+  String performUntilType;
 
   public InlinePerform(Location location, PerformUntilType performUntilType) {
     super(CFASTNodeType.INLINE_PERFORM.getValue(), location);
-    this.performUntilType = performUntilType;
+    this.performUntilType = Optional.ofNullable(performUntilType)
+        .map(PerformUntilType::name)
+        .orElse(null);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/extendedapi/Perform.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/extendedapi/Perform.java
@@ -28,7 +28,7 @@ public class Perform extends CFASTNode {
   String targetSectionName;
   String thruName;
   String thruSectionName;
-  PerformUntilType performUntilType;
+  String performUntilType;
 
   public Perform(ProcedureName target, ProcedureName thru, Location location, PerformUntilType performUntilType) {
     super(CFASTNodeType.PERFORM.getValue(), location);
@@ -36,6 +36,8 @@ public class Perform extends CFASTNode {
     this.targetSectionName = Optional.ofNullable(target).map(ProcedureName::getInSection).orElse(null);
     this.thruName = Optional.ofNullable(thru).map(ProcedureName::getName).orElse(null);
     this.thruSectionName = Optional.ofNullable(thru).map(ProcedureName::getInSection).orElse(null);
-    this.performUntilType = performUntilType;
+    this.performUntilType = Optional.ofNullable(performUntilType)
+        .map(PerformUntilType::name)
+        .orElse(null);
   }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/extendedapi/CFASTBuilderTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/extendedapi/CFASTBuilderTest.java
@@ -14,9 +14,8 @@
  */
 package org.eclipse.lsp.cobol.extendedapi;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.ToNumberPolicy;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,6 +29,7 @@ import org.eclipse.lsp.cobol.common.AnalysisResult;
 import org.eclipse.lsp.cobol.service.DocumentModelService;
 import org.eclipse.lsp.cobol.test.engine.UseCase;
 import org.eclipse.lsp.cobol.test.engine.UseCaseUtils;
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -38,12 +38,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 /** Test for @link({@link CFASTBuilderImpl}. */
 @Slf4j
 class CFASTBuilderTest {
-  private static final Gson GSON =
-      new GsonBuilder()
-          .setPrettyPrinting()
-          .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
-          .create();
-
   static Stream<Arguments> casesToTest() throws IOException {
     return Files.list(Paths.get("src", "test", "resources", "cfast"))
         .filter(p -> p.toString().endsWith(".cbl"))
@@ -69,11 +63,14 @@ class CFASTBuilderTest {
     DocumentModelService documentModelService = new DocumentModelService();
     documentModelService.openDocument("fake/path", src, "COBOL");
     CFASTBuilder builder = new CFASTBuilderImpl(documentModelService);
+    MessageJsonHandler handler = new MessageJsonHandler(ImmutableMap.of());
+    Gson gson = handler.getGson();
+
     Assertions.assertEquals(
-        GSON.toJson(GSON.fromJson(jsonTree, List.class)),
-        GSON.toJson(
-            GSON.fromJson(
-                GSON.toJson(builder.build(analysisResult.getRootNode().findFirstProgramNode()).getControlFlowAST()),
+        gson.toJson(gson.fromJson(jsonTree, List.class)),
+        gson.toJson(
+            gson.fromJson(
+                gson.toJson(builder.build(analysisResult.getRootNode().findFirstProgramNode()).getControlFlowAST()),
                 List.class)));
   }
 


### PR DESCRIPTION
Eclipse library treat Enum as a number instead of string, that's why tests are passing, but actual CFAST coming from COBOL LS contains numbers instead of Enum names

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings