### PR TITLE
Add Command to show Extension's Output Channel

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -86,6 +86,11 @@
         "title": "Run Analysis in CLI"
       },
       {
+        "command": "cobol-lsp.debug.openOutputWindow",
+        "category": "COBOL",
+        "title": "Open Debug Output Window"
+      },
+      {
         "command": "cobol-lsp.snippets.insertSnippets",
         "title": "Insert COBOL Snippet",
         "category": "Snippets"
@@ -142,6 +147,11 @@
           "command": "cobol-lsp.analysis.runAnalysis",
           "category": "COBOL",
           "title": "Run Analysis in CLI"
+        },
+        {
+          "command": "cobol-lsp.debug.openOutputWindow",
+          "category": "COBOL",
+          "title": "Open Debug Output Window"
         },
         {
           "command": "cobol-lsp.snippets.insertSnippets",

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
@@ -68,7 +68,7 @@ describe("Check plugin extension for cobol starts successfully.", () => {
       "Extension activation event was triggered",
     );
 
-    expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(11);
+    expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(12);
 
     expect(fetchCopybookCommand).toHaveBeenCalled();
     expect(gotoCopybookSettings).toHaveBeenCalled();

--- a/clients/cobol-lsp-vscode-extension/src/commands/OpenOutputWIndow.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/OpenOutputWIndow.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+
+import * as vscode from "vscode";
+
+export function openOutputWindow(outputChannel: vscode.OutputChannel) {
+  outputChannel.show();
+}

--- a/clients/cobol-lsp-vscode-extension/src/commands/OpenOutputWIndow.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/OpenOutputWIndow.ts
@@ -14,6 +14,6 @@
 
 import * as vscode from "vscode";
 
-export async function openOutputWindow(outputChannel: vscode.OutputChannel) {
-  await outputChannel.show();
+export function openOutputWindow(outputChannel: vscode.OutputChannel) {
+  outputChannel.show();
 }

--- a/clients/cobol-lsp-vscode-extension/src/commands/OpenOutputWIndow.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/OpenOutputWIndow.ts
@@ -14,6 +14,6 @@
 
 import * as vscode from "vscode";
 
-export function openOutputWindow(outputChannel: vscode.OutputChannel) {
-  outputChannel.show();
+export async function openOutputWindow(outputChannel: vscode.OutputChannel) {
+  await outputChannel.show();
 }

--- a/clients/cobol-lsp-vscode-extension/src/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/extension.ts
@@ -381,7 +381,7 @@ function registerCommands(
     vscode.commands.registerCommand(
       "cobol-lsp.debug.openOutputWindow",
       async () => {
-        openOutputWindow(outputChannel);
+        await openOutputWindow(outputChannel);
       },
     ),
   );

--- a/clients/cobol-lsp-vscode-extension/src/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/extension.ts
@@ -46,6 +46,7 @@ import { ConfigurationWatcher } from "./services/util/ConfigurationWatcher";
 import * as path from "node:path";
 import { Utils } from "./services/util/Utils";
 import { getE4EAPI } from "./services/copybook/E4ECopybookService";
+import { openOutputWindow } from "./commands/OpenOutputWIndow";
 import { getErrorMessage } from "./services/util/ErrorsUtils";
 import {
   initTelemetry,
@@ -372,6 +373,15 @@ function registerCommands(
             `${FAIL_CREATE_COPYBOOK_FOLDER_MSG} : ${getErrorMessage(error)}`,
           );
         }
+      },
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "cobol-lsp.debug.openOutputWindow",
+      async () => {
+        openOutputWindow(outputChannel);
       },
     ),
   );

--- a/clients/cobol-lsp-vscode-extension/src/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/extension.ts
@@ -378,12 +378,9 @@ function registerCommands(
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand(
-      "cobol-lsp.debug.openOutputWindow",
-      async () => {
-        await openOutputWindow(outputChannel);
-      },
-    ),
+    vscode.commands.registerCommand("cobol-lsp.debug.openOutputWindow", () => {
+      openOutputWindow(outputChannel);
+    }),
   );
 
   context.subscriptions.push(


### PR DESCRIPTION
Added a command palette command to show the output channel for the extension. This will make it easier to get to debug information without needing to remember to change the filter/channel.

## How Has This Been Tested?

Tested the change in the extension running locally. It brings up the output window with the extension's channel selected.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
