### PR TITLE
chore: upgrade junit from 5.11.0-M2 to 5.11.2

### DIFF
--- a/server/common/pom.xml
+++ b/server/common/pom.xml
@@ -32,7 +32,7 @@
         <logback.classic.version>1.3.14</logback.classic.version>
         <lsp4j.version>0.14.0</lsp4j.version>
         <commons.lang.version>3.12.0</commons.lang.version>
-        <junit-jupiter.version>5.11.0-M2</junit-jupiter.version>
+        <junit-jupiter.version>5.11.2</junit-jupiter.version>
         <mockito.core.version>5.14.2</mockito.core.version>
         <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
         <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>

--- a/server/dialect-daco/pom.xml
+++ b/server/dialect-daco/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
-        <junit-jupiter.version>5.11.0-M2</junit-jupiter.version>
+        <junit-jupiter.version>5.11.2</junit-jupiter.version>
         <junit.platform.version>1.6.0</junit.platform.version>
         <mockito.core.version>5.14.2</mockito.core.version>
         <maven.cobertura.plugin.version>2.7</maven.cobertura.plugin.version>

--- a/server/dialect-idms/pom.xml
+++ b/server/dialect-idms/pom.xml
@@ -35,7 +35,7 @@
         <lombok.version>1.18.36</lombok.version>
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
-        <junit-jupiter.version>5.11.0-M2</junit-jupiter.version>
+        <junit-jupiter.version>5.11.2</junit-jupiter.version>
         <junit.platform.version>1.6.0</junit.platform.version>
         <mockito.core.version>5.14.2</mockito.core.version>
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>

--- a/server/engine/pom.xml
+++ b/server/engine/pom.xml
@@ -40,7 +40,7 @@
         <exclude.tests>nothing.to.exclude</exclude.tests>
         <google.guava.version>33.2.1-jre</google.guava.version>
         <guice.version>4.2.2</guice.version>
-        <junit-jupiter.version>5.11.0-M2</junit-jupiter.version>
+        <junit-jupiter.version>5.11.2</junit-jupiter.version>
         <logback.classic.version>1.3.14</logback.classic.version>
         <lombok.version>1.18.36</lombok.version>
         <lsp4j.version>0.14.0</lsp4j.version>

--- a/server/test/pom.xml
+++ b/server/test/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
-        <junit-jupiter.version>5.11.0-M2</junit-jupiter.version>
+        <junit-jupiter.version>5.11.2</junit-jupiter.version>
         <mockito.core.version>5.14.2</mockito.core.version>
         <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
         <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>


### PR DESCRIPTION
A regression was introduced in 5.11.0-M2 as part of PR https://github.com/junit-team/junit5/commit/bc87b0762717f35c49169bc97d61b338cb382c21

This resulted in failures to create usecase test files when run with "usecase.test.repo.dir" flag (https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol/pull/2486).
