### PR TITLE
fix: do not show previous benchmark logs for an uri

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/benchmark/BenchmarkService.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/benchmark/BenchmarkService.java
@@ -46,4 +46,10 @@ public interface BenchmarkService {
    * Log accumulated timing information.
    */
   void logTiming();
+
+  /**
+   * Ends a benchmark session for an uri
+   * @param programUri document uri
+   */
+  void endSession(String programUri);
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/benchmark/BenchmarkServiceImpl.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/benchmark/BenchmarkServiceImpl.java
@@ -61,6 +61,14 @@ public class BenchmarkServiceImpl implements BenchmarkService {
     benchmarkSessions.forEach(this::logTiming);
   }
 
+  @Override
+  public void endSession(String programUri) {
+      benchmarkSessions.removeIf(benchmarkSession -> {
+          String benchmarkUri = benchmarkSession.attr("uri");
+          return Objects.nonNull(benchmarkUri) && benchmarkUri.equals(programUri);
+      });
+  }
+
   public void logTiming(BenchmarkSession benchmarkSession) {
     LOG.debug("---- Benchmark for uri : {}", benchmarkSession.attr("uri"));
     Collection<Measurement> measurements = benchmarkSession

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/CobolLanguageEngine.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/CobolLanguageEngine.java
@@ -162,6 +162,7 @@ public class CobolLanguageEngine {
     session.attr("size", String.valueOf(ctx.getExtendedDocument().toString().length()));
     session.attr("result", result.stopProcessing() ? "stopped" : "done");
     benchmarkService.logTiming();
+    benchmarkService.endSession(documentUri);
     if (result.stopProcessing() || !(result.getData() instanceof ProcessingResult)) {
       return toAnalysisResult(
           new ResultWithErrors<>(


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test below change in logs (level DEBUG and above)
prev logs
```
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - ---- Benchmark for uri : file:///Users/amanprashant/IdeaProjects/cobolls-internal-test/SLICK/COBPGM/SLICKB0.cbl
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Compiler Directives processing: 576,833 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Preprocessing: 63,709,333 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Dialects processing: 6,498,208 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Transform tree: 52,186,041 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for dialects compiler directives processing: 1,890,589,042 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Implicit dialects processing: 21,347,625 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Cleanup document processing: 21,221,125 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Parsing stage: 557,475,584 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - ---- Benchmark for uri : file:///Users/amanprashant/IdeaProjects/cobolls-internal-test/SLICK/COBPGM/SLICKB0.cbl
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Compiler Directives processing: 496,667 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Preprocessing: 45,237,584 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Dialects processing: 1,929,750 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Transform tree: 11,748,958 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for dialects compiler directives processing: 1,621,458 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Implicit dialects processing: 2,220,416 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Cleanup document processing: 9,087,167 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Parsing stage: 4,878,625 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - ---- Benchmark for uri : file:///Users/amanprashant/IdeaProjects/cobolls-internal-test/SLICK/COBPGM/SLICKB0.cbl
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Compiler Directives processing: 346,667 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Preprocessing: 37,690,916 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Dialects processing: 1,904,042 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Transform tree: 10,655,166 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for dialects compiler directives processing: 1,193,833 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Implicit dialects processing: 1,762,125 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Cleanup document processing: 5,460,083 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Parsing stage: 4,008,875 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - ---- Benchmark for uri : file:///Users/amanprashant/IdeaProjects/cobolls-internal-test/SLICK/COBPGM/SLICKB0.cbl
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Compiler Directives processing: 353,125 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Preprocessing: 2,790,042 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Dialects processing: 1,657,042 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Transform tree: 11,589,083 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for dialects compiler directives processing: 1,271,084 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Implicit dialects processing: 2,776,417 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Cleanup document processing: 5,568,959 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Parsing stage: 5,519,292 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - ---- Benchmark for uri : file:///Users/amanprashant/IdeaProjects/cobolls-internal-test/SLICK/COBPGM/SLICKB0.cbl
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Compiler Directives processing: 311,333 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Preprocessing: 15,472,500 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Dialects processing: 2,155,542 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Transform tree: 19,811,625 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for dialects compiler directives processing: 1,137,167 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Implicit dialects processing: 5,208,917 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Cleanup document processing: 5,338,458 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Parsing stage: 8,157,000 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - ---- Benchmark for uri : file:///Users/amanprashant/IdeaProjects/cobolls-internal-test/SLICK/COBPGM/SLICKB0.cbl
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Compiler Directives processing: 359,583 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Preprocessing: 11,006,083 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Dialects processing: 1,723,542 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Transform tree: 11,454,375 ns
13:19:09.873 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for dialects compiler directives processing: 1,215,000 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Implicit dialects processing: 7,346,791 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Cleanup document processing: 5,098,208 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Parsing stage: 4,748,125 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - ---- Benchmark for uri : file:///Users/amanprashant/IdeaProjects/cobolls-internal-test/SLICK/COBPGM/SLICKB0.cbl
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Compiler Directives processing: 173,708 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Preprocessing: 4,698,167 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Dialects processing: 1,237,083 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Transform tree: 14,326,875 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for dialects compiler directives processing: 855,000 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Implicit dialects processing: 4,604,000 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Cleanup document processing: 3,992,834 ns
13:19:09.874 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Parsing stage: 6,123,833 ns
``` 
new logs:
Would not show benchmark for the prev runs, but just the last run.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
