### PR TITLE
Fix fall-thru diagnostics

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/services/ControlFlowService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ControlFlowService.ts
@@ -157,6 +157,8 @@ export class ControlFlowAnalysisService implements AnalysisServiceDelegate {
     this.logChannel?.debug(`Invalidate document: ${documentUri}`);
 
     this.invalidatePromise(documentUri, rejectPromise);
+    this.diagnosticService.clearDiagnostics(documentUri);
+
     await this.removeTask(documentUri);
   }
 
@@ -320,10 +322,14 @@ class DiagnosticService {
     documentUri: string,
     diagnostics: Map<string, vscode.Diagnostic[]>,
   ) {
-    this.diagnosticCollection.delete(vscode.Uri.parse(documentUri));
+    this.clearDiagnostics(documentUri);
     diagnostics.forEach((v, k) =>
       this.diagnosticCollection.set(vscode.Uri.parse(k), v),
     );
+  }
+
+  public clearDiagnostics(documentUri: string) {
+    this.diagnosticCollection.delete(vscode.Uri.parse(documentUri));
   }
 }
 

--- a/clients/cobol-lsp-vscode-extension/src/services/ControlFlowService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ControlFlowService.ts
@@ -157,8 +157,9 @@ export class ControlFlowAnalysisService implements AnalysisServiceDelegate {
     this.logChannel?.debug(`Invalidate document: ${documentUri}`);
 
     this.invalidatePromise(documentUri, rejectPromise);
-    this.diagnosticService.clearDiagnostics(documentUri);
-
+    if (rejectPromise) {
+      this.diagnosticService.clearDiagnostics(documentUri);
+    }
     await this.removeTask(documentUri);
   }
 


### PR DESCRIPTION
Fall-thru diagnostics should disappear on close COBOL document
 
## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
