### PR TITLE
fix: Enable checkbox for SQL "None" feature

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlDialect.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlDialect.java
@@ -51,7 +51,8 @@ import org.eclipse.lsp.cobol.service.settings.SettingsParametersEnum;
 public class Db2SqlDialect implements CobolDialect {
   public static final String DIALECT_NAME = "db2";
   public static final String SQL_BACKEND_SETTING = SettingsParametersEnum.SQL_BACKEND_SETTING.label;
-  public static final String SQL_PROCESSING_ENABLED_SETTING = SettingsParametersEnum.SQL_PROCESSING_ENABLED_SETTING.label;
+  public static final String SQL_PROCESSING_ENABLED_SETTING =
+      SettingsParametersEnum.SQL_PROCESSING_ENABLED_SETTING.label;
 
   private final CopybookService copybookService;
   private final MessageService messageService;

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlDialect.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlDialect.java
@@ -51,6 +51,7 @@ import org.eclipse.lsp.cobol.service.settings.SettingsParametersEnum;
 public class Db2SqlDialect implements CobolDialect {
   public static final String DIALECT_NAME = "db2";
   public static final String SQL_BACKEND_SETTING = SettingsParametersEnum.SQL_BACKEND_SETTING.label;
+  public static final String SQL_PROCESSING_ENABLED_SETTING = SettingsParametersEnum.SQL_PROCESSING_ENABLED_SETTING.label;
 
   private final CopybookService copybookService;
   private final MessageService messageService;

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/AnalysisConfigHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/AnalysisConfigHelper.java
@@ -16,7 +16,6 @@ package org.eclipse.lsp.cobol.service.settings;
 
 import lombok.experimental.UtilityClass;
 import org.eclipse.lsp.cobol.common.AnalysisConfig;
-import org.eclipse.lsp.cobol.common.SqlProcessing;
 import org.eclipse.lsp.cobol.common.copybook.CopybookProcessingMode;
 
 /** AnalysisConfig Helper class */
@@ -39,7 +38,7 @@ class AnalysisConfigHelper {
             entity.getDialects(),
             entity.isCicsTranslatorEnabled(),
             false,
-            SqlProcessing.ENABLED,
+            entity.getIsSQLProcessingEnabled(),
             entity.getDialectRegistry(),
             entity.getDialectsSettings());
     analysisConfig.getCompilerOptions().addAll(entity.getCompilerOptions());

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/CachingConfigurationService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/CachingConfigurationService.java
@@ -53,6 +53,7 @@ public class CachingConfigurationService implements ConfigurationService {
                 SUBROUTINE_LOCAL_PATHS.label,
                 CICS_TRANSLATOR_ENABLED.label,
                 DIALECT_REGISTRY.label,
+                SQL_PROCESSING_ENABLED_SETTING.label,
                 COMPILER_OPTIONS.label));
 
     List<String> dialectsSections =
@@ -132,9 +133,10 @@ public class CachingConfigurationService implements ConfigurationService {
         ConfigHelper.parseSubroutineFolder((JsonElement) clientConfig.get(1)),
         ConfigHelper.parseCicsTranslatorOption((JsonElement) clientConfig.get(2)),
         ConfigHelper.parseDialectRegistry((JsonArray) clientConfig.get(3)),
-        ConfigHelper.parseCompilerOptions(clientConfig.get(4)),
+        ConfigHelper.parseSQLProcessingEnabled((JsonElement) clientConfig.get(4)),
+        ConfigHelper.parseCompilerOptions(clientConfig.get(5)),
         getDialectsSettings(
-            clientConfig.subList(5, 5 + dialectsSections.size()).toArray(),
+            clientConfig.subList(6, 6 + dialectsSections.size()).toArray(),
             dialectsSections.toArray()));
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.common.DialectRegistryItem;
+import org.eclipse.lsp.cobol.common.SqlProcessing;
 import org.eclipse.lsp.cobol.common.copybook.SQLBackend;
 import org.eclipse.lsp.cobol.common.dialects.CobolDialect;
 
@@ -114,6 +115,20 @@ public class ConfigHelper {
       return false;
     } else {
       return options.getAsBoolean();
+    }
+  }
+
+  /**
+   * Parse CICS translator client configurations to {@link Boolean}
+   *
+   * @param options CICS translator client configuration
+   * @return True if checked or false
+   */
+  public SqlProcessing parseSQLProcessingEnabled(JsonElement options) {
+    if (options instanceof JsonNull) {
+      return SqlProcessing.ENABLED;
+    } else {
+      return options.getAsBoolean() ? SqlProcessing.ENABLED : SqlProcessing.DISABLED;
     }
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
@@ -125,11 +125,14 @@ public class ConfigHelper {
    * @return True if checked or false
    */
   public SqlProcessing parseSQLProcessingEnabled(JsonElement options) {
-    if (options instanceof JsonNull) {
+      if (!(options instanceof JsonNull)) {
+          if (options.isJsonPrimitive()) {
+              if (options.getAsJsonPrimitive().isBoolean()) {
+                  return options.getAsBoolean() ? SqlProcessing.ENABLED : SqlProcessing.DISABLED;
+              }
+          }
+      }
       return SqlProcessing.ENABLED;
-    } else {
-      return options.getAsBoolean() ? SqlProcessing.ENABLED : SqlProcessing.DISABLED;
-    }
   }
 
   /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
@@ -125,14 +125,14 @@ public class ConfigHelper {
    * @return Enabled if checked or Disabled otherwise, Enabled in the case of an invalid state
    */
   public SqlProcessing parseSQLProcessingEnabled(JsonElement options) {
-      if (!(options instanceof JsonNull)) {
-          if (options.isJsonPrimitive()) {
-              if (options.getAsJsonPrimitive().isBoolean()) {
-                  return options.getAsBoolean() ? SqlProcessing.ENABLED : SqlProcessing.DISABLED;
-              }
-          }
+    if (!(options instanceof JsonNull)) {
+      if (options.isJsonPrimitive()) {
+        if (options.getAsJsonPrimitive().isBoolean()) {
+          return options.getAsBoolean() ? SqlProcessing.ENABLED : SqlProcessing.DISABLED;
+        }
       }
-      return SqlProcessing.ENABLED;
+    }
+    return SqlProcessing.ENABLED;
   }
 
   /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
@@ -125,12 +125,8 @@ public class ConfigHelper {
    * @return Enabled if checked or Disabled otherwise, Enabled in the case of an invalid state
    */
   public SqlProcessing parseSQLProcessingEnabled(JsonElement options) {
-    if (!(options instanceof JsonNull)) {
-      if (options.isJsonPrimitive()) {
-        if (options.getAsJsonPrimitive().isBoolean()) {
-          return options.getAsBoolean() ? SqlProcessing.ENABLED : SqlProcessing.DISABLED;
-        }
-      }
+    if (options.isJsonPrimitive() && options.getAsJsonPrimitive().isBoolean()) {
+      return options.getAsBoolean() ? SqlProcessing.ENABLED : SqlProcessing.DISABLED;
     }
     return SqlProcessing.ENABLED;
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigHelper.java
@@ -119,10 +119,10 @@ public class ConfigHelper {
   }
 
   /**
-   * Parse CICS translator client configurations to {@link Boolean}
+   * Parse SQL Processing Enabled configurations to {@link SqlProcessing}
    *
-   * @param options CICS translator client configuration
-   * @return True if checked or false
+   * @param options SQL Processing checkbox state from configuration
+   * @return Enabled if checked or Disabled otherwise, Enabled in the case of an invalid state
    */
   public SqlProcessing parseSQLProcessingEnabled(JsonElement options) {
       if (!(options instanceof JsonNull)) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigurationService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/settings/ConfigurationService.java
@@ -24,6 +24,7 @@ import lombok.AllArgsConstructor;
 import lombok.Value;
 import org.eclipse.lsp.cobol.common.AnalysisConfig;
 import org.eclipse.lsp.cobol.common.DialectRegistryItem;
+import org.eclipse.lsp.cobol.common.SqlProcessing;
 import org.eclipse.lsp.cobol.common.copybook.CopybookProcessingMode;
 
 /** This interface handles the request for configurations from the client settings */
@@ -77,6 +78,7 @@ public interface ConfigurationService {
     List<String> subroutines;
     boolean cicsTranslatorEnabled;
     List<DialectRegistryItem> dialectRegistry;
+    SqlProcessing isSQLProcessingEnabled;
     List<String> compilerOptions;
     //    CobolProgramLayout layout;
     Map<String, JsonElement> dialectsSettings;
@@ -86,6 +88,7 @@ public interface ConfigurationService {
       subroutines = ImmutableList.of();
       cicsTranslatorEnabled = true;
       dialectRegistry = ImmutableList.of();
+      isSQLProcessingEnabled = SqlProcessing.ENABLED;
       compilerOptions = ImmutableList.of();
       dialectsSettings = ImmutableMap.of();
       //      layout = new CobolProgramLayout();

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CachingConfigurationServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CachingConfigurationServiceTest.java
@@ -81,6 +81,7 @@ class CachingConfigurationServiceTest {
             subroutines,
             new JsonPrimitive("true"),
             new JsonArray(),
+            new JsonPrimitive("true"),
             new JsonArray(),
             predefinedParagraphs);
 
@@ -91,6 +92,7 @@ class CachingConfigurationServiceTest {
                 SUBROUTINE_LOCAL_PATHS.label,
                 CICS_TRANSLATOR_ENABLED.label,
                 DIALECT_REGISTRY.label,
+                SQL_PROCESSING_ENABLED_SETTING.label,
                 COMPILER_OPTIONS.label,
                 "dialect")))
         .thenReturn(supplyAsync(() -> clientConfig));
@@ -126,8 +128,9 @@ class CachingConfigurationServiceTest {
         Arrays.asList(
             dialectSettings,
             subroutineSettings,
-            new JsonNull(),
+            JsonNull.INSTANCE,
             new JsonArray(),
+            JsonNull.INSTANCE,
             new JsonArray(),
             dialectsSettings);
     when(settingsService.fetchConfigurations(
@@ -137,6 +140,7 @@ class CachingConfigurationServiceTest {
                 SUBROUTINE_LOCAL_PATHS.label,
                 CICS_TRANSLATOR_ENABLED.label,
                 DIALECT_REGISTRY.label,
+                SQL_PROCESSING_ENABLED_SETTING.label,
                 COMPILER_OPTIONS.label,
                 "dialect")))
         .thenReturn(supplyAsync(() -> clientConfig));


### PR DESCRIPTION
Added fields such that the current state of the checkbox is loaded from the configuration and used within to enable/disable processing on SQL-related errors. Also updated the usage of `JsonNull()` in one test as that has been deprecated in lieu of `JsonNull.INSTANCE`.

## How Has This Been Tested?

Ran existing tests. 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
