### PR TITLE
Added check when SYSID is used

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSReadOptionsCheckUtility.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/utility/CICSReadOptionsCheckUtility.java
@@ -86,6 +86,10 @@ public class CICSReadOptionsCheckUtility extends CICSOptionsCheckBaseUtility {
 
         checkMutuallyExclusiveOptions("DEBKEY, DEBREC, RBA, RRN or XRBA", ctx.DEBKEY(), ctx.DEBREC(), ctx.RBA(), ctx.RRN(), ctx.XRBA());
 
+        if (!ctx.SYSID().isEmpty()) {
+            checkHasExactlyOneOption("KEYLENGTH, RBA, XRBA or RRN", ctx, ctx.KEYLENGTH(), ctx.RBA(), ctx.XRBA(), ctx.RRN());
+        }
+
         checkMutuallyExclusiveOptions("EQUAL or GTEQ", ctx.EQUAL(), ctx.GTEQ());
 
         checkDuplicates(ctx);


### PR DESCRIPTION
Added a check when SYSID is used as the compiler states that the use of it implies that one of the following:
- KEYLENGTH
- RBA
- XRBA
- RRN

must be specified.

## How Has This Been Tested?

Ran existing tests.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
