### PR TITLE
chore: rename registerEvent to telemetryEvent

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/OpenSettingsCommandTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/OpenSettingsCommandTest.spec.ts
@@ -14,7 +14,7 @@
 
 import * as vscode from "vscode";
 import { gotoCopybookSettings } from "../../commands/OpenSettingsCommand";
-import { registerEvent } from "../../services/reporter";
+import { telemetryEvent } from "../../services/reporter";
 
 jest.mock("../../services/reporter");
 
@@ -22,7 +22,7 @@ test("check gotoCopybookSettings calls telemetry services and vscode execute com
   expect(gotoCopybookSettings).toBeTruthy();
   gotoCopybookSettings();
 
-  expect(registerEvent).toHaveBeenCalledWith(
+  expect(telemetryEvent).toHaveBeenCalledWith(
     "Open copybook settings",
     ["COBOL", "copybook", "settings"],
     "The user invokes the open settings quick fix to see the copybook locations stored in the settings file",

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
@@ -20,7 +20,7 @@ import { CopybooksCodeActionProvider } from "../services/copybook/CopybooksCodeA
 import { LanguageClientService } from "../services/LanguageClientService";
 import { SnippetCompletionProvider } from "../services/snippetcompletion/SnippetCompletionProvider";
 import { Utils } from "../services/util/Utils";
-import { registerEvent } from "../services/reporter";
+import { telemetryEvent } from "../services/reporter";
 
 jest.mock("../commands/SmartTabCommand");
 jest.mock("../commands/OpenSettingsCommand");
@@ -60,7 +60,7 @@ beforeEach(() => {
 describe("Check plugin extension for cobol starts successfully.", () => {
   test("start extension", async () => {
     await activate(context);
-    expect(registerEvent).toHaveBeenCalledWith(
+    expect(telemetryEvent).toHaveBeenCalledWith(
       "log",
       ["bootstrap", "experiment-tag"],
       "Extension activation event was triggered",
@@ -114,7 +114,7 @@ describe("Check plugin extension for cobol fails.", () => {
 
   test("start fails.", async () => {
     await activate(context);
-    expect(registerEvent).toHaveBeenCalledWith(
+    expect(telemetryEvent).toHaveBeenCalledWith(
       "log",
       ["bootstrap", "experiment-tag"],
       "Extension activation event was triggered",

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/LanguageClientServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/LanguageClientServiceTest.spec.ts
@@ -24,7 +24,7 @@ import { Utils } from "../../services/util/Utils";
 import { EXP_LANGUAGE_ID, HP_LANGUAGE_ID } from "../../constants";
 import { mockSpawnProcess } from "../../__mocks__/child_process.utility";
 import { getErrorMessage } from "../../services/util/ErrorsUtils";
-import { registerEvent } from "../../services/reporter";
+import { telemetryEvent } from "../../services/reporter";
 import { outputChannel } from "../../services/util/OutputChannel";
 import { SettingsService } from "../../services/Settings";
 
@@ -75,7 +75,7 @@ describe("LanguageClientService positive scenario", () => {
     jest.spyOn(fs, "existsSync").mockReturnValue(true);
     languageClientService.enableNativeBuild();
 
-    expect(registerEvent).toHaveBeenCalledWith(
+    expect(telemetryEvent).toHaveBeenCalledWith(
       "Native Build enabled",
       ["COBOL", "native build enabled", "settings"],
       "Native build enabled",

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybooksCodeActionProviderTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybooksCodeActionProviderTest.spec.ts
@@ -17,7 +17,7 @@ jest.mock("../../../services/reporter");
 import * as vscode from "vscode";
 import { CopybooksCodeActionProvider } from "../../../services/copybook/CopybooksCodeActionProvider";
 import { Utils } from "../../../services/util/Utils";
-import { registerEvent } from "../../../services/reporter";
+import { telemetryEvent } from "../../../services/reporter";
 
 describe("Test Copybook code action provider", () => {
   const copybooksCodeAction = new CopybooksCodeActionProvider();
@@ -89,7 +89,7 @@ describe("Test Copybook code action provider", () => {
     expect(
       copybooksCodeAction.provideCodeActions(doc, range, context, token).length,
     ).toBe(1);
-    expect(registerEvent).toHaveBeenCalledWith(
+    expect(telemetryEvent).toHaveBeenCalledWith(
       "QuickFix for copybook activation",
       ["COBOL", "hover", "copybook", "quickfix"],
       "User try to understand the syntax error for a missing copybook",

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/reporter/Telemetry.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/reporter/Telemetry.spec.ts
@@ -24,7 +24,7 @@ import * as path from "path";
 import { TelemetryEventMeasurements } from "../../../services/reporter/model";
 import {
   anonymizeContent,
-  registerEvent,
+  telemetryEvent,
   registerExceptionEvent,
   setReporter,
 } from "../../../services/reporter";
@@ -52,7 +52,7 @@ function runScenario(
   telemetryMeasurements?: TelemetryEventMeasurements,
 ) {
   if (eventType === "log") {
-    registerEvent(eventName!, categories, undefined, telemetryMeasurements);
+    telemetryEvent(eventName!, categories, undefined, telemetryMeasurements);
     expect(spySendTelemetry).toHaveBeenCalledTimes(expectedNumberOfCalls);
   } else {
     registerExceptionEvent(eventName, rootCause!, categories);

--- a/clients/cobol-lsp-vscode-extension/src/commands/OpenSettingsCommand.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/OpenSettingsCommand.ts
@@ -12,10 +12,10 @@
  *   Broadcom, Inc. - initial API and implementation
  */
 import * as vscode from "vscode";
-import { registerEvent } from "../services/reporter";
+import { telemetryEvent } from "../services/reporter";
 
 export function gotoCopybookSettings(): void {
-  registerEvent(
+  telemetryEvent(
     "Open copybook settings",
     ["COBOL", "copybook", "settings"],
     "The user invokes the open settings quick fix to see the copybook locations stored in the settings file",

--- a/clients/cobol-lsp-vscode-extension/src/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/extension.ts
@@ -59,7 +59,7 @@ import * as path from "node:path";
 import { getErrorMessage } from "./services/util/ErrorsUtils";
 import {
   initTelemetry,
-  registerEvent,
+  telemetryEvent,
   registerExceptionEvent,
 } from "./services/reporter";
 import { CopybooksCompletionProvider } from "./services/copybook/CopybooksCompletionProvider";
@@ -146,12 +146,12 @@ export async function activate(
   DialectRegistry.clear();
   const { configurationWatcher, dialectService } = await initialize(context);
   initSmartTab(context);
-  registerEvent(
+  telemetryEvent(
     "log",
     ["bootstrap", "experiment-tag"],
     "Extension activation event was triggered",
   );
-  registerEvent(
+  telemetryEvent(
     "analysis-mode",
     ["bootstrap", "analysis-mode"],
     `COBOL LS is being used in ${vscode.workspace.getConfiguration().get(ANALYSIS_MODE) as string} mode`,

--- a/clients/cobol-lsp-vscode-extension/src/services/ControlFlowService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ControlFlowService.ts
@@ -27,7 +27,7 @@ import {
 import { SettingsService } from "./Settings";
 import { WorkerResultMessage } from "./worker/messages";
 import { GraphDTO } from "@code4z/analysis/lib/model/GraphDTO";
-import { registerEvent, registerExceptionEvent } from "./reporter";
+import { telemetryEvent, registerExceptionEvent } from "./reporter";
 
 const EVENT_ANALYSIS_ERROR = "ccf.analysis.error";
 
@@ -264,7 +264,7 @@ export class ControlFlowAnalysisService implements AnalysisServiceDelegate {
     this.diagnosticService.showAllDiagnostics(documentUri, diagnostics);
     events.forEach((event) => {
       if ("eventName" in event) {
-        registerEvent(event.eventName, ["ccf"], event.message);
+        telemetryEvent(event.eventName, ["ccf"], event.message);
       } else {
         registerExceptionEvent(event.errorName, event.message, ["ccf"]);
       }

--- a/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
@@ -33,7 +33,7 @@ import { HP_LANGUAGE_ID, EXP_LANGUAGE_ID, LANGUAGE_ID } from "../constants";
 import { JavaCheck } from "./JavaCheck";
 import { NativeExecutableService } from "./nativeLanguageClient/nativeExecutableService";
 import { SettingsService } from "./Settings";
-import { registerEvent } from "./reporter";
+import { telemetryEvent } from "./reporter";
 import { setupBridge4GitWatcher } from "./BridgeForGitLoader";
 import {
   setUpProcessorGroupConfigWatcher,
@@ -71,7 +71,7 @@ export class LanguageClientService {
 
   public enableNativeBuild() {
     this.isNativeBuildEnabled = true;
-    registerEvent(
+    telemetryEvent(
       "Native Build enabled",
       ["COBOL", "native build enabled", "settings"],
       "Native build enabled",

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybooksCodeActionProvider.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybooksCodeActionProvider.ts
@@ -13,7 +13,7 @@
  */
 import * as vscode from "vscode";
 import { QUICKFIX_GOTOSETTINGS } from "../../constants";
-import { registerEvent } from "../reporter";
+import { telemetryEvent } from "../reporter";
 
 export class CopybooksCodeActionProvider implements vscode.CodeActionProvider {
   public provideCodeActions(
@@ -26,7 +26,7 @@ export class CopybooksCodeActionProvider implements vscode.CodeActionProvider {
       return [];
     }
     // Telemetry should be collected only if shouldHaveCodeAction is true
-    registerEvent(
+    telemetryEvent(
       "QuickFix for copybook activation",
       ["COBOL", "hover", "copybook", "quickfix"],
       "User try to understand the syntax error for a missing copybook",

--- a/clients/cobol-lsp-vscode-extension/src/services/nativeLanguageClient/serverRuntimeCodeActionProvider.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/nativeLanguageClient/serverRuntimeCodeActionProvider.ts
@@ -16,7 +16,7 @@ import {
   QUICKFIX_UPDATE_DIALECTSSETTINGS,
   QUICKFIX_UPDATE_SERVER_TO_JAVA,
 } from "../../constants";
-import { registerEvent } from "../reporter";
+import { telemetryEvent } from "../reporter";
 
 export class ServerRuntimeCodeActionProvider
   implements vscode.CodeActionProvider
@@ -31,7 +31,7 @@ export class ServerRuntimeCodeActionProvider
       return [];
     }
     // Telemetry should be collected only if shouldHaveCodeAction is true
-    registerEvent(
+    telemetryEvent(
       "QuickFix for server type",
       ["COBOL", "native server", "server type", "quickfix"],
       "User is trying to fix in compatible server type and dialects",

--- a/clients/cobol-lsp-vscode-extension/src/services/reporter/index.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/reporter/index.ts
@@ -41,7 +41,7 @@ export async function initTelemetry(context: vscode.ExtensionContext) {
  * @param notes optional brief description
  * @param telemetryMeasurement optional set of numeric data with a key name
  */
-export function registerEvent(
+export function telemetryEvent(
   eventName: string,
   categories?: string[],
   notes?: string,

--- a/clients/cobol-lsp-vscode-extension/src/services/util/ConfigurationWatcher.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/ConfigurationWatcher.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 import { SERVER_RUNTIME } from "../../constants";
 import { SettingsService } from "../Settings";
-import { registerEvent } from "../reporter";
+import { telemetryEvent } from "../reporter";
 import { clearDiagnostics } from "../ExternalAPIsService";
 
 export class ConfigurationWatcher {
@@ -29,7 +29,7 @@ export class ConfigurationWatcher {
       return;
     }
     if (selection === "Ok") {
-      registerEvent(
+      telemetryEvent(
         "serverRuntime modified by user",
         ["COBOL", "serverRuntime", "settings"],
         `Server type modified by user to ${this.getServerRuntime()}`,

--- a/clients/cobol-lsp-vscode-extension/src/web/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/web/extension.ts
@@ -20,7 +20,7 @@ import {
 } from "../services/snippetcompletion/SnippetCompletionProvider";
 import { LANGUAGE_ID } from "../constants";
 import { initSmartTab, RangeTabShiftStore } from "../commands/SmartTabCommand";
-import { initTelemetry, registerEvent } from "../services/reporter";
+import { initTelemetry, telemetryEvent } from "../services/reporter";
 import { SubroutinesCompletionsProvider } from "../services/subroutines/SubroutinesCompletionsProvider";
 import { CopybooksCompletionProvider } from "../services/copybook/CopybooksCompletionProvider";
 import { initializeExternalAPIs } from "../services/ExternalAPIsService";
@@ -29,7 +29,7 @@ import { createSampleConfiguration } from "../commands/CreateSampleConfiguration
 
 export async function activate(context: ExtensionContext) {
   await initTelemetry(context);
-  registerEvent(
+  telemetryEvent(
     "log",
     ["bootstrap", "experiment-tag"],
     "Web extension activation event was triggered",


### PR DESCRIPTION
No functional changes. Just rename `registerEvent` to the more accurate `telemetryEvent`.