### PR TITLE
chore: add logger for copybook download time

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -242,10 +242,13 @@ export class CopybookDownloadService {
   ): Promise<void> {
     const totalCopybooksToDownload = copybookNames.length;
     let processedCopybooks = 0;
-
+    const downloadRequestStartTime = performance.now();
     await Promise.all(
       copybookNames.map(async (copybookName) => {
         await this.downloadCopybook(copybookName, documentUri).finally(() => {
+          this.outputChannel?.appendLine(
+            `==> Copybook ${copybookName.name}(dialect:${copybookName.dialect}) download completed in : ${performance.now() - downloadRequestStartTime} milliseconds`,
+          );
           processedCopybooks++;
           this.updateDownloadProgress(
             progress,


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] No impact , just a logger addition.
Expect output channel to have logs similar to below if copybooks are downloaded
```
==> Copybook AABAAA(dialect:COBOL) download completed in : 16.415334000001167 milliseconds
==> Copybook ZZAAA(dialect:COBOL) download completed in : 16.601416999999856 milliseconds
==> Copybook XXSDDD(dialect:COBOL) download completed in : 16.677333999999973 milliseconds
==> Copybook SUBSCHEMA-BINDS(dialect:IDMS) download completed in : 1843.7317090000015 milliseconds
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
