### PR TITLE
fix: Prevent zowe profile popup show for local programs

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -114,8 +114,9 @@ describe("Tests copybook download service", () => {
       });
     });
 
-    describe("profile not profiled", () => {
+    describe("profile not provided", () => {
       beforeEach(() => {
+        workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOK"];
         profileName = "";
       });
 
@@ -124,8 +125,23 @@ describe("Tests copybook download service", () => {
           { name: "copybook-name", dialect: DEFAULT_DIALECT },
         ]);
         expect(downloadService["processDownloadError"]).toHaveBeenCalledWith(
-          `${PROVIDE_PROFILE_MSG}`,
+          PROVIDE_PROFILE_MSG,
         );
+      });
+    });
+
+    describe("no profile and no remote location configured", () => {
+      beforeEach(() => {
+        workspaceConfigurationMock[PATHS_DSN] = [];
+        workspaceConfigurationMock[PATHS_USS] = [];
+        profileName = "";
+      });
+
+      it("should not show the missing zowe profile message", async () => {
+        await downloadService.downloadCopybooks("document-uri", [
+          { name: "copybook-name", dialect: DEFAULT_DIALECT },
+        ]);
+        expect(downloadService["processDownloadError"]).not.toHaveBeenCalled();
       });
     });
 

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -100,6 +100,7 @@ describe("Tests copybook download service", () => {
   describe("checks the prerequisites are checked before invoking download", () => {
     describe("unknown-profile", () => {
       beforeEach(() => {
+        workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOK"];
         profileName = "unknown-profile";
       });
 
@@ -293,9 +294,9 @@ describe("Tests copybook download service", () => {
     ProfileUtils.getAvailableProfiles = jest.fn().mockReturnValue("profile");
     DownloadUtil.isProfileLocked = jest.fn().mockReturnValue(false);
     DownloadUtil.checkForInvalidCredProfile = jest.fn().mockReturnValue(false);
-    DownloadUtil.areCopybookDownloadConfigurationsPresent = jest
-      .fn()
-      .mockReturnValue(true);
+    jest
+      .spyOn(DownloadUtil, "areCopybookDownloadConfigurationsPresent")
+      .mockReturnValue({ dsn: "DATASET.WITH.COPYBOOK" });
     const downloadService = new CopybookDownloadService(
       "storage-path",
       {} as unknown as IApiRegisterClient,

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -346,13 +346,13 @@ export class CopybookDownloadService {
     }
     if (!this.explorerApi) return false;
 
-    const copybookLocation =
+    const copybooksLocation =
       DownloadUtil.areCopybookDownloadConfigurationsPresent(
         documentUri,
         dialects,
       );
 
-    if (!copybookLocation) {
+    if (!copybooksLocation) {
       return false;
     }
 
@@ -375,7 +375,7 @@ export class CopybookDownloadService {
       !(await DownloadUtil.checkForInvalidCredProfile(
         profile,
         this.explorerApi,
-        copybookLocation,
+        copybooksLocation,
       ))
     );
   }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -246,22 +246,13 @@ export class CopybookDownloadService {
       return this.e4eDownloader?.listRemoteCopybooksE4E(documentUri) ?? [];
     }
 
-    const dialects = [
-      DEFAULT_DIALECT,
-      ...DialectRegistry.getActiveDialects().map((di) => di.name),
-    ];
-
     const copybooks: string[] = [];
 
     const dsnPaths: string[] = SettingsService.getDsnPath(documentUri, dialect);
     const ussPaths: string[] = SettingsService.getUssPath(documentUri, dialect);
 
-    if (dsnPaths.length === 0 && ussPaths.length === 0) {
-      return [];
-    }
-
     if (
-      !(await this.isPrerequisiteForDownloadSatisfied(documentUri, dialects))
+      !(await this.isPrerequisiteForDownloadSatisfied(documentUri, [dialect]))
     ) {
       return [];
     }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -15,7 +15,6 @@
 import * as vscode from "vscode";
 import {
   COPYBOOKS_FOLDER,
-  DEFAULT_DIALECT,
   ENDEVOR_PROCESSOR,
   PROVIDE_PROFILE_MSG,
   ZOWE_FOLDER,
@@ -32,7 +31,6 @@ import { searchCopybookInExtensionFolder } from "../util/FSUtils";
 import { CopybookURI } from "./CopybookURI";
 import path = require("path");
 import { getErrorMessage } from "../util/ErrorsUtils";
-import { DialectRegistry } from "../DialectRegistry";
 
 export class CopybookName {
   constructor(

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -244,11 +244,6 @@ export class CopybookDownloadService {
       return this.e4eDownloader?.listRemoteCopybooksE4E(documentUri) ?? [];
     }
 
-    const copybooks: string[] = [];
-
-    const dsnPaths: string[] = SettingsService.getDsnPath(documentUri, dialect);
-    const ussPaths: string[] = SettingsService.getUssPath(documentUri, dialect);
-
     if (
       !(await this.isPrerequisiteForDownloadSatisfied(documentUri, [dialect]))
     ) {
@@ -262,6 +257,10 @@ export class CopybookDownloadService {
     if (!profile) {
       return [];
     }
+
+    const copybooks: string[] = [];
+    const dsnPaths: string[] = SettingsService.getDsnPath(documentUri, dialect);
+    const ussPaths: string[] = SettingsService.getUssPath(documentUri, dialect);
 
     const results = await Promise.allSettled([
       ...dsnPaths.map(async (dsn) => {

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -356,6 +356,17 @@ export class CopybookDownloadService {
       return !!(await this.e4eDownloader?.getE4EConfig(documentUri));
     }
     if (!this.explorerApi) return false;
+
+    const copybookLocation =
+      DownloadUtil.areCopybookDownloadConfigurationsPresent(
+        documentUri,
+        dialects,
+      );
+
+    if (!copybookLocation) {
+      return false;
+    }
+
     const profile = ProfileUtils.getProfileNameForCopybook(
       documentUri,
       this.explorerApi,
@@ -375,8 +386,7 @@ export class CopybookDownloadService {
       !(await DownloadUtil.checkForInvalidCredProfile(
         profile,
         this.explorerApi,
-        documentUri,
-        dialects,
+        copybookLocation,
       ))
     );
   }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
@@ -66,12 +66,13 @@ export class DownloadUtil {
    * returns true if the passed profile has invalid credentials, false otherwise
    * @param profileName
    * @param explorerAPI
+   * @param remoteLocation DSN or USS that is used to test mainframe access
    * @returns true if the passed profile has invalid credentials, false otherwise
    */
   public static async checkForInvalidCredProfile(
     profileName: string,
     explorerAPI: IApiRegisterClient,
-    copybookLocation: CopybookRemoteLocation,
+    remoteLocation: MainframeRemoteLocation,
   ): Promise<boolean> {
     if (
       ZoweExplorerDownloader.profileStore.get(profileName) === "valid-profile"
@@ -81,10 +82,10 @@ export class DownloadUtil {
 
     try {
       const profile = this.loadProfile(profileName, explorerAPI);
-      if (copybookLocation.uss) {
-        await explorerAPI.getUssApi(profile).fileList(copybookLocation.uss);
-      } else if (copybookLocation.dsn) {
-        await explorerAPI.getMvsApi(profile).allMembers(copybookLocation.dsn);
+      if (remoteLocation.uss) {
+        await explorerAPI.getUssApi(profile).fileList(remoteLocation.uss);
+      } else if (remoteLocation.dsn) {
+        await explorerAPI.getMvsApi(profile).allMembers(remoteLocation.dsn);
       }
     } catch (error) {
       if (this.checkForInvalidCredentials(error, profileName)) {
@@ -169,7 +170,7 @@ export class DownloadUtil {
   public static areCopybookDownloadConfigurationsPresent(
     documentUri: string,
     dialects: string[],
-  ): CopybookRemoteLocation | null {
+  ): MainframeRemoteLocation | null {
     const uniqueDialects = new Set(
       dialects.map((dialect) => dialect?.toUpperCase()).filter(Boolean),
     );
@@ -245,7 +246,7 @@ export class DownloadUtil {
   }
 }
 
-export type CopybookRemoteLocation =
+export type MainframeRemoteLocation =
   | {
       dsn: string;
       uss?: never;

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
@@ -71,22 +71,12 @@ export class DownloadUtil {
   public static async checkForInvalidCredProfile(
     profileName: string,
     explorerAPI: IApiRegisterClient,
-    documentUri: string,
-    dialects: string[],
+    copybookLocation: CopybookRemoteLocation,
   ): Promise<boolean> {
     if (
       ZoweExplorerDownloader.profileStore.get(profileName) === "valid-profile"
     ) {
       return false;
-    }
-
-    const copybookLocation = this.areCopybookDownloadConfigurationsPresent(
-      documentUri,
-      dialects,
-    );
-
-    if (!copybookLocation) {
-      return true;
     }
 
     try {
@@ -173,12 +163,13 @@ export class DownloadUtil {
    * checks if copybook download configurations are present
    * @param documentUri
    * @param dialects
-   * @returns true if if copybook download configurations are present, false otherwise
+   * @returns first configured remote location if if copybook download
+   * configurations are present, null otherwise
    */
   public static areCopybookDownloadConfigurationsPresent(
     documentUri: string,
     dialects: string[],
-  ) {
+  ): CopybookRemoteLocation | null {
     const uniqueDialects = new Set(
       dialects.map((dialect) => dialect?.toUpperCase()).filter(Boolean),
     );
@@ -253,3 +244,13 @@ export class DownloadUtil {
     );
   }
 }
+
+export type CopybookRemoteLocation =
+  | {
+      dsn: string;
+      uss?: never;
+    }
+  | {
+      uss: string;
+      dsn?: never;
+    };


### PR DESCRIPTION
Another fix for [DE630106](https://rally1.rallydev.com/#/?detail=/defect/820989575793&fdp=true): zowe profile popup continuously showing for Local copybooks 

The `isPrerequisiteForDownloadSatisfied` function was showing Zowe profile popup even when no remote copybook location is configured in settings, which doesn't make sense.

## How Has This Been Tested?

`clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts`

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
