### PR TITLE
fix: Avoid document model data race

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
@@ -121,15 +121,15 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
       Integer currentRevision,
       boolean open,
       SourceUnitGraph.EventSource eventSource) {
-    documentModelService.changeDocument(uri, text);
-    return scheduleAnalysis(uri, text, currentRevision, open, false, eventSource);
+    CobolDocumentModel model = documentModelService.changeDocument(uri, text);
+    if (model != null) return scheduleAnalysis(model, currentRevision, open, false, eventSource);
+    else return new FutureTask<>(() -> model);
   }
 
   /**
    * Schedule an analysis
    *
-   * @param uri source URI
-   * @param text content
+   * @param documentModel document model
    * @param currentRevision the document currentRevision
    * @param open Is document just opened, or it's reanalyse request
    * @param force forcefully schedule the analysis
@@ -137,27 +137,26 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
    * @return document model with analysis result
    */
   public synchronized FutureTask<CobolDocumentModel> scheduleAnalysis(
-      String uri,
-      String text,
+      CobolDocumentModel documentModel,
       Integer currentRevision,
       boolean open,
       boolean force,
       SourceUnitGraph.EventSource eventSource) {
-    notifyAllListeners(AnalysisState.SCHEDULED, documentModelService.get(uri), eventSource);
+    final String uri = documentModel.getUri();
+    notifyAllListeners(AnalysisState.SCHEDULED, documentModel, eventSource);
     String id = makeId(uri, currentRevision);
     Integer prevId = analysisResultsRevisions.put(uri, currentRevision);
     if (currentRevision.equals(prevId) && !force) {
-      notifyAllListeners(AnalysisState.SKIPPED, documentModelService.get(uri), eventSource);
+      notifyAllListeners(AnalysisState.SKIPPED, documentModel, eventSource);
       return analysisResults.get(id);
     }
     ExecutorService analysisExecutor = getExecutor(uri);
-    CobolDocumentModel documentModel = documentModelService.get(uri);
     if (documentModel.getLastAnalysisResult() != null) {
       cancelRunningAnalysis(ImmutableList.of(documentModel));
     }
     FutureTask<CobolDocumentModel> futureTask =
         new FutureTask<>(
-            scheduleAnalysis(uri, text, currentRevision, open, force, eventSource, id));
+            scheduleAnalysis(documentModel, currentRevision, open, force, eventSource, id));
     analysisResults.put(id, futureTask);
     analysisExecutor.submit(futureTask);
     if (prevId != null && !force) {
@@ -168,13 +167,15 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
   }
 
   private Callable<CobolDocumentModel> scheduleAnalysis(
-      String uri,
-      String text,
+      CobolDocumentModel documentModel,
       Integer currentRevision,
       boolean open,
       boolean force,
       SourceUnitGraph.EventSource eventSource,
       String id) {
+    final String uri = documentModel.getUri();
+    final String text = documentModel.getText();
+    final String langId = documentModel.getLanguageId();
     return () -> {
       if (currentRevision < analysisResultsRevisions.get(uri) && !force) {
         notifyAllListeners(AnalysisState.SKIPPED, documentModelService.get(uri), eventSource);
@@ -191,7 +192,7 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
         notifyAllListeners(AnalysisState.STARTED, documentModelService.get(uri), eventSource);
         communications.notifyProgressBegin(uri);
         documentModelService.get(uri).setOutlineResult(null);
-        analysisService.analyzeDocument(uri, text, open);
+        analysisService.analyzeDocument(uri, text, open, langId);
         notifyAllListeners(AnalysisState.COMPLETED, documentModelService.get(uri), eventSource);
         analysisResults.remove(id);
         return documentModelService.get(uri);
@@ -272,13 +273,9 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
     LOG.info("subroutine cache cleared!");
 
     CobolDocumentModel document = documentModelService.get(cobolDocUri);
-    scheduleAnalysis(
-        cobolDocUri,
-        document.getText(),
-        analysisResultsRevisions.get(document.getUri()),
-        false,
-        true,
-        eventSource);
+    if (document != null)
+      scheduleAnalysis(
+          document, analysisResultsRevisions.get(document.getUri()), false, true, eventSource);
   }
 
   /**
@@ -298,8 +295,7 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
     openDocuments.forEach(
         doc ->
             scheduleAnalysis(
-                doc.getUri(),
-                doc.getText(),
+                doc,
                 analysisResultsRevisions.getOrDefault(doc.getUri(), 0),
                 false,
                 true,
@@ -330,14 +326,14 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
     documentModelService.removeDocumentDiagnostics(copybookUri);
     Optional.ofNullable(documentModelService.get(copybookUri))
         .ifPresent(model -> model.update(copybookContent));
-    List<String> openedUris =
+    List<CobolDocumentModel> openedModels =
         documentModelService.getAllOpened().stream()
             .filter(model -> uris.contains(model.getUri()))
             .filter(model -> !analysisService.isCopybook(model.getUri(), model.getText()))
-            .map(CobolDocumentModel::getUri)
             .collect(Collectors.toList());
-    for (String uri : openedUris) {
-      String languageId = documentModelService.get(uri).getLanguageId();
+    for (CobolDocumentModel documentModel : openedModels) {
+      final String uri = documentModel.getUri();
+      final String languageId = documentModel.getLanguageId();
       copybookService.getCopybookUsage(uri).stream()
           .filter(model -> Objects.nonNull(model.getUri()))
           .filter(model -> model.getUri().equals(copybookUri))
@@ -354,14 +350,8 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
 
       subroutineService.invalidateCache();
       LOG.info("Cache invalidated");
-      CobolDocumentModel document = documentModelService.get(uri);
       scheduleAnalysis(
-          uri,
-          document.getText(),
-          analysisResultsRevisions.get(document.getUri()),
-          false,
-          true,
-          eventSource);
+          documentModel, analysisResultsRevisions.getOrDefault(uri, 0), false, true, eventSource);
     }
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
@@ -16,19 +16,25 @@ package org.eclipse.lsp.cobol.lsp.analysis;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.cfg.CFASTBuilder;
 import org.eclipse.lsp.cobol.common.AnalysisResult;
 import org.eclipse.lsp.cobol.common.SubroutineService;
 import org.eclipse.lsp.cobol.common.copybook.CopybookService;
 import org.eclipse.lsp.cobol.common.dialects.CobolLanguageId;
 import org.eclipse.lsp.cobol.common.dialects.TrueDialectService;
+import org.eclipse.lsp.cobol.core.model.extendedapi.ExtendedApiResult;
+import org.eclipse.lsp.cobol.core.model.extendedapi.Program;
 import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.SourceUnitGraph;
+import org.eclipse.lsp.cobol.lsp.jrpc.CobolLanguageClient;
 import org.eclipse.lsp.cobol.service.AnalysisService;
 import org.eclipse.lsp.cobol.service.CobolDocumentModel;
 import org.eclipse.lsp.cobol.service.DocumentModelService;
@@ -48,6 +54,9 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
   private final SubroutineService subroutineService;
   private final Communications communications;
   private final SourceUnitGraph sourceUnitGraph;
+
+  private final CFASTBuilder cfastBuilder;
+  private final Provider<CobolLanguageClient> clientProvider;
 
   private final Map<String, FutureTask<CobolDocumentModel>> analysisResults =
       Collections.synchronizedMap(new HashMap<>());
@@ -75,7 +84,9 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
       AnalysisService analysisService,
       CopybookService copybookService,
       SubroutineService subroutineService,
-      Communications communications) {
+      Communications communications,
+      @Nullable CFASTBuilder cfastBuilder,
+      Provider<CobolLanguageClient> clientProvider) {
     this.dialectService = dialectService;
     this.documentModelService = documentModelService;
     this.analysisService = analysisService;
@@ -85,6 +96,8 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
     analysisStateListeners = new ArrayList<>();
     this.sourceUnitGraph = sourceUnitGraph;
     this.analysisStateListeners.add(sourceUnitGraph);
+    this.cfastBuilder = cfastBuilder;
+    this.clientProvider = clientProvider;
   }
 
   /**
@@ -118,6 +131,7 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
     FutureTask<CobolDocumentModel> futureTask =
         new FutureTask<>(
             scheduleAnalysis(documentModel, currentRevision, open, force, eventSource, id));
+
     analysisResults.put(id, futureTask);
     analysisExecutor.submit(futureTask);
     if (prevId != null && !force) {
@@ -125,6 +139,18 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
           .ifPresent(cf -> cf.cancel(true));
     }
     return futureTask;
+  }
+
+  private void postCFASTResults(String uri, AnalysisResult result) {
+    if (cfastBuilder == null) return;
+
+    List<Program> astList =
+        result.getRootNode().findPrograms().stream()
+            .map(cfastBuilder::build)
+            .flatMap(m -> m.getControlFlowAST().stream())
+            .collect(Collectors.toList());
+
+    this.clientProvider.get().cfastReady(new ExtendedApiResult(astList, uri));
   }
 
   private Callable<CobolDocumentModel> scheduleAnalysis(
@@ -153,10 +179,18 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
         notifyAllListeners(AnalysisState.STARTED, documentModel, eventSource);
         communications.notifyProgressBegin(uri);
         documentModel.setOutlineResult(null);
-        analysisService.analyzeDocument(uri, text, open, langId);
-        notifyAllListeners(AnalysisState.COMPLETED, documentModel, eventSource);
+
+        AnalysisResult result = analysisService.analyzeDocument(uri, text, open, langId);
+        CobolDocumentModel newDocumentModel = documentModel;
+
+        if (result != null) {
+          newDocumentModel = documentModelService.processAnalysisResult(uri, result, text);
+          postCFASTResults(uri, result);
+        }
+
+        notifyAllListeners(AnalysisState.COMPLETED, newDocumentModel, eventSource);
         analysisResults.remove(id);
-        return documentModel;
+        return newDocumentModel;
       } catch (
           Exception
               genericException) { // Ideally we should not do this, but a safer catch might help to
@@ -166,8 +200,10 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
             genericException,
             uri,
             genericException);
-        notifyAllListeners(AnalysisState.EXCEPTIONALLY_FINISHED, documentModel, eventSource);
-        return documentModel;
+        CobolDocumentModel newDocumentModel =
+            documentModelService.processAnalysisResult(uri, AnalysisResult.EMPTY, text);
+        notifyAllListeners(AnalysisState.EXCEPTIONALLY_FINISHED, newDocumentModel, eventSource);
+        return newDocumentModel;
       } finally {
         if (Objects.equals(analysisResultsRevisions.get(uri), currentRevision) || force) {
           communications.publishDiagnostics(documentModelService.getOpenedDiagnostic());

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
@@ -88,45 +88,6 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
   }
 
   /**
-   * Schedule an analysis last known revision of the file will be assumed or 0 if none
-   *
-   * @param uri source URI
-   * @param text content
-   * @param open Is document just opened, or it's reanalyse request
-   * @return document model with analysis result
-   */
-  public synchronized FutureTask<CobolDocumentModel> scheduleAnalysis(
-      String uri, String text, boolean open) {
-    return scheduleAnalysis(
-        uri,
-        text,
-        analysisResultsRevisions.getOrDefault(uri, 0),
-        open,
-        SourceUnitGraph.EventSource.IDE);
-  }
-
-  /**
-   * Schedule an analysis last known revision of the file will be assumed or 0 if none
-   *
-   * @param uri source URI
-   * @param text content
-   * @param currentRevision the document currentRevision
-   * @param open Is document just opened, or it's reanalyse request
-   * @param eventSource source of the event
-   * @return document model with analysis result
-   */
-  public synchronized FutureTask<CobolDocumentModel> scheduleAnalysis(
-      String uri,
-      String text,
-      Integer currentRevision,
-      boolean open,
-      SourceUnitGraph.EventSource eventSource) {
-    CobolDocumentModel model = documentModelService.changeDocument(uri, text);
-    if (model != null) return scheduleAnalysis(model, currentRevision, open, false, eventSource);
-    else return new FutureTask<>(() -> model);
-  }
-
-  /**
    * Schedule an analysis
    *
    * @param documentModel document model
@@ -178,7 +139,7 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
     final String langId = documentModel.getLanguageId();
     return () -> {
       if (currentRevision < analysisResultsRevisions.get(uri) && !force) {
-        notifyAllListeners(AnalysisState.SKIPPED, documentModelService.get(uri), eventSource);
+        notifyAllListeners(AnalysisState.SKIPPED, documentModel, eventSource);
         LOG.debug(
             "[scheduleAnalysis] skip revision: "
                 + currentRevision
@@ -189,13 +150,13 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
       LOG.debug("[scheduleAnalysis] waiting for previous analysis of {} to finish", uri);
       try {
         LOG.debug("[scheduleAnalysis] Start analysis: " + uri);
-        notifyAllListeners(AnalysisState.STARTED, documentModelService.get(uri), eventSource);
+        notifyAllListeners(AnalysisState.STARTED, documentModel, eventSource);
         communications.notifyProgressBegin(uri);
-        documentModelService.get(uri).setOutlineResult(null);
+        documentModel.setOutlineResult(null);
         analysisService.analyzeDocument(uri, text, open, langId);
-        notifyAllListeners(AnalysisState.COMPLETED, documentModelService.get(uri), eventSource);
+        notifyAllListeners(AnalysisState.COMPLETED, documentModel, eventSource);
         analysisResults.remove(id);
-        return documentModelService.get(uri);
+        return documentModel;
       } catch (
           Exception
               genericException) { // Ideally we should not do this, but a safer catch might help to
@@ -205,9 +166,8 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
             genericException,
             uri,
             genericException);
-        notifyAllListeners(
-            AnalysisState.EXCEPTIONALLY_FINISHED, documentModelService.get(uri), eventSource);
-        return documentModelService.get(uri);
+        notifyAllListeners(AnalysisState.EXCEPTIONALLY_FINISHED, documentModel, eventSource);
+        return documentModel;
       } finally {
         if (Objects.equals(analysisResultsRevisions.get(uri), currentRevision) || force) {
           communications.publishDiagnostics(documentModelService.getOpenedDiagnostic());
@@ -419,9 +379,10 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
    * @param uri of document
    * @param text content od document.
    * @param languageId
+   * @return document model
    */
-  public void openDocument(String uri, String text, String languageId) {
-    documentModelService.openDocument(uri, text, languageId);
+  public CobolDocumentModel openDocument(String uri, String text, String languageId) {
+    return documentModelService.openDocument(uri, text, languageId);
   }
 
   @Override

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/extended/AnalysisHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/extended/AnalysisHandler.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.cfg.CFASTBuilder;
+import org.eclipse.lsp.cobol.common.AnalysisResult;
 import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp.cobol.common.model.tree.ProgramNode;
 import org.eclipse.lsp.cobol.common.model.tree.RootNode;
@@ -78,12 +79,21 @@ public class AnalysisHandler {
       throws ExecutionException, InterruptedException {
     String uri = analysisResultEvent.getUri();
     CobolDocumentModel doc = documentModelService.get(uri);
+    if (doc == null) {
+      communications.notifyGeneralMessage(MessageType.Info, "Unable to retrieve document model");
+      return new ExtendedApiResult(ImmutableList.of(), "");
+    }
     if (analysisService.isCopybook(uri, analysisResultEvent.getText())) {
       communications.notifyGeneralMessage(
           MessageType.Info, "Cannot retrieve outline tree because file was treated as a copybook");
       return new ExtendedApiResult(ImmutableList.of(), "");
     }
-    RootNode rootNode = doc.getLastAnalysisResult().getRootNode();
+    final AnalysisResult results = doc.getLastAnalysisResult();
+    if (results == null) {
+      communications.notifyGeneralMessage(MessageType.Info, "Analysis result is not available");
+      return new ExtendedApiResult(ImmutableList.of(), "");
+    }
+    RootNode rootNode = results.getRootNode();
     int line = analysisResultEvent.getLine();
     int character = analysisResultEvent.getCharacter();
     Position position = new Position(line, character);
@@ -140,10 +150,6 @@ public class AnalysisHandler {
     AnalysisResultEvent analysisResultEvent =
         ofNullable(new Gson().fromJson(params.toString(), AnalysisResultEvent.class))
             .orElseGet(() -> new AnalysisResultEvent("", "", 0, 0));
-    String uri = analysisResultEvent.getUri();
-    if (documentModelService.get(uri) == null) {
-      asyncAnalysisService.scheduleAnalysis(uri, analysisResultEvent.getText(), true);
-    }
     return ImmutableList.of(asyncAnalysisService.createDependencyOn(analysisResultEvent.getUri()));
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DidChangeHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DidChangeHandler.java
@@ -64,7 +64,6 @@ public class DidChangeHandler {
     }
     CobolDocumentModel model = documentModelService.changeDocument(uri, text);
     if (model != null) {
-      model.update(text);
       asyncAnalysisService.scheduleAnalysis(
           model, params.getTextDocument().getVersion(), false, false, eventSource);
     }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DidChangeHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DidChangeHandler.java
@@ -20,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.lsp.SourceUnitGraph;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
 import org.eclipse.lsp.cobol.lsp.handlers.HandlerUtility;
+import org.eclipse.lsp.cobol.service.CobolDocumentModel;
+import org.eclipse.lsp.cobol.service.DocumentModelService;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 
 /** LSP DidChange Handler */
@@ -27,12 +29,16 @@ import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 public class DidChangeHandler {
   private final AsyncAnalysisService asyncAnalysisService;
   private final SourceUnitGraph sourceUnitGraph;
+  private final DocumentModelService documentModelService;
 
   @Inject
   public DidChangeHandler(
-      AsyncAnalysisService asyncAnalysisService, SourceUnitGraph sourceUnitGraph) {
+      AsyncAnalysisService asyncAnalysisService,
+      SourceUnitGraph sourceUnitGraph,
+      DocumentModelService documentModelService) {
     this.asyncAnalysisService = asyncAnalysisService;
     this.sourceUnitGraph = sourceUnitGraph;
+    this.documentModelService = documentModelService;
   }
 
   /**
@@ -56,7 +62,11 @@ public class DidChangeHandler {
           allAssociatedFilesForACopybook, uri, text, SourceUnitGraph.EventSource.IDE);
       return;
     }
-    asyncAnalysisService.scheduleAnalysis(
-        uri, text, params.getTextDocument().getVersion(), false, eventSource);
+    CobolDocumentModel model = documentModelService.changeDocument(uri, text);
+    if (model != null) {
+      model.update(text);
+      asyncAnalysisService.scheduleAnalysis(
+          model, params.getTextDocument().getVersion(), false, false, eventSource);
+    }
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DidOpenHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DidOpenHandler.java
@@ -21,6 +21,7 @@ import org.eclipse.lsp.cobol.lsp.SourceUnitGraph;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
 import org.eclipse.lsp.cobol.lsp.events.notifications.DidOpenNotification;
 import org.eclipse.lsp.cobol.lsp.handlers.HandlerUtility;
+import org.eclipse.lsp.cobol.service.CobolDocumentModel;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 
 /** LSP DidOpen Handler */
@@ -48,8 +49,9 @@ public class DidOpenHandler {
     if (!HandlerUtility.isUriSupported(uri)) {
       return;
     }
-    asyncAnalysisService.openDocument(
-        uri, params.getTextDocument().getText(), params.getTextDocument().getLanguageId());
+    final CobolDocumentModel model =
+        asyncAnalysisService.openDocument(
+            uri, params.getTextDocument().getText(), params.getTextDocument().getLanguageId());
 
     if (this.asyncAnalysisService.isCopybook(uri, params.getTextDocument().getText())
         || this.sourceUnitGraph.isUserSuppliedCopybook(uri)) {
@@ -58,11 +60,7 @@ public class DidOpenHandler {
     }
 
     asyncAnalysisService.scheduleAnalysis(
-        uri,
-        params.getTextDocument().getText(),
-        params.getTextDocument().getVersion(),
-        true,
-        eventSource);
+        model, params.getTextDocument().getVersion(), true, false, eventSource);
   }
 
   /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DocumentHighlightHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DocumentHighlightHandler.java
@@ -21,6 +21,7 @@ import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
 import org.eclipse.lsp.cobol.lsp.events.queries.DocumentHighlightQuery;
+import org.eclipse.lsp.cobol.service.CobolDocumentModel;
 import org.eclipse.lsp.cobol.service.DocumentModelService;
 import org.eclipse.lsp.cobol.service.delegates.references.Occurrences;
 import org.eclipse.lsp4j.DocumentHighlight;
@@ -63,8 +64,9 @@ public class DocumentHighlightHandler {
    */
   public List<DocumentHighlight> documentHighlight(DocumentHighlightParams params) {
     String uri = params.getTextDocument().getUri();
-    return occurrences.findHighlights(
-        documentModelService.get(uri).getLastAnalysisResult(), params);
+    final CobolDocumentModel documentModel = documentModelService.get(uri);
+    if (documentModel == null) return ImmutableList.of();
+    return occurrences.findHighlights(documentModel.getLastAnalysisResult(), params);
   }
 
   /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DocumentSymbolHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DocumentSymbolHandler.java
@@ -103,7 +103,6 @@ public class DocumentSymbolHandler {
 
   /**
    * get cancel conditions
-   *
    * @param params
    * @return list of {@link LspEventCancelCondition
    */

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DocumentSymbolHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DocumentSymbolHandler.java
@@ -95,8 +95,8 @@ public class DocumentSymbolHandler {
         () -> {
           final CobolDocumentModel documentModel = documentModelService.get(uri);
           if (documentModel == null) return false;
-          return (documentModel.getOutlineResult() != null
-                  && !documentModel.getOutlineResult().isEmpty())
+          final List<?> outline = documentModel.getOutlineResult();
+          return (outline != null && !outline.isEmpty())
               || analysisService.isCopybook(uri, documentModel.getText());
         });
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DocumentSymbolHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DocumentSymbolHandler.java
@@ -24,6 +24,7 @@ import org.eclipse.lsp.cobol.lsp.*;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
 import org.eclipse.lsp.cobol.lsp.events.queries.DocumentSymbolQuery;
 import org.eclipse.lsp.cobol.service.AnalysisService;
+import org.eclipse.lsp.cobol.service.CobolDocumentModel;
 import org.eclipse.lsp.cobol.service.DocumentModelService;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
@@ -56,7 +57,9 @@ public class DocumentSymbolHandler {
   public List<Either<SymbolInformation, DocumentSymbol>> documentSymbol(
       DocumentSymbolParams params) {
     String uri = params.getTextDocument().getUri();
-    return createDocumentSymbols(documentModelService.get(uri).getOutlineResult());
+    final CobolDocumentModel documentModel = documentModelService.get(uri);
+    if (documentModel == null) return ImmutableList.of();
+    return createDocumentSymbols(documentModel.getOutlineResult());
   }
 
   private List<Either<SymbolInformation, DocumentSymbol>> createDocumentSymbols(
@@ -89,15 +92,18 @@ public class DocumentSymbolHandler {
     String uri = params.getTextDocument().getUri();
     return ImmutableList.of(
         asyncAnalysisService.createDependencyOn(uri),
-        () ->
-            documentModelService.get(uri) != null
-                && ((documentModelService.get(uri).getOutlineResult() != null
-                        && !documentModelService.get(uri).getOutlineResult().isEmpty())
-                    || analysisService.isCopybook(uri, documentModelService.get(uri).getText())));
+        () -> {
+          final CobolDocumentModel documentModel = documentModelService.get(uri);
+          if (documentModel == null) return false;
+          return (documentModel.getOutlineResult() != null
+                  && !documentModel.getOutlineResult().isEmpty())
+              || analysisService.isCopybook(uri, documentModel.getText());
+        });
   }
 
   /**
    * get cancel conditions
+   *
    * @param params
    * @return list of {@link LspEventCancelCondition
    */

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/FoldingRangeHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/FoldingRangeHandler.java
@@ -17,16 +17,16 @@ package org.eclipse.lsp.cobol.lsp.handlers.text;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.lsp.cobol.common.model.tree.Node;
+import org.eclipse.lsp.cobol.common.AnalysisResult;
 import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
 import org.eclipse.lsp.cobol.lsp.events.queries.FoldingQuery;
 import org.eclipse.lsp.cobol.service.AnalysisService;
+import org.eclipse.lsp.cobol.service.CobolDocumentModel;
 import org.eclipse.lsp.cobol.service.DocumentModelService;
 import org.eclipse.lsp.cobol.service.DocumentServiceHelper;
 import org.eclipse.lsp4j.FoldingRange;
@@ -58,13 +58,11 @@ public class FoldingRangeHandler {
    */
   public List<FoldingRange> foldingRange(FoldingRangeRequestParams params) {
     String uri = params.getTextDocument().getUri();
-    Node rootNode =
-        documentService.isDocumentSynced(uri)
-            ? documentService.get(uri).getAnalysisResult().getRootNode()
-            : null;
-    return rootNode == null
-        ? Collections.emptyList()
-        : new ArrayList<>(DocumentServiceHelper.getFoldingRange(rootNode, uri));
+    final CobolDocumentModel documentModel = documentService.get(uri);
+    if (documentModel == null || !documentModel.isDocumentSynced()) return ImmutableList.of();
+    final AnalysisResult results = documentModel.getAnalysisResult();
+    if (results == null) return ImmutableList.of();
+    return new ArrayList<>(DocumentServiceHelper.getFoldingRange(results.getRootNode(), uri));
   }
 
   /**
@@ -79,6 +77,9 @@ public class FoldingRangeHandler {
 
   /**
    * Get dependency for this handler
+   *
+   *
+   *
    * @param uri
    * @return list of {@link LspEventDependency
    */
@@ -96,6 +97,9 @@ public class FoldingRangeHandler {
   public List<LspEventCancelCondition> getCancelConditions(String uri) {
     return ImmutableList.of(
         asyncAnalysisService.createCancelConditionOnClose(uri),
-        () -> analysisService.isCopybook(uri, documentService.get(uri).getText()));
+        () -> {
+          final CobolDocumentModel documentModel = documentService.get(uri);
+          return documentModel == null || analysisService.isCopybook(uri, documentModel.getText());
+        });
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/FoldingRangeHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/FoldingRangeHandler.java
@@ -77,9 +77,6 @@ public class FoldingRangeHandler {
 
   /**
    * Get dependency for this handler
-   *
-   *
-   *
    * @param uri
    * @return list of {@link LspEventDependency
    */

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/AnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/AnalysisService.java
@@ -17,28 +17,18 @@ package org.eclipse.lsp.cobol.service;
 import static java.lang.String.format;
 
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.lsp.cobol.cfg.CFASTBuilder;
 import org.eclipse.lsp.cobol.common.AnalysisConfig;
 import org.eclipse.lsp.cobol.common.AnalysisResult;
 import org.eclipse.lsp.cobol.common.LanguageEngineFacade;
 import org.eclipse.lsp.cobol.common.copybook.CopybookProcessingMode;
-import org.eclipse.lsp.cobol.common.copybook.CopybookService;
 import org.eclipse.lsp.cobol.common.utils.ThreadInterruptionUtil;
-import org.eclipse.lsp.cobol.core.model.extendedapi.ExtendedApiResult;
-import org.eclipse.lsp.cobol.core.model.extendedapi.Program;
-import org.eclipse.lsp.cobol.lsp.jrpc.CobolLanguageClient;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookIdentificationService;
 import org.eclipse.lsp.cobol.service.settings.ConfigurationService;
 
@@ -49,30 +39,17 @@ public class AnalysisService {
   private final LanguageEngineFacade engine;
   private final ConfigurationService configurationService;
   private final CopybookIdentificationService copybookIdentificationService;
-  private final CopybookService copybookService;
   private final CountDownLatch waitConfig = new CountDownLatch(1);
   private List<String> copybookExtensions;
-
-  private final DocumentModelService documentService;
-  private final Optional<CFASTBuilder> cfastBuilder;
-  private final Provider<CobolLanguageClient> clientProvider;
 
   @Inject
   AnalysisService(
       LanguageEngineFacade engine,
       ConfigurationService configurationService,
-      @Named("combinedStrategy") CopybookIdentificationService copybookIdentificationService,
-      CopybookService copybookService,
-      DocumentModelService documentService,
-      @Nullable CFASTBuilder cfastBuilder,
-      Provider<CobolLanguageClient> clientProvider) {
+      @Named("combinedStrategy") CopybookIdentificationService copybookIdentificationService) {
     this.engine = engine;
     this.configurationService = configurationService;
     this.copybookIdentificationService = copybookIdentificationService;
-    this.copybookService = copybookService;
-    this.documentService = documentService;
-    this.cfastBuilder = Optional.ofNullable(cfastBuilder);
-    this.clientProvider = clientProvider;
   }
 
   /**
@@ -108,17 +85,18 @@ public class AnalysisService {
    * @param text Content
    * @param isNew Is document just opened, or it's reanalyse request.
    * @param langId - document language id
+   * @return Analysis results
    */
-  public void analyzeDocument(String uri, String text, boolean isNew, String langId) {
+  public AnalysisResult analyzeDocument(String uri, String text, boolean isNew, String langId) {
     String logPrefix = isNew ? "[analyzeDocument] Document " : "[reanalyzeDocument] Document ";
     LOG.debug(logPrefix + uri + " opened");
 
-    List<Program> astList = new LinkedList<>();
-    if (!isCopybook(uri, text)) {
-      LOG.debug(logPrefix + uri + " treated as a program, start analyzing");
-      astList = analyzeDocumentWithCopybooks(uri, text, langId);
+    if (isCopybook(uri, text)) {
+      LOG.debug(logPrefix + uri + " treated as a copybook, skipping analysis");
+      return null;
     }
-    this.clientProvider.get().cfastReady(new ExtendedApiResult(astList, uri));
+    LOG.debug(logPrefix + uri + " treated as a program, start analyzing");
+    return analyzeDocumentWithCopybooks(uri, text, langId);
   }
 
   /**
@@ -129,33 +107,20 @@ public class AnalysisService {
    * @param langId - document language id
    * @return a list of program nodes
    */
-  private List<Program> analyzeDocumentWithCopybooks(String uri, String text, String langId) {
-    List<Program> astList = new LinkedList<>();
+  private AnalysisResult analyzeDocumentWithCopybooks(String uri, String text, String langId) {
     try {
       CopybookProcessingMode copybookProcessingMode =
           CopybookProcessingMode.getCopybookProcessingMode(uri, CopybookProcessingMode.ENABLED);
       AnalysisConfig config = configurationService.getConfig(uri, copybookProcessingMode);
       ThreadInterruptionUtil.checkThreadInterrupted();
       AnalysisResult result = engine.analyze(uri, text, config, langId);
-      documentService.processAnalysisResult(uri, result, text);
-      ThreadInterruptionUtil.checkThreadInterrupted();
-
-      cfastBuilder.ifPresent(
-          builder ->
-              astList.addAll(
-                  result.getRootNode().findPrograms().stream()
-                      .map(builder::build)
-                      .flatMap(m -> m.getControlFlowAST().stream())
-                      .collect(Collectors.toList())));
-
       LOG.debug("[doAnalysis] Document " + uri + " analyzed: " + result.getDiagnostics());
+      return result;
 
     } catch (Exception e) {
-      documentService.processAnalysisResult(uri, AnalysisResult.EMPTY, text);
       LOG.debug(format("An exception thrown while applying %s for %s:", "analysis", uri));
       LOG.error(format("An exception thrown while applying %s for %s:", "analysis", uri), e);
       throw e;
     }
-    return astList;
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/AnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/AnalysisService.java
@@ -107,15 +107,16 @@ public class AnalysisService {
    * @param uri Source URI
    * @param text Content
    * @param isNew Is document just opened, or it's reanalyse request.
+   * @param langId - document language id
    */
-  public void analyzeDocument(String uri, String text, boolean isNew) {
+  public void analyzeDocument(String uri, String text, boolean isNew, String langId) {
     String logPrefix = isNew ? "[analyzeDocument] Document " : "[reanalyzeDocument] Document ";
     LOG.debug(logPrefix + uri + " opened");
 
     List<Program> astList = new LinkedList<>();
     if (!isCopybook(uri, text)) {
       LOG.debug(logPrefix + uri + " treated as a program, start analyzing");
-      astList = analyzeDocumentWithCopybooks(uri, text);
+      astList = analyzeDocumentWithCopybooks(uri, text, langId);
     }
     this.clientProvider.get().cfastReady(new ExtendedApiResult(astList, uri));
   }
@@ -125,17 +126,17 @@ public class AnalysisService {
    *
    * @param uri - document uri
    * @param text - document text
+   * @param langId - document language id
    * @return a list of program nodes
    */
-  private List<Program> analyzeDocumentWithCopybooks(String uri, String text) {
+  private List<Program> analyzeDocumentWithCopybooks(String uri, String text, String langId) {
     List<Program> astList = new LinkedList<>();
     try {
       CopybookProcessingMode copybookProcessingMode =
           CopybookProcessingMode.getCopybookProcessingMode(uri, CopybookProcessingMode.ENABLED);
       AnalysisConfig config = configurationService.getConfig(uri, copybookProcessingMode);
       ThreadInterruptionUtil.checkThreadInterrupted();
-      AnalysisResult result =
-          engine.analyze(uri, text, config, documentService.get(uri).getLanguageId());
+      AnalysisResult result = engine.analyze(uri, text, config, langId);
       documentService.processAnalysisResult(uri, result, text);
       ThreadInterruptionUtil.checkThreadInterrupted();
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/DocumentModelService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/DocumentModelService.java
@@ -47,11 +47,13 @@ public class DocumentModelService {
    * @param uri - document uri
    * @param text - document text
    * @param languageId
+   * @return document model
    */
   @Synchronized
-  public void openDocument(String uri, String text, String languageId) {
+  public CobolDocumentModel openDocument(String uri, String text, String languageId) {
     CobolDocumentModel model = docs.computeIfAbsent(uri, u -> new CobolDocumentModel(uri, text));
     Optional.ofNullable(languageId).ifPresent(model::setLanguageId);
+    return model;
   }
 
   /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/DocumentModelService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/DocumentModelService.java
@@ -95,13 +95,15 @@ public class DocumentModelService {
    * @param uri - document uri
    * @param analysisResult - analysis result
    * @param text - updated text
+   * @return update document model
    */
   @Synchronized
-  public void processAnalysisResult(String uri, AnalysisResult analysisResult, String text) {
+  public CobolDocumentModel processAnalysisResult(
+      String uri, AnalysisResult analysisResult, String text) {
     CobolDocumentModel document = docs.get(uri);
     if (document == null) {
       LOG.warn("Can't process analysis result of " + uri);
-      return;
+      return null;
     }
     removeAllRelatedDiagnostics(document);
     updateDiagnosticRepo(uri, analysisResult.getDiagnostics());
@@ -110,6 +112,8 @@ public class DocumentModelService {
     updatedModel.setOutlineResult(
         BuildOutlineTreeFromSyntaxTree.convert(analysisResult.getRootNode(), uri));
     docs.put(uri, updatedModel);
+
+    return updatedModel;
   }
 
   /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/DocumentModelService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/DocumentModelService.java
@@ -130,10 +130,13 @@ public class DocumentModelService {
    *
    * @param uri - document uri
    * @param text - document text
+   * @return document model associated with the uri
    */
   @Synchronized
-  public void changeDocument(String uri, String text) {
-    Optional.ofNullable(docs.get(uri)).ifPresent(d -> d.update(text));
+  public CobolDocumentModel changeDocument(String uri, String text) {
+    CobolDocumentModel model = docs.get(uri);
+    if (model != null) model.update(text);
+    return model;
   }
 
   /**

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisServiceTest.java
@@ -17,6 +17,7 @@ package org.eclipse.lsp.cobol.lsp.analysis;
 import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Provider;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -24,6 +25,7 @@ import java.util.stream.Stream;
 import org.eclipse.lsp.cobol.common.SubroutineService;
 import org.eclipse.lsp.cobol.common.dialects.TrueDialectService;
 import org.eclipse.lsp.cobol.lsp.SourceUnitGraph;
+import org.eclipse.lsp.cobol.lsp.jrpc.CobolLanguageClient;
 import org.eclipse.lsp.cobol.service.AnalysisService;
 import org.eclipse.lsp.cobol.service.CobolDocumentModel;
 import org.eclipse.lsp.cobol.service.DocumentModelService;
@@ -44,6 +46,7 @@ class AsyncAnalysisServiceTest {
   @Mock private SubroutineService subroutineService;
   @Mock private Communications communication;
   @Mock private SourceUnitGraph sourceUnitGraph;
+  @Mock private Provider<CobolLanguageClient> clientProvider;
 
   private AsyncAnalysisService asyncAnalysisService;
 
@@ -57,7 +60,9 @@ class AsyncAnalysisServiceTest {
             analysisService,
             copybookService,
             subroutineService,
-            communication);
+            communication,
+            null,
+            clientProvider);
   }
 
   @Test

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisServiceTest.java
@@ -74,7 +74,7 @@ class AsyncAnalysisServiceTest {
 
   @Test
   void testReanalyseCopybooksAssociatedPrograms() {
-    Map<String, Integer> analysisResultsRevisionsMock = mock(Map.class);
+    Map<String, Integer> analysisResultsRevisionsMock = new HashMap<>();
     try {
       Field field = AsyncAnalysisService.class.getDeclaredField("analysisResultsRevisions");
       field.setAccessible(true);
@@ -90,7 +90,7 @@ class AsyncAnalysisServiceTest {
     when(documentModelService.getAllOpened()).thenReturn(ImmutableList.of(cobolDocumentModel));
     when(documentModelService.get(any())).thenReturn(cobolDocumentModel);
     when(analysisService.isCopybook(anyString(), anyString())).thenReturn(false);
-    when(analysisResultsRevisionsMock.get(cobolDocumentModel.getUri())).thenReturn(1);
+    analysisResultsRevisionsMock.put(cobolDocumentModel.getUri(), 1);
     asyncAnalysisService.reanalyseCopybooksAssociatedPrograms(
         uris, "copybookUri", "copybookContent", eventSource);
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/AnalysisServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/AnalysisServiceTest.java
@@ -91,7 +91,7 @@ class AnalysisServiceTest {
     String text = UUID.randomUUID().toString();
     when(copybookIdentificationService.isCopybook(any(), any(), any())).thenReturn(true);
 
-    service.analyzeDocument(uri, text, true);
+    service.analyzeDocument(uri, text, true, "");
     verify(documentService, times(0)).processAnalysisResult(eq(uri), any(), anyString());
     verify(engine, times(0)).analyze(any(), any(), any());
   }
@@ -105,10 +105,7 @@ class AnalysisServiceTest {
     String text = UUID.randomUUID().toString();
     when(copybookIdentificationService.isCopybook(any(), any(), any())).thenReturn(false);
     when(engine.analyze(any(), any(), any(), anyString())).thenReturn(result);
-    CobolDocumentModel mockDocModel = mock(CobolDocumentModel.class);
-    when(mockDocModel.getLanguageId()).thenReturn("cobol");
-    when(documentService.get(uri)).thenReturn(mockDocModel);
-    service.analyzeDocument(uri, text, true);
+    service.analyzeDocument(uri, text, true, "cobol");
     verify(documentService, times(1)).processAnalysisResult(eq(uri), any(), anyString());
     verify(engine, times(1)).analyze(any(), any(), any(), anyString());
   }
@@ -119,7 +116,7 @@ class AnalysisServiceTest {
     String text = UUID.randomUUID().toString();
     when(copybookIdentificationService.isCopybook(any(), any(), any())).thenReturn(true);
 
-    service.analyzeDocument(uri, text, false);
+    service.analyzeDocument(uri, text, false, "");
     verify(engine, times(0)).analyze(any(), any(), any());
   }
 
@@ -129,11 +126,8 @@ class AnalysisServiceTest {
     String text = UUID.randomUUID().toString();
     when(copybookIdentificationService.isCopybook(any(), any(), any())).thenReturn(false);
     when(engine.analyze(any(), any(), any(), anyString())).thenReturn(prepareAnalysisResult());
-    CobolDocumentModel mockDocModel = mock(CobolDocumentModel.class);
-    when(mockDocModel.getLanguageId()).thenReturn("cobol");
-    when(documentService.get(uri)).thenReturn(mockDocModel);
 
-    service.analyzeDocument(uri, text, false);
+    service.analyzeDocument(uri, text, false, "cobol");
     verify(engine, times(1)).analyze(any(), any(), any(), anyString());
   }
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/AnalysisServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/AnalysisServiceTest.java
@@ -20,15 +20,12 @@ import static org.mockito.Mockito.*;
 import com.google.common.collect.ImmutableList;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import org.eclipse.lsp.cobol.cfg.CFASTBuilder;
 import org.eclipse.lsp.cobol.common.AnalysisResult;
 import org.eclipse.lsp.cobol.common.LanguageEngineFacade;
-import org.eclipse.lsp.cobol.common.copybook.CopybookService;
 import org.eclipse.lsp.cobol.common.model.tree.RootNode;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookIdentificationService;
 import org.eclipse.lsp.cobol.service.delegates.communications.Communications;
 import org.eclipse.lsp.cobol.service.settings.ConfigurationService;
-import org.eclipse.lsp.cobol.utils.MockCobolClientProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,35 +40,16 @@ class AnalysisServiceTest {
   @Mock private ConfigurationService configurationService;
   @Mock private CopybookIdentificationService copybookIdentificationService;
   @Mock private Communications communications;
-  @Mock private DocumentModelService documentService;
-  @Mock private CopybookService copybookService;
-  @Mock private CFASTBuilder cfastBuilder;
 
   @BeforeEach
   void init() {
-    service =
-        new AnalysisService(
-            engine,
-            configurationService,
-            copybookIdentificationService,
-            copybookService,
-            documentService,
-            cfastBuilder,
-            new MockCobolClientProvider());
+    service = new AnalysisService(engine, configurationService, copybookIdentificationService);
     service.setExtensionConfig(ImmutableList.of());
   }
 
   @Test
   void testIsCopybook() throws InterruptedException {
-    service =
-        new AnalysisService(
-            engine,
-            configurationService,
-            copybookIdentificationService,
-            copybookService,
-            documentService,
-            cfastBuilder,
-            new MockCobolClientProvider());
+    service = new AnalysisService(engine, configurationService, copybookIdentificationService);
 
     CompletableFuture<Boolean> booleanCompletableFuture =
         CompletableFuture.supplyAsync(() -> service.isCopybook("", ""));
@@ -92,21 +70,18 @@ class AnalysisServiceTest {
     when(copybookIdentificationService.isCopybook(any(), any(), any())).thenReturn(true);
 
     service.analyzeDocument(uri, text, true, "");
-    verify(documentService, times(0)).processAnalysisResult(eq(uri), any(), anyString());
     verify(engine, times(0)).analyze(any(), any(), any());
   }
 
   @Test
   void testAnalyzeDocument_program() throws InterruptedException {
     AnalysisResult result = mock(AnalysisResult.class);
-    when(result.getRootNode()).thenReturn(new RootNode());
 
     String uri = UUID.randomUUID().toString();
     String text = UUID.randomUUID().toString();
     when(copybookIdentificationService.isCopybook(any(), any(), any())).thenReturn(false);
     when(engine.analyze(any(), any(), any(), anyString())).thenReturn(result);
     service.analyzeDocument(uri, text, true, "cobol");
-    verify(documentService, times(1)).processAnalysisResult(eq(uri), any(), anyString());
     verify(engine, times(1)).analyze(any(), any(), any(), anyString());
   }
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolTextDocumentServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolTextDocumentServiceTest.java
@@ -111,7 +111,7 @@ class CobolTextDocumentServiceTest {
             documentModelService,
             watcherService,
             copybookService);
-    DidChangeHandler didChangeHandler = new DidChangeHandler(asyncAnalysisService, documentGraph);
+    DidChangeHandler didChangeHandler = new DidChangeHandler(asyncAnalysisService, documentGraph, documentModelService);
     DefinitionHandler definitionHandler =
         new DefinitionHandler(asyncAnalysisService, documentModelService, occurrences);
     DocumentSymbolHandler documentSymbolHandler =

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolTextDocumentServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolTextDocumentServiceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.google.gson.JsonObject;
+import com.google.inject.Provider;
 import java.util.Set;
 import org.eclipse.lsp.cobol.cfg.CFASTBuilder;
 import org.eclipse.lsp.cobol.common.SubroutineService;
@@ -33,6 +34,7 @@ import org.eclipse.lsp.cobol.lsp.events.queries.DocumentHighlightQuery;
 import org.eclipse.lsp.cobol.lsp.events.queries.FormattingQuery;
 import org.eclipse.lsp.cobol.lsp.handlers.extended.AnalysisHandler;
 import org.eclipse.lsp.cobol.lsp.handlers.text.*;
+import org.eclipse.lsp.cobol.lsp.jrpc.CobolLanguageClient;
 import org.eclipse.lsp.cobol.service.delegates.actions.CodeActions;
 import org.eclipse.lsp.cobol.service.delegates.communications.Communications;
 import org.eclipse.lsp.cobol.service.delegates.completions.Completions;
@@ -71,6 +73,8 @@ class CobolTextDocumentServiceTest {
 
   @Mock LspMessageBroker lspMessageBroker;
 
+  @Mock private Provider<CobolLanguageClient> clientProvider;
+
   private CobolTextDocumentService service;
 
   /**
@@ -90,7 +94,9 @@ class CobolTextDocumentServiceTest {
             analysisService,
             copybookService,
             subroutineService,
-            communications);
+            communications,
+            null,
+            clientProvider);
 
     CompletionHandler completionHandler =
         new CompletionHandler(asyncAnalysisService, completions, documentModelService);
@@ -111,7 +117,8 @@ class CobolTextDocumentServiceTest {
             documentModelService,
             watcherService,
             copybookService);
-    DidChangeHandler didChangeHandler = new DidChangeHandler(asyncAnalysisService, documentGraph, documentModelService);
+    DidChangeHandler didChangeHandler =
+        new DidChangeHandler(asyncAnalysisService, documentGraph, documentModelService);
     DefinitionHandler definitionHandler =
         new DefinitionHandler(asyncAnalysisService, documentModelService, occurrences);
     DocumentSymbolHandler documentSymbolHandler =


### PR DESCRIPTION
`documentModelService.get(...)` results may be changed (or become null) while the analysis is running.

```
java.util.concurrent.CompletionException: java.lang.NullPointerException
    at java.base@21.0.2/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332)
    at java.base@21.0.2/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347)
    at java.base@21.0.2/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:708)
    at java.base@21.0.2/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
    at java.base@21.0.2/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2194)
    at org.eclipse.lsp.cobol.lsp.LspEventConsumer.handle(LspEventConsumer.java:75)
    at org.eclipse.lsp.cobol.lsp.LspEventConsumer.lambda$handle$3(LspEventConsumer.java:51)
    at java.base@21.0.2/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
    at java.base@21.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.base@21.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.base@21.0.2/java.lang.Thread.runWith(Thread.java:1596)
    at java.base@21.0.2/java.lang.Thread.run(Thread.java:1583)
    at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:833)
    at org.graalvm.nativeimage.builder/com.oracle.svm.core.windows.WindowsPlatformThreads.osThreadStartRoutine(WindowsPlatformThreads.java:214)
Caused by: java.lang.NullPointerException
    at org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService.scheduleAnalysis(AsyncAnalysisService.java:155)
    at org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService.scheduleAnalysis(AsyncAnalysisService.java:125)
    at org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService.scheduleAnalysis(AsyncAnalysisService.java:100)
    at org.eclipse.lsp.cobol.lsp.handlers.extended.AnalysisHandler.getDependencies(AnalysisHandler.java:145)
    at org.eclipse.lsp.cobol.lsp.events.queries.AnalysisQuery.getDependencies(AnalysisQuery.java:51)
    at org.eclipse.lsp.cobol.lsp.LspEventConsumer.handle(LspEventConsumer.java:61)
    ... 8 more
```