### PR TITLE
fix: do not consider string quoted exec statement as implicit dialect

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlLexer.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/implicitDialects/sql/Db2SqlLexer.g4
@@ -74,7 +74,7 @@ DOUBLEDIGIT_1: '01';
 SINGLEDIGITLITERAL : DIGIT;
 INTEGERLITERAL : DIGIT+;
 IDENTIFIER : [\p{Alnum}\p{General_Category=Other_Letter}] [-_\p{Alnum}\p{General_Category=Other_Letter}]*;
-
+QUOTED_STRING: SINGLE_QUOTED_STRINGLITERAL | DOUBLE_QUOTED_STRINGLITERAL;
 NUMERICLITERAL : (PLUSCHAR | MINUSCHAR)? DIGIT* (DOT_FS | COMMACHAR) DIGIT+ (('e' | 'E') (PLUSCHAR | MINUSCHAR)? DIGIT+)?;
 // whitespace, line breaks, comments, ...
 NEWLINE : '\r'? '\n' -> channel(HIDDEN);
@@ -83,6 +83,13 @@ WS : [ \t\f]+ -> channel(HIDDEN);
 // treat all the non-processed tokens as errors
 ERRORCHAR : . ;
 
+fragment SINGLE_QUOTED_STRINGLITERAL :
+	'\'' (~['\n\r] | '\'\'' | '"')* '\''
+;
+
+fragment DOUBLE_QUOTED_STRINGLITERAL :
+	'"' (~["\n\r] | '""' | '\'')* '"'
+;
 
  fragment DIGIT: [0-9];
  // case insensitive chars

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestExecStatmentIsProcessedWhenNotAStringQuoted.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestExecStatmentIsProcessedWhenNotAStringQuoted.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** Test exec statement inside a quoted string is not considered as implicit dialect */
+public class TestExecStatmentIsProcessedWhenNotAStringQuoted {
+  public static final String TEXT_EXEC_SQL =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. test12.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       DATA DIVISION.\n"
+          + "        WORKING-STORAGE SECTION.\n"
+          + "        01 {$*WERR} pic x.\n"
+          + "        LINKAGE SECTION.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           DISPLAY \"CHECK EXEC SQL STATE\".\n"
+          + "             STOP RUN.";
+
+  public static final String TEXT_EXEC_CICS =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. test12.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       DATA DIVISION.\n"
+          + "        WORKING-STORAGE SECTION.\n"
+          + "        01 {$*WERR} pic x.\n"
+          + "        LINKAGE SECTION.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           DISPLAY \"CHECK EXEC CICS STATE\".\n"
+          + "             STOP RUN.";
+
+  @Test
+  void testExecSqlStringQuoted() {
+    UseCaseEngine.runTest(TEXT_EXEC_SQL, ImmutableList.of(), ImmutableMap.of());
+  }
+
+  @Test
+  void testExecCicsStringQuoted() {
+    UseCaseEngine.runTest(TEXT_EXEC_CICS, ImmutableList.of(), ImmutableMap.of());
+  }
+}


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test below code has 0 diagnostics
```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. test12.
       ENVIRONMENT DIVISION.
       DATA DIVISION.
        WORKING-STORAGE SECTION.
        01 WERR pic x.
        LINKAGE SECTION.
       PROCEDURE DIVISION.
           MOVE "|091IT'S FORBIDDEN TO CODE '�=' IN AN EXEC SQL STATE
      -        "MENT ; USE '^=' OR '<>' INSTEAD" TO WERR
             STOP RUN.
``` 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
