### PR TITLE
fix: do not show self content of a copybook on hover at location insi…

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/hover/CopybookHoverProvider.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/delegates/hover/CopybookHoverProvider.java
@@ -45,6 +45,7 @@ public class CopybookHoverProvider implements HoverProvider {
         return getHover(containedCopybookNode.get(0).getContent());
       }
     }
+
     return Optional.ofNullable(document)
         .map(CobolDocumentModel::getAnalysisResult)
         .map(AnalysisResult::getRootNode)
@@ -52,6 +53,7 @@ public class CopybookHoverProvider implements HoverProvider {
         .filter(CopyNode.class::isInstance)
         .map(CopyNode.class::cast)
         .filter(node -> node.getUri() != null)
+        .filter(n -> !n.getUri().equals(uri))
         .map(documentGraph::getCopyNodeContent)
         .map(this::getHover)
         .orElse(null);


### PR DESCRIPTION
…de a copybook

## How Has This Been Tested?

do not show self content of a copybook on hover at location inside a copybook

- [x] Test hover on below program
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. Untitled-1.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       1 data1.
         COPY copyfile.

       1 dat2.
         COPY copyfile.
``` 
copyfile.cpy (here hover over commented code, there shouldn't be any hover info)
```cobol
      **************************************************************************
       COPY cpyFile1 SUPPRESS.
      *  3 fileObject PIC X(143).
``` 
cpyFile1.cpy
```cobol
         3 fileObject PIC X(143).
``` 

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
