### PR TITLE
fix: fix wrong identification of floating comment

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/rewriter/LineIndicatorProcessor.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/rewriter/LineIndicatorProcessor.java
@@ -39,7 +39,7 @@ public abstract class LineIndicatorProcessor implements CobolLineReWriter {
   private static final String DOUBLE_QUOTE_LITERAL = "\"([^\"]|\"\"|'')*+\"";
   private static final String SINGLE_QUOTE_LITERAL = "'([^']|''|\"\")*+'";
   public static final Pattern FLOATING_COMMENT_LINE =
-      Pattern.compile("(?<validText>.*?)(?<floatingComment>\\*>.*)?");
+      Pattern.compile("^(?<validText>('[^']*?'|\"[^\"]*\"|[^\"'])*)(?<floatingComment>\\*>.*?)$");
 
   protected abstract CobolProgramLayout getLayout();
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/dialects/ibm/TestCommentLines.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/dialects/ibm/TestCommentLines.java
@@ -15,23 +15,46 @@
 
 package org.eclipse.lsp.cobol.dialects.ibm;
 
+import static org.eclipse.lsp.cobol.test.engine.UseCaseUtils.analyze;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.eclipse.lsp.cobol.common.AnalysisResult;
 import org.eclipse.lsp.cobol.common.CleanerPreprocessor;
+import org.eclipse.lsp.cobol.common.copybook.SQLBackend;
+import org.eclipse.lsp.cobol.common.dialects.CobolLanguageId;
+import org.eclipse.lsp.cobol.common.error.ErrorSource;
 import org.eclipse.lsp.cobol.common.error.SyntaxError;
 import org.eclipse.lsp.cobol.common.message.MessageService;
 import org.eclipse.lsp.cobol.service.settings.layout.CodeLayoutStore;
+import org.eclipse.lsp.cobol.test.engine.UseCase;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 
 /** This test checks multiple comment entries are parsed and cleaned up correctly */
 class TestCommentLines {
   public static final String DOCUMENT_URI = "file:///c:/workspace/document.cbl";
+  public static final String FLOATING_COMMENT_TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. test2.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       DATA DIVISION.\n"
+          + "        WORKING-STORAGE SECTION.\n"
+          + "       PROCEDURE DIVISION.     \n"
+          + "           DISPLAY 'scn 1 *>'*> is this valid comment but with warning\n"
+          + "           DISPLAY 'scn 1 *>' *> is this valid comment without warning\n"
+          + "           DISPLAY 'scn 2 *>'*> is this valid comment but with warning\n"
+          + "           DISPLAY 'scn 2 *>' *> is this valid comment without warning\n"
+          + "           STOP RUN.";
   private static final String TEXT =
       "      * Copyright (c) 2021 Broadcom.\n"
           + "      * The term Broadcom  refers to Broadcom Inc. and/or its subsidiaries.\n"
@@ -41,7 +64,6 @@ class TestCommentLines {
           + "000022*> Floating comment                                               qweasdzx\n"
           + "000025 *> 25 Floating comment  w/o space      qweasdzx\n"
           + "000030 PROGRAM-ID. comments.    *> Floating comment\n";
-
   private static final String EXPECTED =
       "       \n"
           + "       \n"
@@ -67,5 +89,36 @@ class TestCommentLines {
             .toString();
     assertEquals(EXPECTED, actual);
     assertTrue(accumulatedErrors.isEmpty());
+  }
+
+  @Test
+  void testFloatingComment() {
+    AnalysisResult actual =
+        analyze(
+            UseCase.builder()
+                .documentUri(DOCUMENT_URI)
+                .text(FLOATING_COMMENT_TEXT)
+                .cicsTranslator(true)
+                .dialects(Collections.emptyList())
+                .sqlBackend(SQLBackend.DB2_SERVER)
+                .build(),
+            CobolLanguageId.COBOL);
+    List<Diagnostic> diagnostics = actual.getDiagnostics().get(DOCUMENT_URI);
+    assertEquals(diagnostics.size(), 2);
+    Diagnostic expectedFirstDiagnostics =
+        new Diagnostic(
+            new Range(new Position(6, 28), new Position(6, 29)),
+            "Missing blank before inline comment",
+            DiagnosticSeverity.Warning,
+            ErrorSource.PREPROCESSING.getText());
+    Diagnostic expectedLastDiagnostics =
+        new Diagnostic(
+            new Range(new Position(8, 28), new Position(8, 29)),
+            "Missing blank before inline comment",
+            DiagnosticSeverity.Warning,
+            ErrorSource.PREPROCESSING.getText());
+
+    assertEquals(expectedFirstDiagnostics, diagnostics.get(0));
+    assertEquals(expectedLastDiagnostics, diagnostics.get(1));
   }
 }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Below code should not shown any error
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. test2.
       ENVIRONMENT DIVISION.
       DATA DIVISION.
        WORKING-STORAGE SECTION.
       PROCEDURE DIVISION.     
           DISPLAY 'scn 1 *>'*> is this valid comment
           DISPLAY 'scn 2 *>'*> is this valid comment
           STOP RUN.
``` 

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
