### PR TITLE
Fix: "Insert COBOL Snippets" now returns correct entry when there are duplicate prefixes

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/services/snippetcompletion/SnippetCompletionProvider.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/snippetcompletion/SnippetCompletionProvider.ts
@@ -227,7 +227,8 @@ export async function pickSnippet() {
     // Create the snippets list using settings for dialect
     snippets.forEach((snippet, key) => {
       // Also store the key as we are aligning the view with VSCode snippet
-      prefixToKeyMap.set(snippet.prefix, key);
+      const tempKey = snippet.prefix + (snippet.description ?? key);
+      prefixToKeyMap.set(tempKey, key);
       snippetList.push({
         detail: snippet.description ?? key,
         label: snippet.prefix,
@@ -236,7 +237,7 @@ export async function pickSnippet() {
     });
     input.onDidChangeSelection((items) => {
       const item = items[0];
-      const snippetKey = prefixToKeyMap.get(item.label);
+      const snippetKey = prefixToKeyMap.get(item.label + item.detail);
       if (snippetKey) {
         const snippet = snippets.get(snippetKey);
         if (snippet) {

--- a/clients/cobol-lsp-vscode-extension/src/services/snippetcompletion/SnippetCompletionProvider.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/snippetcompletion/SnippetCompletionProvider.ts
@@ -217,35 +217,30 @@ function formatString(arg: string) {
 export async function pickSnippet() {
   try {
     const editor = vscode.window.activeTextEditor;
-    const snippetList: vscode.QuickPickItem[] = [];
-    const prefixToKeyMap = new Map<string, string>();
+    type ItemType = { snippet: Snippet } & vscode.QuickPickItem;
+    const snippetList: ItemType[] = [];
     const snippets = await loadSnippets();
-    const input = vscode.window.createQuickPick<vscode.QuickPickItem>();
+    const input = vscode.window.createQuickPick<ItemType>();
     input.matchOnDetail = true;
     input.matchOnDescription = true;
     input.placeholder = "Type to search snippet";
     // Create the snippets list using settings for dialect
     snippets.forEach((snippet, key) => {
       // Also store the key as we are aligning the view with VSCode snippet
-      const tempKey = snippet.prefix + (snippet.description ?? key);
-      prefixToKeyMap.set(tempKey, key);
       snippetList.push({
         detail: snippet.description ?? key,
         label: snippet.prefix,
+        snippet,
       });
-      input.items = snippetList;
     });
+    input.items = snippetList;
     input.onDidChangeSelection((items) => {
       const item = items[0];
-      const snippetKey = prefixToKeyMap.get(item.label + item.detail);
-      if (snippetKey) {
-        const snippet = snippets.get(snippetKey);
-        if (snippet) {
-          const snippetString = new vscode.SnippetString(
-            snippet.body.join("\n"),
-          );
-          editor?.insertSnippet(snippetString);
-        }
+      if (item) {
+        const snippetString = new vscode.SnippetString(
+          item.snippet.body.join("\n"),
+        );
+        editor?.insertSnippet(snippetString);
       }
     });
     input.show();


### PR DESCRIPTION
Add the description/detail to the prefix that is stored in the map. This allows multiple snippets with the same prefix to be available within the "Insert COBOL Snippet" command.

Previously it would show all, but only give the last one's values when any of that prefix were selected.

## How Has This Been Tested?

Tested with the extension running locally and ran all existing tests.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
