### PR TITLE
fix: Use default dialect name for SQL dialect

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookCompletionProviderTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookCompletionProviderTest.spec.ts
@@ -278,7 +278,7 @@ describe("CopybooksCompletionProvider", () => {
       positionChar = lineText.length;
     });
 
-    test("returns all completions for copybooks using SQL dialect", async () => {
+    test("returns all completions for copybooks (SQL dialect is resolved as default COBOL dialect)", async () => {
       const provider = new CopybooksCompletionProvider(cdsMock);
       await provider.provideCompletionItems(
         documentMock,
@@ -289,7 +289,7 @@ describe("CopybooksCompletionProvider", () => {
 
       expect(cdsMock.listRemoteCopybooks).toHaveBeenCalledWith(
         "file://PROGRAM.cbl",
-        "SQL",
+        "COBOL",
       );
     });
   });

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybooksCompletionProvider.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybooksCompletionProvider.ts
@@ -72,6 +72,13 @@ export class CopybooksCompletionProvider implements CompletionItemProvider {
         isCopyStatement: isDefaultCopyStatement,
       },
       {
+        /**
+         * SQL preprocessor is supposed to use `SQL` as a name, but because
+         * the server is sending `COBOL` as a dialect name in the
+         * `copybook/resolve` requests for `EXEC SQL INCLUDE` statements,
+         * we need to use it for auto-completions as well, so copybook
+         * downloading works correctly.
+         */
         name: DEFAULT_DIALECT,
         isCopyStatement: isSQLCopyStatement,
       },

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybooksCompletionProvider.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybooksCompletionProvider.ts
@@ -72,7 +72,7 @@ export class CopybooksCompletionProvider implements CompletionItemProvider {
         isCopyStatement: isDefaultCopyStatement,
       },
       {
-        name: "SQL",
+        name: DEFAULT_DIALECT,
         isCopyStatement: isSQLCopyStatement,
       },
       ...DialectRegistry.getActiveDialects().map((di) => ({


### PR DESCRIPTION
Fix for [DE630100](https://rally1.rallydev.com/#/?detail=/defect/820986678201&fdp=true): Autocompletion doesn't show any copybook for INCLUDE statement [verify Remote and Local copybooks]

The default dialect name (`COBOL`) instead of `SQL` name is used when listing completions for `EXEC SQL INCLUDE` statement. This is to make it compatible with the server - it sends `COBOL` as a dialect name in the `copybook/resolve` requests for the `EXEC SQL INCLUDE` statements.

## How Has This Been Tested?

Updated unit test & manual testing.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
