### PR TITLE
fix: fix hover information for FD variables

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
+++ b/clients/cobol-lsp-vscode-extension/src/test/suite/lsp.spec.test.ts
@@ -709,10 +709,10 @@ suite("Integration Test Suite", function () {
         (hoverResults_para1[0].contents[0] as vscode.MarkdownString).value,
       ),
       normalizeLineEndings(`\`\`\`cobol
-              PARAG1.
-                  DISPLAY 'PARAG1'.
-                  PERFORM PARAG3.
-                  PERFORM PARAG2.
+       PARAG1.
+           DISPLAY 'PARAG1'.
+           PERFORM PARAG3.
+           PERFORM PARAG2.
 
 \`\`\``),
     );
@@ -727,8 +727,8 @@ suite("Integration Test Suite", function () {
           .value,
       ),
       normalizeLineEndings(`\`\`\`cobol
-              PARAG3.
-                  DISPLAY 'PARAG3'.
+       PARAG3.
+           DISPLAY 'PARAG3'.
 
 \`\`\`
 
@@ -745,8 +745,8 @@ _NOTE: multiple versions exist due to replac(e/ing) or multiple use of same copy
           .value,
       ),
       normalizeLineEndings(`\`\`\`cobol
-              PARAG2.
-                  DISPLAY 'PARAG2'.
+       PARAG2.
+           DISPLAY 'PARAG2'.
 
 \`\`\`
 
@@ -763,8 +763,8 @@ _NOTE: multiple versions exist due to replac(e/ing) or multiple use of same copy
           .value,
       ),
       normalizeLineEndings(`\`\`\`cobol
-              S010 SECTION.
-                  display 'section S010'.
+       S010 SECTION.
+           display 'section S010'.
 
 \`\`\``),
     );
@@ -790,15 +790,15 @@ _NOTE: multiple versions exist due to replac(e/ing) or multiple use of same copy
     ).value;
     assert.ok(
       hoverContent.includes(`\`\`\`cobol
-              PARAG3.
-                  DISPLAY 'PARAG3'.
+       PARAG3.
+           DISPLAY 'PARAG3'.
 
 \`\`\``),
     );
     assert.ok(
       hoverContent.includes(`\`\`\`cobol
-              PARAG2.
-                  DISPLAY 'PARAG2'.
+       PARAG2.
+           DISPLAY 'PARAG2'.
 
 \`\`\``),
     );

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/ParagraphNameNode.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/ParagraphNameNode.java
@@ -60,7 +60,7 @@ public class ParagraphNameNode extends Node implements DefinedAndUsedStructure, 
         .map(ParagraphNode::getFullVariableDescription)
         .map(desc -> Arrays.stream(desc.split("\\r?\\n")))
         .orElse(Stream.empty())
-        .map(line -> new MarkupContent(MarkupKind.MARKDOWN, line))
+        .map(line -> new MarkupContent(MarkupKind.PLAINTEXT, line))
         .collect(Collectors.toList());
   }
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/SectionNameNode.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/SectionNameNode.java
@@ -15,7 +15,11 @@
 package org.eclipse.lsp.cobol.common.model.tree;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.eclipse.lsp.cobol.common.model.DefinedAndUsedStructure;
@@ -54,11 +58,12 @@ public class SectionNameNode extends Node implements DefinedAndUsedStructure, De
    */
   @Override
   public List<MarkupContent> getFormattedDisplayString() {
-    return ImmutableList.of(
-        getNearestParentByType(NodeType.PROCEDURE_SECTION)
+    return getNearestParentByType(NodeType.PROCEDURE_SECTION)
             .map(ProcedureSectionNode.class::cast)
             .map(ProcedureSectionNode::getFullVariableDescription)
-            .map(desc -> new MarkupContent(MarkupKind.PLAINTEXT, desc))
-            .orElse(new MarkupContent(MarkupKind.MARKDOWN, "")));
+            .map(desc -> Arrays.stream(desc.split("\\r?\\n")))
+            .orElse(Stream.empty())
+            .map(line -> new MarkupContent(MarkupKind.PLAINTEXT, line))
+            .collect(Collectors.toList());
   }
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/SectionNameNode.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/SectionNameNode.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import lombok.Getter;
 import lombok.Setter;
 import org.eclipse.lsp.cobol.common.model.DefinedAndUsedStructure;
@@ -59,11 +58,11 @@ public class SectionNameNode extends Node implements DefinedAndUsedStructure, De
   @Override
   public List<MarkupContent> getFormattedDisplayString() {
     return getNearestParentByType(NodeType.PROCEDURE_SECTION)
-            .map(ProcedureSectionNode.class::cast)
-            .map(ProcedureSectionNode::getFullVariableDescription)
-            .map(desc -> Arrays.stream(desc.split("\\r?\\n")))
-            .orElse(Stream.empty())
-            .map(line -> new MarkupContent(MarkupKind.PLAINTEXT, line))
-            .collect(Collectors.toList());
+        .map(ProcedureSectionNode.class::cast)
+        .map(ProcedureSectionNode::getFullVariableDescription)
+        .map(desc -> Arrays.stream(desc.split("\\r?\\n")))
+        .orElse(Stream.empty())
+        .map(line -> new MarkupContent(MarkupKind.PLAINTEXT, line))
+        .collect(Collectors.toList());
   }
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/SectionNameNode.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/SectionNameNode.java
@@ -58,7 +58,7 @@ public class SectionNameNode extends Node implements DefinedAndUsedStructure, De
         getNearestParentByType(NodeType.PROCEDURE_SECTION)
             .map(ProcedureSectionNode.class::cast)
             .map(ProcedureSectionNode::getFullVariableDescription)
-            .map(desc -> new MarkupContent(MarkupKind.MARKDOWN, desc))
+            .map(desc -> new MarkupContent(MarkupKind.PLAINTEXT, desc))
             .orElse(new MarkupContent(MarkupKind.MARKDOWN, "")));
   }
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/variable/VariableNode.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/variable/VariableNode.java
@@ -162,7 +162,10 @@ public abstract class VariableNode extends Node implements DefinedAndUsedStructu
     prefix.append(PREFIX);
     List<MarkupContent> childrenDescription = getChildrenDescription(prefix.toString());
     lines.addAll(childrenDescription);
-    lines.addAll(otherDetails);
+    if (!otherDetails.isEmpty()) {
+      lines.add(new MarkupContent(MarkupKind.MARKDOWN, ""));
+      lines.addAll(otherDetails);
+    }
     return lines;
   }
 

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/variable/VariableNode.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/variable/VariableNode.java
@@ -142,38 +142,41 @@ public abstract class VariableNode extends Node implements DefinedAndUsedStructu
   /**
    * Get user friendly variable description.
    *
-   * @return the string with described variable.
+   * @return the List of {@link MarkupContent} with described variable.
    */
   public List<MarkupContent> getFullVariableDescription() {
     StringBuilder prefix = new StringBuilder();
     List<MarkupContent> lines = new ArrayList<>();
-    for (String parentLine : parentsDescription()) {
-      lines.add(new MarkupContent(MarkupKind.MARKDOWN, parentLine));
+    List<MarkupContent> otherDetails = new ArrayList<>();
+    for (VariableNode node : getParentVariableNodes()) {
+      if (doesNodeHaveLevel(node)) {
+        lines.add(new MarkupContent(MarkupKind.MARKDOWN, node.getVariableDisplayString()));
+      } else {
+        otherDetails.add(new MarkupContent(MarkupKind.MARKDOWN, node.getVariableDisplayString()));
+      }
     }
-    if (shouldAppendPrefix()) prefix.append(PREFIX);
+    if (!lines.isEmpty()) prefix.append(PREFIX);
     lines.add(
         new MarkupContent(
             MarkupKind.MARKDOWN, prepend(prefix.toString(), getVariableDisplayString())));
     prefix.append(PREFIX);
     List<MarkupContent> childrenDescription = getChildrenDescription(prefix.toString());
     lines.addAll(childrenDescription);
+    lines.addAll(otherDetails);
     return lines;
   }
 
-  private Boolean shouldAppendPrefix() {
-    return getNearestParentByType(VARIABLE)
-        .map(VariableNode.class::cast)
-        .map(t -> !ImmutableList.of(FD, SD, MAP_NAME).contains(t.getVariableType()))
-        .orElse(false);
+  private static Boolean doesNodeHaveLevel(VariableNode vn) {
+    return !ImmutableList.of(FD, SD, MAP_NAME).contains(vn.getVariableType());
   }
 
-  private List<String> parentsDescription() {
+  private List<VariableNode> getParentVariableNodes() {
     return getNearestParentByType(VARIABLE)
         .map(VariableNode.class::cast)
         .map(
             variableNode -> {
-              List<String> result = variableNode.parentsDescription();
-              result.add(variableNode.getVariableDisplayString());
+              List<VariableNode> result = variableNode.getParentVariableNodes();
+              result.add(variableNode);
               return result;
             })
         .orElseGet(ArrayList::new);

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/variables/FileDescriptionNode.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/variables/FileDescriptionNode.java
@@ -59,7 +59,7 @@ public class FileDescriptionNode extends VariableNode {
   @Override
   protected List<MarkupContent> getChildrenDescription(String prefix) {
     List<MarkupContent> result = new ArrayList<>();
-    result.add(new MarkupContent(MarkupKind.PLAINTEXT, "*******    FILE-CONTROL ****"));
+    result.add(new MarkupContent(MarkupKind.PLAINTEXT, "*******    FILE-CONTROL"));
     Arrays.stream(fileControlClause.split("\\r?\\n"))
         .map(e -> new MarkupContent(MarkupKind.MARKDOWN, e))
         .forEach(result::add);

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/delegates/hover/VariableHoverTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/delegates/hover/VariableHoverTest.java
@@ -147,6 +147,7 @@ class VariableHoverTest {
         "```cobol\n"
             + "       01 ACCOUNT-RECORD.\n"
             + "         03 ACCOUNT-KEY.\n"
+            + "\n"
             + "       FD  ACCTFILE                          IS EXTERNAL\n"
             + "       DATA RECORD IS ACCOUNT-RECORD.\n"
             + "\n"

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/delegates/hover/VariableHoverTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/delegates/hover/VariableHoverTest.java
@@ -32,22 +32,32 @@ import org.junit.jupiter.api.Test;
 
 /** Test {@link DefinedAndUsedStructureHoverProvider} */
 class VariableHoverTest {
-  private final DefinedAndUsedStructureHoverProvider variableHover =
-      new DefinedAndUsedStructureHoverProvider();
-  SourceUnitGraph documentGraph;
-
-  @BeforeEach
-  void setUp() {
-    this.documentGraph = mock(SourceUnitGraph.class);
-    when(documentGraph.isUserSuppliedCopybook(anyString())).thenReturn(false);
-  }
-
+  public static final String FD_SOURCE_UNIT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST1.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       FILE-CONTROL.\n"
+          + "           SELECT {$ACCTFILE}\n"
+          + "               ASSIGN        TO UT-ACCTFILE\n"
+          + "               ORGANIZATION  IS INDEXED\n"
+          + "               ACCESS MODE   IS DYNAMIC\n"
+          + "               RECORD KEY    IS {$ACCOUNT-KEY}\n"
+          + "               FILE STATUS   IS {$FS-ACCTFILE}.\n"
+          + "       DATA DIVISION.\n"
+          + "       FILE SECTION.\n"
+          + "       FD  {$*ACCTFILE}                          IS EXTERNAL\n"
+          + "           DATA RECORD IS {$ACCOUNT-RECORD}.\n"
+          + "       01  {$*ACCOUNT-RECORD}.\n"
+          + "           03  {$*ACCOUNT-KEY}.\n"
+          + "               05  {$*ACCOUNT-ID}                 PIC 9(06)  VALUE ZERO.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       77  {$*FS-ACCTFILE}                    PIC 9(02) VALUE ZERO.";
   private static final String HEADER =
       "       Identification Division.\n"
           + "       Program-id. TEST1.\n"
           + "       Data Division.\n"
           + "       Working-Storage Section.\n";
-
   private static final String FULL_TEXT =
       HEADER
           + "       01 {$*TEST2} PIC 9.\n"
@@ -60,6 +70,15 @@ class VariableHoverTest {
           + "           88 {$*COND-ITEM2} VALUES 1 THRU 3\n"
           + "                                4 THROUGH 5.\n"
           + "       01 {$*ANOTHER} PIC X(6) USAGE UTF-8.";
+  private final DefinedAndUsedStructureHoverProvider variableHover =
+      new DefinedAndUsedStructureHoverProvider();
+  SourceUnitGraph documentGraph;
+
+  @BeforeEach
+  void setUp() {
+    this.documentGraph = mock(SourceUnitGraph.class);
+    when(documentGraph.isUserSuppliedCopybook(anyString())).thenReturn(false);
+  }
 
   @Test
   void getHoverForNullDocument() {
@@ -114,6 +133,24 @@ class VariableHoverTest {
     assertEquals(MarkupKind.MARKDOWN, markupContent.getKind());
     assertEquals(
         "```cobol\n" + "       01 ANOTHER PIC X(6) USAGE UTF-8.\n" + "\n" + "```",
+        markupContent.getValue());
+  }
+
+  @Test
+  void testFDVariableHover() {
+    Hover hover =
+        variableHover.getHover(getModel(FD_SOURCE_UNIT), getPosition(14, 30), documentGraph);
+    assertNotNull(hover);
+    MarkupContent markupContent = hover.getContents().getRight();
+    assertEquals(MarkupKind.MARKDOWN, markupContent.getKind());
+    assertEquals(
+        "```cobol\n"
+            + "       01 ACCOUNT-RECORD.\n"
+            + "         03 ACCOUNT-KEY.\n"
+            + "       FD  ACCTFILE                          IS EXTERNAL\n"
+            + "       DATA RECORD IS ACCOUNT-RECORD.\n"
+            + "\n"
+            + "```",
         markupContent.getValue());
   }
 

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestFileDescriptor.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestFileDescriptor.java
@@ -88,7 +88,7 @@ class TestFileDescriptor {
           + "       RECORD CONTAINS 80 CHARACTERS\n"
           + "       RECORDING MODE IS F\n"
           + "       BLOCK CONTAINS 0 RECORDS.\n"
-          + "*******    FILE-CONTROL ****\n"
+          + "*******    FILE-CONTROL\n"
           + "       ASSIGN TO \"c:\\infile.dat\"\n"
           + "       ORGANIZATION IS LINE SEQUENTIAL\n"
           + "       ACCESS MODE IS SEQUENTIAL\n"


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test hover on below code
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. TEST1.
       ENVIRONMENT DIVISION.
       INPUT-OUTPUT SECTION.
       FILE-CONTROL.
           SELECT ACCTFILE
               ASSIGN        TO UT-ACCTFILE
               ORGANIZATION  IS INDEXED
               ACCESS MODE   IS DYNAMIC
               RECORD KEY    IS ACCOUNT-KEY
               FILE STATUS   IS FS-ACCTFILE.
       DATA DIVISION.
       FILE SECTION.
       FD  ACCTFILE                          IS EXTERNAL
           DATA RECORD IS ACCOUNT-RECORD.
       01  ACCOUNT-RECORD.
           03  ACCOUNT-KEY.
               05  ACCOUNT-ID                 PIC 9(06)  VALUE ZERO.
       WORKING-STORAGE SECTION.
       77  FS-ACCTFILE                    PIC 9(02) VALUE ZERO.
``` 
Hover on line 10, col: 40
```cobol
       01 ACCOUNT-RECORD.
         03 ACCOUNT-KEY.
           05 ACCOUNT-ID PIC 9(06) VALUE ZERO.
       FD  ACCTFILE                          IS EXTERNAL
       DATA RECORD IS ACCOUNT-RECORD.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
