### PR TITLE
feat: support IN/OF for procedures in TestCaseEngine grammat

### DIFF
--- a/server/test/src/main/antlr4/org/eclipse/usecase/UseCasePreprocessor.g4
+++ b/server/test/src/main/antlr4/org/eclipse/usecase/UseCasePreprocessor.g4
@@ -82,7 +82,7 @@ procedureStatement
    ;
 
 procedureUsage
-   : PROCEDUREUSAGE paragraph=word (INOF section=word)?
+   : PARAGRPHUSAGE paragraph=word (INOF section=word)?
    | SECTIONUSAGE section=word
    ;
 
@@ -145,7 +145,7 @@ VARIABLEDEFINITION : START '$*';
 VARIABLEUSAGE : START '$';
 CONSTANTUSAGE : START '&';
 PARAGRPHDEFINITION : START '#*';
-PROCEDUREUSAGE : START '#';
+PARAGRPHUSAGE : START '#';
 INOF : 'IN' | 'OF';
 SECTIONDEFINITION : START '@*';
 SECTIONUSAGE : START '@';

--- a/server/test/src/main/antlr4/org/eclipse/usecase/UseCasePreprocessor.g4
+++ b/server/test/src/main/antlr4/org/eclipse/usecase/UseCasePreprocessor.g4
@@ -25,7 +25,7 @@ multiTokenError
    ;
 
 multiToken
-   : (identifiers | copybookStatement | variableStatement | functionUsage | procedureStatement | subroutineStatement
+   : (words | copybookStatement | variableStatement | functionUsage | procedureStatement | subroutineStatement
    | constantStatement | errorStatement | multiTokenError | TEXT)+
    ;
 

--- a/server/test/src/main/antlr4/org/eclipse/usecase/UseCasePreprocessor.g4
+++ b/server/test/src/main/antlr4/org/eclipse/usecase/UseCasePreprocessor.g4
@@ -16,7 +16,7 @@
 grammar UseCasePreprocessor;
 
 startRule
-   : .*? ((copybookStatement | functionDefinition | variableStatement | functionUsage | paragraphStatement | sectionStatement | subroutineStatement
+   : .*? ((copybookStatement | functionDefinition | variableStatement | functionUsage | procedureStatement | subroutineStatement
    | constantStatement | errorStatement | multiTokenError | linkageSection | NEWLINE)+ .*?)+ EOF
    ;
 
@@ -25,7 +25,7 @@ multiTokenError
    ;
 
 multiToken
-   : (word | copybookStatement | variableStatement | functionUsage | paragraphStatement | sectionStatement | subroutineStatement
+   : (identifiers | copybookStatement | variableStatement | functionUsage | procedureStatement | subroutineStatement
    | constantStatement | errorStatement | multiTokenError | TEXT)+
    ;
 
@@ -34,7 +34,7 @@ linkageSection
    ;
 
 errorStatement
-   : START (STRINGLITERAL | word | TEXT | NUMBERLITERAL)? diagnostic* STOP
+   : START (STRINGLITERAL | words | TEXT | NUMBERLITERAL)? diagnostic* STOP
    ;
 
 copybookStatement
@@ -54,7 +54,7 @@ variableStatement
    ;
 
 variableUsage
-   : VARIABLEUSAGE word
+   : VARIABLEUSAGE name = word (INOF word)*
    ;
 
 functionUsage
@@ -77,24 +77,17 @@ constantUsage
    : CONSTANTUSAGE word
    ;
 
-paragraphStatement
-   : (paragraphUsage | paragraphDefinition) diagnostic* STOP
+procedureStatement
+   : (procedureUsage | paragraphDefinition | sectionDefinition) diagnostic* STOP
    ;
 
-sectionStatement
-   : (sectionUsage | sectionDefinition) diagnostic* STOP
-   ;
-
-paragraphUsage
-   : PARAGRPHUSAGE word
+procedureUsage
+   : PROCEDUREUSAGE paragraph=word (INOF section=word)?
+   | SECTIONUSAGE section=word
    ;
 
 paragraphDefinition
    : PARAGRPHDEFINITION word
-   ;
-
-sectionUsage
-   : SECTIONUSAGE word
    ;
 
 sectionDefinition
@@ -110,11 +103,15 @@ subroutineUsage
    ;
 
 diagnostic
-   : DIAGNOSTICSTART identifier
+   : DIAGNOSTICSTART identifiers
    ;
 
 word
    : identifier replacement?
+   ;
+
+words
+   : identifiers replacement?
    ;
 
 replacement
@@ -122,8 +119,9 @@ replacement
    | (PRODUCE_REPLACEMENT identifier (PRODUCE_REPLACEMENT identifier)*)
    ;
 
+identifiers: identifier+;
 identifier
-   : (IDENTIFIER | NUMBERLITERAL | LINKAGE | SECTION | DOT | STRINGLITERAL | TEXT)+
+   : (IDENTIFIER | NUMBERLITERAL | LINKAGE | SECTION | INOF | DOT | STRINGLITERAL | TEXT)
    ;
 
 cpyIdentifier
@@ -147,7 +145,8 @@ VARIABLEDEFINITION : START '$*';
 VARIABLEUSAGE : START '$';
 CONSTANTUSAGE : START '&';
 PARAGRPHDEFINITION : START '#*';
-PARAGRPHUSAGE : START '#';
+PROCEDUREUSAGE : START '#';
+INOF : 'IN' | 'OF';
 SECTIONDEFINITION : START '@*';
 SECTIONUSAGE : START '@';
 COPYBOOKDEFINITION : START '~*';
@@ -167,7 +166,7 @@ DOT : '.';
 
 NUMBERLITERAL : [\-+0-9.,]+;
 STRINGLITERAL : ['"] .*? ['"\n];
-IDENTIFIER : [a-zA-Z0-9:]+ ([-_]+ [a-zA-Z0-9:]+)*;
+IDENTIFIER : [a-zA-Z0-9'":]+ ([-_]+ [a-zA-Z0-9'":]+)*;
 
 COPYBOOKNAME : [a-zA-Z0-9#@$]+ ([-_]+ [a-zA-Z0-9#@$]+)*;
 QUOTED_COPYBOOKNAME : '\'' COPYBOOKNAME '\'';

--- a/server/test/src/main/java/org/eclipse/lsp/cobol/test/engine/UseCasePreprocessorListener.java
+++ b/server/test/src/main/java/org/eclipse/lsp/cobol/test/engine/UseCasePreprocessorListener.java
@@ -132,10 +132,10 @@ class UseCasePreprocessorListener extends UseCasePreprocessorBaseListener {
   public void exitErrorStatement(ErrorStatementContext ctx) {
     pop();
     ReplacementContext replacementContext =
-            ofNullable(ctx.word()).map(WordContext::replacement).orElse(null);
+            ofNullable(ctx.words()).map(WordsContext::replacement).orElse(null);
     String text =
-            ofNullable(ctx.word())
-                    .map(WordContext::identifier)
+            ofNullable(ctx.words())
+                    .map(WordsContext::identifiers)
                     .map(RuleContext::getText)
                     .orElse(
                             ofNullable(ctx.STRINGLITERAL())
@@ -183,16 +183,16 @@ class UseCasePreprocessorListener extends UseCasePreprocessorBaseListener {
   @Override
   public void exitVariableStatement(VariableStatementContext ctx) {
     pop();
-    ofNullable(ctx.variableUsage())
-            .map(VariableUsageContext::word)
-            .ifPresent(
-                    it ->
-                            processToken(
-                                    it.identifier().getText(),
-                                    ctx,
-                                    it.replacement(),
-                                    variableUsages,
-                                    ctx.diagnostic()));
+    ofNullable(ctx.variableUsage()).ifPresent(vuCtx -> {
+      // TODO: for now we only process the first variable id
+        processToken(
+              vuCtx.name.identifier().getText(),
+              ctx,
+              vuCtx.name.replacement(),
+              variableUsages,
+              ctx.diagnostic(),
+              false);
+    });
     ofNullable(ctx.variableDefinition())
             .map(VariableDefinitionContext::word)
             .ifPresent(
@@ -206,23 +206,32 @@ class UseCasePreprocessorListener extends UseCasePreprocessorBaseListener {
   }
 
   @Override
-  public void enterParagraphStatement(ParagraphStatementContext ctx) {
+  public void enterProcedureStatement(ProcedureStatementContext ctx) {
     push();
   }
 
   @Override
-  public void exitParagraphStatement(ParagraphStatementContext ctx) {
+  public void exitProcedureStatement(ProcedureStatementContext ctx) {
     pop();
-    ofNullable(ctx.paragraphUsage())
-            .map(ParagraphUsageContext::word)
-            .ifPresent(
-                    it ->
-                            processToken(
-                                    it.identifier().getText(),
-                                    ctx,
-                                    it.replacement(),
-                                    paragraphUsages,
-                                    ctx.diagnostic()));
+    if (ctx.procedureUsage() != null) {
+      ProcedureUsageContext procCtx = ctx.procedureUsage();
+      if (procCtx.paragraph != null && procCtx.section == null) {
+        processToken(
+              procCtx.paragraph.identifier().getText(),
+              ctx,
+              procCtx.paragraph.replacement(),
+              paragraphUsages,
+              ctx.diagnostic());
+      }
+      if (procCtx.paragraph == null && procCtx.section != null) {
+        processToken(
+                procCtx.section.identifier().getText(),
+                ctx,
+                procCtx.section.replacement(),
+                sectionUsages,
+                ctx.diagnostic());
+      }
+    }
     ofNullable(ctx.paragraphDefinition())
             .map(ParagraphDefinitionContext::word)
             .ifPresent(
@@ -232,6 +241,16 @@ class UseCasePreprocessorListener extends UseCasePreprocessorBaseListener {
                                     ctx,
                                     it.replacement(),
                                     paragraphDefinitions,
+                                    ctx.diagnostic()));
+    ofNullable(ctx.sectionDefinition())
+            .map(SectionDefinitionContext::word)
+            .ifPresent(
+                    it ->
+                            processToken(
+                                    it.identifier().getText(),
+                                    ctx,
+                                    it.replacement(),
+                                    sectionDefinitions,
                                     ctx.diagnostic()));
   }
 
@@ -244,7 +263,7 @@ class UseCasePreprocessorListener extends UseCasePreprocessorBaseListener {
   public void exitFunctionDefinition(FunctionDefinitionContext ctx) {
     String multiTokenText = peek().toString().replaceAll(Pattern.quote("{$$*"), "").replaceAll("}", "");
     String affectedTokens = multiTokenText.substring(0, multiTokenText.indexOf('|'));
-    String functionID = ctx.diagnostic().identifier().getText();
+    String functionID = ctx.diagnostic().identifiers().getText();
     addTokenLocation(
         functionDefinitions,
         functionID,
@@ -273,36 +292,6 @@ class UseCasePreprocessorListener extends UseCasePreprocessorBaseListener {
                                     ctx,
                                     it.replacement(),
                                     functionUsages,
-                                    ctx.diagnostic()));
-  }
-
-  @Override
-  public void enterSectionStatement(SectionStatementContext ctx) {
-    push();
-  }
-
-  @Override
-  public void exitSectionStatement(SectionStatementContext ctx) {
-    pop();
-    ofNullable(ctx.sectionUsage())
-            .map(SectionUsageContext::word)
-            .ifPresent(
-                    it ->
-                            processToken(
-                                    it.identifier().getText(),
-                                    ctx,
-                                    it.replacement(),
-                                    sectionUsages,
-                                    ctx.diagnostic()));
-    ofNullable(ctx.sectionDefinition())
-            .map(SectionDefinitionContext::word)
-            .ifPresent(
-                    it ->
-                            processToken(
-                                    it.identifier().getText(),
-                                    ctx,
-                                    it.replacement(),
-                                    sectionDefinitions,
                                     ctx.diagnostic()));
   }
 
@@ -522,14 +511,14 @@ class UseCasePreprocessorListener extends UseCasePreprocessorBaseListener {
       return replacementTexts;
   }
 
-  private void addTokenLocation(Map<String, List<Location>> storage, String text, Range range) {
+  private void addTokenLocation(Map<String, List<Location>> storage, String key, Range range) {
     Location location = new Location(documentUri, range);
-    if (storage.containsKey(text)) {
-      storage.get(text).add(location);
+    if (storage.containsKey(key)) {
+      storage.get(key).add(location);
     } else {
       List<Location> list = new ArrayList<>();
       list.add(location);
-      storage.put(text, list);
+      storage.put(key, list);
     }
   }
 
@@ -542,7 +531,7 @@ class UseCasePreprocessorListener extends UseCasePreprocessorBaseListener {
   private void registerDiagnostics(Range range, List<DiagnosticContext> diagnostic) {
     diagnostic.stream()
             .peek(addPositionShift())
-            .map(DiagnosticContext::identifier)
+            .map(DiagnosticContext::identifiers)
             .map(RuleContext::getText)
             .map(expectedDiagnostics::get)
             .forEach(registerDiagnostic(range));


### PR DESCRIPTION
This is a preparation for adding ability to specify exact procedure reference in test case. This ability is enabler to fix "go to definition" bug, where we can't distinguish paragraphs with the same names but in different sections.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
