### PR TITLE
fix: fix END IF coloring for HP COBOL

### DIFF
--- a/clients/cobol-lsp-vscode-extension/syntaxes/HP.COBOL.tmLanguage.json
+++ b/clients/cobol-lsp-vscode-extension/syntaxes/HP.COBOL.tmLanguage.json
@@ -82,7 +82,7 @@
       ]
     },
     "cobol-condition-keyword": {
-      "match": "(?<![\\-\\w])(?i:IF|ELSE|END-IF|ENDIF|EVALUATE|NOT|WHEN\\s+OTHER|WHEN|END-EVALUATE|CONTINUE)(?![\\-\\w])",
+      "match": "(?<![\\-\\w])(?i:IF|ELSE|END-IF|END\\s+IF|ENDIF|EVALUATE|NOT|WHEN\\s+OTHER|WHEN|END-EVALUATE|CONTINUE)(?![\\-\\w])",
       "name": "keyword.control.condition.cobol"
     },
     "cobol-branch-keyword": {


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] In HP cobol `END IF` should be considered as conditional keyword (colouring)

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
