### PR TITLE
fix: return processor groups if `pgm_conf.json` file is missing or incorrect

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroupsLoader.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroupsLoader.spec.ts
@@ -111,14 +111,23 @@ describe("ProcessorGroupsLoader", () => {
       beforeEach(() => {
         getWorkspaceFolderResult.uri = WORKSPACE_URI;
         readFileResult[`${WORKSPACE_PATH}/.cobolplugin/proc_grps.json`] =
-          `{"pgroups": []}`;
+          `{"pgroups": [{ "name": "b4g group" }]}`;
         readFileResult[`${WORKSPACE_PATH}/.cobolplugin/pgm_conf.json`] =
           new FileNotFound();
       });
 
-      it("returns undefined", async () => {
+      it("returns just process groups definitions and empty programs", async () => {
         const result = await readWorkspaceConfig(WORKSPACE_URI);
-        expect(result).toBeUndefined();
+        expect(result).toEqual({
+          processorGroups: {
+            "b4g group": {
+              libs: [],
+              name: "b4g group",
+              preprocessors: [],
+            },
+          },
+          programs: [],
+        });
       });
     });
 
@@ -126,13 +135,22 @@ describe("ProcessorGroupsLoader", () => {
       beforeEach(() => {
         getWorkspaceFolderResult.uri = WORKSPACE_URI;
         readFileResult[`${WORKSPACE_PATH}/.cobolplugin/proc_grps.json`] =
-          `{"pgroups": []}`;
+          `{"pgroups": [{ "name": "b4g group" }]}`;
         readFileResult[`${WORKSPACE_PATH}/.cobolplugin/pgm_conf.json`] = "{}";
       });
 
-      it("returns undefined & error is logged", async () => {
+      it("returns just processor groups definitions and empty programs", async () => {
         const result = await readWorkspaceConfig(WORKSPACE_URI);
-        expect(result).toBeUndefined();
+        expect(result).toEqual({
+          processorGroups: {
+            "b4g group": {
+              libs: [],
+              name: "b4g group",
+              preprocessors: [],
+            },
+          },
+          programs: [],
+        });
         expect(outputChannel.error).toHaveBeenCalledWith(
           expect.stringContaining("Could not validate data"),
         );

--- a/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroupsLoader.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroupsLoader.ts
@@ -220,7 +220,7 @@ const readWorkspaceConfigCached = new Memoize(
     });
 
     const programs = await readProgramConfig(workspaceUri);
-    if (!programs) return;
+    if (!programs) return workspaceConfig;
 
     programs.pgms.forEach((program) => {
       let processorGroup = processorGroups.find(


### PR DESCRIPTION
When reading processor groups configuration we need to return the `proc_grps.json` configuration even if the `pgm_conf.json` file is missing or is invalid, because it might be substituted by the B4G `.bridge.json` configuration.

## How Has This Been Tested?

Manual test and updated unit tests.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
