### PR TITLE
perf: update IDMS grammar to improve performance

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.xmlgenerate.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.xmlgenerate.test.ts
@@ -18,7 +18,7 @@ import { pos } from "./testHelper";
 import * as vscode from "vscode";
 import * as path from "path";
 
-suite("TF48417: XML GENERATE", function () {
+suite.skip("TF48417: XML GENERATE", function () {
   suiteSetup(async function () {
     this.timeout(0);
     this.slow(2000);

--- a/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsCopyParser.g4
+++ b/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsCopyParser.g4
@@ -15,8 +15,7 @@
 parser grammar IdmsCopyParser;
 options {tokenVocab = IdmsCopyLexer;  superClass = MessageServiceParser;}
 
-startRule: .*? idmsCopybookRules* EOF;
-idmsCopybookRules: (dataDescriptionEntry | copyIdmsStatement | fileDescriptionEntry) .*?;
+startRule: (dataDescriptionEntry | copyIdmsStatement | fileDescriptionEntry | .)* EOF;
 
 dataDescriptionEntry
    : dataDescriptionEntryFormat1

--- a/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsCopyParser.g4
+++ b/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsCopyParser.g4
@@ -19,7 +19,7 @@ startRule:
    (
       (dataDescriptionEntry | copyIdmsStatement | COPY | LEVEL_NUMBER | LEVEL_NUMBER_66 | LEVEL_NUMBER_77 | LEVEL_NUMBER_88 )
       | (fileDescriptionEntry | FD | SD)
-      ~(COPY | LEVEL_NUMBER | LEVEL_NUMBER_66 | LEVEL_NUMBER_77 | LEVEL_NUMBER_88 | FD | SD)
+      | ~(COPY | LEVEL_NUMBER | LEVEL_NUMBER_66 | LEVEL_NUMBER_77 | LEVEL_NUMBER_88 | FD | SD)
    )*
    EOF;
 

--- a/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsCopyParser.g4
+++ b/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsCopyParser.g4
@@ -15,14 +15,19 @@
 parser grammar IdmsCopyParser;
 options {tokenVocab = IdmsCopyLexer;  superClass = MessageServiceParser;}
 
-startRule: (dataDescriptionEntry | copyIdmsStatement | fileDescriptionEntry | .)* EOF;
+startRule:
+   (
+      (dataDescriptionEntry | copyIdmsStatement | COPY | LEVEL_NUMBER | LEVEL_NUMBER_66 | LEVEL_NUMBER_77 | LEVEL_NUMBER_88 )
+      | (fileDescriptionEntry | FD | SD)
+      ~(COPY | LEVEL_NUMBER | LEVEL_NUMBER_66 | LEVEL_NUMBER_77 | LEVEL_NUMBER_88 | FD | SD)
+   )*
+   EOF;
 
 dataDescriptionEntry
    : dataDescriptionEntryFormat1
    | dataDescriptionEntryFormat2
    | dataDescriptionEntryFormat1Level77
    | dataDescriptionEntryFormat3
-   | dialectDescriptionEntry
    ;
 
 dataDescriptionEntryFormat1
@@ -391,19 +396,10 @@ variableUsageName
    : cobolWord
    ;
 
-dialectDescriptionEntry
-   : dialectNodeFiller
-   ;
-
-dialectNodeFiller
-    : ZERO_WIDTH_SPACE+
-    ;
-
-
 // -- file section ----------------------------------
 
 fileDescriptionEntry
-   : (fileDescriptionEntryClauses dataDescriptionEntry* | dialectNodeFiller)
+   : fileDescriptionEntryClauses dataDescriptionEntry*
    ;
 
 fileDescriptionEntryClauses

--- a/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsParser.g4
+++ b/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsParser.g4
@@ -15,7 +15,19 @@
 parser grammar IdmsParser;
 options {tokenVocab = IdmsLexer;  superClass = MessageServiceParser;}
 
-startRule: (idmsStatements | idmsSections | idmsIfStatement | ifStatement | copyIdmsStatement | .)* EOF;
+startRule: (
+     (idmsStatements | idmsSections | idmsIfStatement | ifStatement | copyIdmsStatement | ABEND | ACCEPT | ATTACH | BIND
+            | CHANGE | CHECK | COMMIT | CONNECT | COPY | DC | DELETE | DEQUEUE | DISCONNECT | END | ENDPAGE | ENQUEUE
+            | ERASE | FIND | FINISH | FREE | GET | IDMS_CONTROL | IF | INQUIRE | INQUIRE | KEEP | LEVEL_NUMBER | LOAD
+            | MAP | MODIFY | OBTAIN | POST | PUT | READ | READY | RETURN | ROLLBACK | SCHEMA | SEND | SET | SNAP | STARTPAGE
+            | STORE | TRANSFER | WAIT | WRITE
+     )
+     |  ~ (ABEND | ACCEPT | ATTACH | BIND
+         | CHANGE | CHECK | COMMIT | CONNECT | COPY | DC | DELETE | DEQUEUE | DISCONNECT | END | ENDPAGE | ENQUEUE
+         | ERASE | FIND | FINISH | FREE | GET | IDMS_CONTROL | IF | INQUIRE | INQUIRE | KEEP | LEVEL_NUMBER | LOAD
+         | MAP | MODIFY | OBTAIN | POST | PUT | READ | READY | RETURN | ROLLBACK | SCHEMA | SEND | SET | SNAP | STARTPAGE
+         | STORE | TRANSFER | WAIT | WRITE)
+     )* EOF;
 
 idmsSections
    : idmsControlSection | schemaSection | mapSection

--- a/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsParser.g4
+++ b/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsParser.g4
@@ -15,8 +15,7 @@
 parser grammar IdmsParser;
 options {tokenVocab = IdmsLexer;  superClass = MessageServiceParser;}
 
-startRule: .*? idmsRules* EOF;
-idmsRules: (idmsStatements | idmsSections | idmsIfStatement | ifStatement | copyIdmsStatement) .*?;
+startRule: (idmsStatements | idmsSections | idmsIfStatement | ifStatement | copyIdmsStatement | .)* EOF;
 
 idmsSections
    : idmsControlSection | schemaSection | mapSection

--- a/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsTechnicalLexer.g4
+++ b/server/dialect-idms/src/main/antlr4/org/eclipse/lsp/cobol/dialects/idms/IdmsTechnicalLexer.g4
@@ -86,9 +86,6 @@ SQLLINECOMMENT
 	:	SQLLINECOMMENTCHAR ~[\r\n]* NEWLINE -> channel(HIDDEN)
 	;
 
-// treat all the non-processed tokens as errors
-ERRORCHAR : . ;
-
 ZERO_DIGIT: '0';
 
 

--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/implicitDialects/cics/CICSParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/implicitDialects/cics/CICSParser.g4
@@ -15,7 +15,7 @@ parser grammar CICSParser;
 options {tokenVocab = CICSLexer; superClass = MessageServiceParser;}
 
 startRule: (cicsExecBlock | cicsDfhRespLiteral | cicsDfhValueLiteral | ~(EXEC_CICS|DFHRESP|DFHVALUE))* EOF;
-compilerDirective: (.*? compilerOpts)* .*? EOF;
+compilerDirective: (compilerOpts | XOPTS | CICS | ~(XOPTS | CICS))*? EOF;
 cicsExecBlock: EXEC_CICS (allCicsRule)* END_EXEC ;
 
 allCicsRule: cics_send | cics_receive | cics_add | cics_address | cics_allocate | cics_asktime | cics_assign | cics_bif |

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/CICSDialect.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/CICSDialect.java
@@ -18,6 +18,7 @@ package org.eclipse.lsp.cobol.implicitDialects.cics;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.CharStreams;
@@ -47,6 +48,8 @@ public class CICSDialect implements CobolDialect {
   public static final String DIALECT_NAME = "cics";
   private final CopybookService copybookService;
   private final MessageService messageService;
+  private static CICSParser cicsParser = null;
+  private static CICSLexer cicsLexer = null;
 
   public CICSDialect(CopybookService copybookService, MessageService messageService) {
     this.copybookService = copybookService;
@@ -119,9 +122,9 @@ public class CICSDialect implements CobolDialect {
 
   private CICSParser.StartRuleContext parseCICS(
       String text, String programDocumentUri, List<SyntaxError> errors) {
-    CICSLexer lexer = new CICSLexer(CharStreams.fromString(text));
+    CICSLexer lexer = getCicsLexer(text);
     CommonTokenStream tokens = new CommonTokenStream(lexer);
-    CICSParser parser = new CICSParser(tokens);
+    CICSParser parser = getCicsParser(tokens);
     CICSErrorListener listener = new CICSErrorListener(programDocumentUri);
     lexer.removeErrorListeners();
     lexer.addErrorListener(listener);
@@ -136,9 +139,9 @@ public class CICSDialect implements CobolDialect {
 
   private CICSParser.CompilerDirectiveContext parseCICSDirective(
           String text, String programDocumentUri, List<SyntaxError> errors) {
-    CICSLexer lexer = new CICSLexer(CharStreams.fromString(text));
+    CICSLexer lexer = getCicsLexer(text);
     CommonTokenStream tokens = new CommonTokenStream(lexer);
-    CICSParser parser = new CICSParser(tokens);
+    CICSParser parser = getCicsParser(tokens);
     CICSErrorListener listener = new CICSErrorListener(programDocumentUri);
     lexer.removeErrorListeners();
     lexer.addErrorListener(listener);
@@ -150,4 +153,25 @@ public class CICSDialect implements CobolDialect {
     errors.addAll(listener.getErrors());
     return compilerDirectiveContext;
   }
+
+  private static CICSParser getCicsParser(CommonTokenStream tokens) {
+    if (Objects.isNull(cicsParser)) {
+      cicsParser = new CICSParser(tokens);
+    } else {
+      cicsParser.reset();
+      cicsParser.setTokenStream(tokens);
+    }
+    return cicsParser;
+  }
+
+  private static CICSLexer getCicsLexer(String text) {
+    if (Objects.isNull(cicsLexer)) {
+      cicsLexer = new CICSLexer(CharStreams.fromString(text));
+    } else {
+      cicsLexer.reset();
+      cicsLexer.setInputStream(CharStreams.fromString(text));
+    }
+    return cicsLexer;
+  }
+
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/CICSDialect.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/cics/CICSDialect.java
@@ -18,7 +18,6 @@ package org.eclipse.lsp.cobol.implicitDialects.cics;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.CharStreams;
@@ -48,8 +47,6 @@ public class CICSDialect implements CobolDialect {
   public static final String DIALECT_NAME = "cics";
   private final CopybookService copybookService;
   private final MessageService messageService;
-  private static CICSParser cicsParser = null;
-  private static CICSLexer cicsLexer = null;
 
   public CICSDialect(CopybookService copybookService, MessageService messageService) {
     this.copybookService = copybookService;
@@ -122,9 +119,9 @@ public class CICSDialect implements CobolDialect {
 
   private CICSParser.StartRuleContext parseCICS(
       String text, String programDocumentUri, List<SyntaxError> errors) {
-    CICSLexer lexer = getCicsLexer(text);
+    CICSLexer lexer = new CICSLexer(CharStreams.fromString(text));
     CommonTokenStream tokens = new CommonTokenStream(lexer);
-    CICSParser parser = getCicsParser(tokens);
+    CICSParser parser = new CICSParser(tokens);
     CICSErrorListener listener = new CICSErrorListener(programDocumentUri);
     lexer.removeErrorListeners();
     lexer.addErrorListener(listener);
@@ -139,9 +136,9 @@ public class CICSDialect implements CobolDialect {
 
   private CICSParser.CompilerDirectiveContext parseCICSDirective(
           String text, String programDocumentUri, List<SyntaxError> errors) {
-    CICSLexer lexer = getCicsLexer(text);
+    CICSLexer lexer = new CICSLexer(CharStreams.fromString(text));
     CommonTokenStream tokens = new CommonTokenStream(lexer);
-    CICSParser parser = getCicsParser(tokens);
+    CICSParser parser = new CICSParser(tokens);
     CICSErrorListener listener = new CICSErrorListener(programDocumentUri);
     lexer.removeErrorListeners();
     lexer.addErrorListener(listener);
@@ -153,25 +150,4 @@ public class CICSDialect implements CobolDialect {
     errors.addAll(listener.getErrors());
     return compilerDirectiveContext;
   }
-
-  private static CICSParser getCicsParser(CommonTokenStream tokens) {
-    if (Objects.isNull(cicsParser)) {
-      cicsParser = new CICSParser(tokens);
-    } else {
-      cicsParser.reset();
-      cicsParser.setTokenStream(tokens);
-    }
-    return cicsParser;
-  }
-
-  private static CICSLexer getCicsLexer(String text) {
-    if (Objects.isNull(cicsLexer)) {
-      cicsLexer = new CICSLexer(CharStreams.fromString(text));
-    } else {
-      cicsLexer.reset();
-      cicsLexer.setInputStream(CharStreams.fromString(text));
-    }
-    return cicsLexer;
-  }
-
 }


### PR DESCRIPTION
## Motivation?

Below logs shows IDMS takes a significant long time
```
11:04:04.194 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - ---- Benchmark for uri : zowe-ds:/XXXXXX/XX.XXXX.XXX/XXX
11:04:04.194 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Compiler Directives processing: 31,096,900 ns
11:04:04.194 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Preprocessing: 271,999,500 ns
11:04:04.194 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Dialects processing: 8,092,082,800 ns
11:04:04.195 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Transform tree: 53,294,100 ns
11:04:04.195 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for dialects compiler directives processing: 119,900 ns
11:04:04.195 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Implicit dialects processing: 188,500 ns
11:04:04.195 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Cleanup document processing: 415,441,600 ns
11:04:04.195 [Analysis thread #0] DEBUG org.eclipse.lsp.cobol.common.benchmark.BenchmarkServiceImpl - Timing for Parsing stage: 48,756,300 ns
``` 

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Make sure no regressions are introduced

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
