### PR TITLE
fix: use correct dialect when loading copybooks libs configuration

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroups.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/ProcessorGroups.spec.ts
@@ -20,6 +20,7 @@ import {
 import {
   DEFAULT_DIALECT,
   ENDEVOR_PROCESSOR,
+  PATHS_LOCAL_KEY,
   SETTINGS_CPY_NDVR_DEPENDENCIES,
 } from "../../constants";
 import { DatasetLib } from "../../services/copybookLibs/DatasetLib";
@@ -221,11 +222,32 @@ describe("Processor groups", () => {
       describe("no matching pg", () => {
         beforeEach(() => {
           isEndevorElementResult = false;
+          getConfigurationResult[PATHS_LOCAL_KEY] = ["local/copybooks"];
+          getConfigurationResult[`idms.${PATHS_LOCAL_KEY}`] = [
+            "local/idms/copybooks",
+          ];
         });
         it("uses vscode setting if no matching processor group is available", async () => {
           const document = vscode.Uri.joinPath(WORKSPACE_URI, "NO_PG.cob");
           const pg = await loadProcessorGroup(document);
           expect(pg?.name).toEqual("VSCodeSettingProcessorGroup");
+          expect(pg?.libs).toEqual([new LocalPathLib("local/copybooks")]);
+        });
+      });
+
+      describe("no matching pg - idms dialect", () => {
+        beforeEach(() => {
+          isEndevorElementResult = false;
+          getConfigurationResult[PATHS_LOCAL_KEY] = ["local/copybooks"];
+          getConfigurationResult[`idms.${PATHS_LOCAL_KEY}`] = [
+            "local/idms/copybooks",
+          ];
+        });
+        it("uses vscode setting if no matching processor group is available", async () => {
+          const document = vscode.Uri.joinPath(WORKSPACE_URI, "NO_PG.cob");
+          const pg = await loadProcessorGroup(document, "IDMS");
+          expect(pg?.name).toEqual("VSCodeSettingProcessorGroup");
+          expect(pg.libs).toEqual([new LocalPathLib("local/idms/copybooks")]);
         });
       });
 

--- a/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ProcessorGroups.ts
@@ -126,7 +126,10 @@ function toForwardSlashUppercase(path: string): string {
   return path.split("\\").join("/").toUpperCase();
 }
 
-export async function loadProcessorGroup(documentUri: Uri) {
+export async function loadProcessorGroup(
+  documentUri: Uri,
+  dialect = DEFAULT_DIALECT,
+) {
   let workspaceConfig = await readEndevorConfig(documentUri);
 
   if (!workspaceConfig) {
@@ -148,7 +151,7 @@ export async function loadProcessorGroup(documentUri: Uri) {
     }
   }
 
-  return readSettingConfig(DEFAULT_DIALECT);
+  return readSettingConfig(dialect);
 }
 
 async function getB4GProcessorGroupName(documentUri: Uri) {
@@ -176,7 +179,7 @@ async function loadProcessorGroupSettings<
   defaultValue: ProcessorGroupProperties[P],
   dialect: string = "COBOL",
 ) {
-  const processorGroup = await loadProcessorGroup(documentUri);
+  const processorGroup = await loadProcessorGroup(documentUri, dialect);
   if (!processorGroup) {
     return defaultValue;
   }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookMessageHandler.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookMessageHandler.ts
@@ -60,4 +60,5 @@ export async function resolveCopybookURI(
       return result.value.toString();
     }
   }
+  outputChannel.error("Unable to resolve copybook", { pgLibs, copybookName });
 }


### PR DESCRIPTION
Fix for [DE649016](https://rally1.rallydev.com/#/?detail=/defect/834400319449&fdp=true): IDMS copybooks are not resolved

## How Has This Been Tested?
Manual testing and & `src/__tests__/services/ProcessorGroups.spec.ts` unit test

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
