### PR TITLE
fix: Do not check zowe profile if no remote copybooks location is configured

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
@@ -82,7 +82,7 @@ export namespace extensions {
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace window {
-  export const showErrorMessage = jest.fn();
+  export const showErrorMessage = jest.fn().mockResolvedValue(undefined);
   export const showInformationMessage = jest.fn();
   export const createStatusBarItem = () => {
     return { show: () => {} };

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -256,7 +256,6 @@ describe("Tests copybook download service", () => {
     });
 
     it("checks no profile checks are done when download configurations are not configured", async () => {
-      vscode.window.showErrorMessage = jest.fn();
       const downloadService = new CopybookDownloadService(
         "storage-path",
         zoweExplorerMock,
@@ -809,6 +808,33 @@ describe("Tests copybook download service", () => {
         );
 
         expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("Check Zowe profile configuration if remote location is configured", () => {
+      beforeEach(() => {
+        workspaceConfigurationMock = {
+          "paths-dsn": ["DATASET.WITH.COPYBOOKS"],
+          "paths-uss": [],
+          "copybook-extensions": [".CPY", ".cpy", ""],
+        };
+        profileName = "";
+      });
+
+      test("error popup is shown", async () => {
+        const cds = new CopybookDownloadService(
+          "/globalStorage",
+          zoweExplorerApiMock,
+        );
+        await cds.listRemoteCopybooks(
+          Uri.file("/test.cbl").toString(),
+          DEFAULT_DIALECT,
+        );
+
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+          "Please specify a valid Zowe Explorer profile to download copybooks from the mainframe.",
+          "Change settings",
+        );
       });
     });
   });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -543,8 +543,8 @@ describe("Tests copybook download service", () => {
     let zoweExplorerApiMock: IApiRegisterClient;
     let getAllMembersMock: jest.SpyInstance<IZosFilesResponseMemberList>;
     let fileListMock: jest.SpyInstance<IZosFilesResponseFileList>;
-    let datasetMembers: string[];
-    let ussFiles: { name: string; mode?: string }[];
+    let datasetMembers: string[] = [];
+    let ussFiles: { name: string; mode?: string }[] = [];
 
     beforeEach(() => {
       getAllMembersMock = jest.fn().mockResolvedValue({
@@ -785,6 +785,30 @@ describe("Tests copybook download service", () => {
             FAILED_REQUESTS_LIMIT * 2,
           );
         });
+      });
+    });
+
+    describe("Do not require Zowe profile configuration if no remote location is configured", () => {
+      beforeEach(() => {
+        workspaceConfigurationMock = {
+          "paths-dsn": [],
+          "paths-uss": [],
+          "copybook-extensions": [".CPY", ".cpy", ""],
+        };
+        profileName = "";
+      });
+
+      test("no error popup is shown", async () => {
+        const cds = new CopybookDownloadService(
+          "/globalStorage",
+          zoweExplorerApiMock,
+        );
+        await cds.listRemoteCopybooks(
+          Uri.file("/test.cbl").toString(),
+          DEFAULT_DIALECT,
+        );
+
+        expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
       });
     });
   });

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -252,12 +252,6 @@ export class CopybookDownloadService {
       ...DialectRegistry.getActiveDialects().map((di) => di.name),
     ];
 
-    if (
-      !(await this.isPrerequisiteForDownloadSatisfied(documentUri, dialects))
-    ) {
-      return [];
-    }
-
     const profile = ProfileUtils.getProfileNameForCopybook(
       documentUri,
       this.explorerApi,
@@ -270,6 +264,13 @@ export class CopybookDownloadService {
 
     const dsnPaths: string[] = SettingsService.getDsnPath(documentUri, dialect);
     const ussPaths: string[] = SettingsService.getUssPath(documentUri, dialect);
+
+    if (
+      (dsnPaths.length > 0 || ussPaths.length > 0) &&
+      !(await this.isPrerequisiteForDownloadSatisfied(documentUri, dialects))
+    ) {
+      return [];
+    }
 
     const results = await Promise.allSettled([
       ...dsnPaths.map(async (dsn) => {

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -252,14 +252,6 @@ export class CopybookDownloadService {
       ...DialectRegistry.getActiveDialects().map((di) => di.name),
     ];
 
-    const profile = ProfileUtils.getProfileNameForCopybook(
-      documentUri,
-      this.explorerApi,
-    );
-    if (!profile) {
-      return [];
-    }
-
     const copybooks: string[] = [];
 
     const dsnPaths: string[] = SettingsService.getDsnPath(documentUri, dialect);
@@ -269,6 +261,14 @@ export class CopybookDownloadService {
       (dsnPaths.length > 0 || ussPaths.length > 0) &&
       !(await this.isPrerequisiteForDownloadSatisfied(documentUri, dialects))
     ) {
+      return [];
+    }
+
+    const profile = ProfileUtils.getProfileNameForCopybook(
+      documentUri,
+      this.explorerApi,
+    );
+    if (!profile) {
       return [];
     }
 

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -256,9 +256,12 @@ export class CopybookDownloadService {
 
     const dsnPaths: string[] = SettingsService.getDsnPath(documentUri, dialect);
     const ussPaths: string[] = SettingsService.getUssPath(documentUri, dialect);
+    
+    if (dsnPaths.length === 0 && ussPaths.length === 0) {
+      return [];
+    }
 
     if (
-      (dsnPaths.length > 0 || ussPaths.length > 0) &&
       !(await this.isPrerequisiteForDownloadSatisfied(documentUri, dialects))
     ) {
       return [];

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -256,7 +256,7 @@ export class CopybookDownloadService {
 
     const dsnPaths: string[] = SettingsService.getDsnPath(documentUri, dialect);
     const ussPaths: string[] = SettingsService.getUssPath(documentUri, dialect);
-    
+
     if (dsnPaths.length === 0 && ussPaths.length === 0) {
       return [];
     }


### PR DESCRIPTION
Fix for [DE630106](https://rally1.rallydev.com/#/?detail=/defect/820989575793&fdp=true): zowe profile popup continuously showing for Local copybooks

## How Has This Been Tested?

Added unit test to `src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
