### PR TITLE
feat: Improve mapping functionality

### DIFF
--- a/server/common/pom.xml
+++ b/server/common/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>common</artifactId>
     <groupId>org.eclipse.lsp.cobol</groupId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
 
     <properties>
         <maven.compiler.release>8</maven.compiler.release>

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedDocument.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedDocument.java
@@ -15,6 +15,7 @@
 package org.eclipse.lsp.cobol.common.mapping;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import lombok.Getter;
 import org.eclipse.lsp.cobol.common.model.Locality;
@@ -167,11 +168,11 @@ public class ExtendedDocument {
    *
    * @param range - range of text to replace
    * @param statementRange - a statement range within the text range
-   * @param statementMap - an original text map
+   * @param statementMap - a map of token names and its ranges from the original text
    * @param replacementMap - a new text replacement map
    */
   public void replace(
-      Range range, Range statementRange, String statementMap, String replacementMap) {
+      Range range, Range statementRange, Map<String, Range> statementMap, String replacementMap) {
     Range updatedRange = updateRangeDueToChanges(range);
     currentText.replace(updatedRange, statementRange, statementMap, replacementMap);
     dirty = true;

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedDocument.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedDocument.java
@@ -162,6 +162,21 @@ public class ExtendedDocument {
     dirty = true;
   }
 
+  /**
+   * Replaces given range of text with a new text using replacement map
+   *
+   * @param range - range of text to replace
+   * @param statementRange - a statement range within the text range
+   * @param statementMap - an original text map
+   * @param replacementMap - a new text replacement map
+   */
+  public void replace(
+      Range range, Range statementRange, String statementMap, String replacementMap) {
+    Range updatedRange = updateRangeDueToChanges(range);
+    currentText.replace(updatedRange, statementRange, statementMap, replacementMap);
+    dirty = true;
+  }
+
   public void delete(int lineNumber) {
     int deleteLine = updateLineDueToChanges(lineNumber);
     currentText.delete(deleteLine);

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedText.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedText.java
@@ -29,6 +29,7 @@ public class ExtendedText {
   private final List<ExtendedTextLine> lines = new ArrayList<>();
   private final List<Mapper> mappers;
   private final List<ReplaceStrategy> replacers;
+  private final TextMapReplacer textMapReplacer;
   @Getter private final String uri;
 
   public ExtendedText(String text, String uri) {
@@ -45,6 +46,7 @@ public class ExtendedText {
             new OneToOneReplaceStrategy(),
             new SingleLineReplaceStrategy(),
             new MultilineReplaceStrategy());
+    this.textMapReplacer = new TextMapReplacer(this);
   }
 
   @Override
@@ -330,6 +332,19 @@ public class ExtendedText {
         return;
       }
     }
+  }
+
+  /**
+   * Replaces given range of text with a new text using replacement map
+   *
+   * @param range - range of text to replace
+   * @param statementRange - a statement range within the text range
+   * @param statementMap - an original text map
+   * @param replacementMap - a new text replacement map
+   */
+  public void replace(
+      Range range, Range statementRange, String statementMap, String replacementMap) {
+    this.textMapReplacer.execute(range, statementRange, statementMap, replacementMap);
   }
 
   private MappedCharacter getCharacterAt(Position position) {

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedText.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedText.java
@@ -29,7 +29,6 @@ public class ExtendedText {
   private final List<ExtendedTextLine> lines = new ArrayList<>();
   private final List<Mapper> mappers;
   private final List<ReplaceStrategy> replacers;
-  private final TextMapReplacer textMapReplacer;
   @Getter private final String uri;
 
   public ExtendedText(String text, String uri) {
@@ -46,7 +45,6 @@ public class ExtendedText {
             new OneToOneReplaceStrategy(),
             new SingleLineReplaceStrategy(),
             new MultilineReplaceStrategy());
-    this.textMapReplacer = new TextMapReplacer(this);
   }
 
   @Override
@@ -344,7 +342,7 @@ public class ExtendedText {
    */
   public void replace(
       Range range, Range statementRange, String statementMap, String replacementMap) {
-    this.textMapReplacer.execute(range, statementRange, statementMap, replacementMap);
+    TextMapReplacer.execute(this, range, statementRange, statementMap, replacementMap);
   }
 
   private MappedCharacter getCharacterAt(Position position) {

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedText.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedText.java
@@ -17,6 +17,7 @@ package org.eclipse.lsp.cobol.common.mapping;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import lombok.Getter;
@@ -337,11 +338,11 @@ public class ExtendedText {
    *
    * @param range - range of text to replace
    * @param statementRange - a statement range within the text range
-   * @param statementMap - an original text map
+   * @param statementMap - a map of token names and its ranges from the original text
    * @param replacementMap - a new text replacement map
    */
   public void replace(
-      Range range, Range statementRange, String statementMap, String replacementMap) {
+      Range range, Range statementRange, Map<String, Range> statementMap, String replacementMap) {
     TextMapReplacer.execute(this, range, statementRange, statementMap, replacementMap);
   }
 

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedText.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedText.java
@@ -300,7 +300,7 @@ public class ExtendedText {
    */
   public void addLineBreak(Position position) {
     ExtendedTextLine line = lines.get(position.getLine());
-    ExtendedTextLine newLine = line.subline(position.getCharacter(), line.size() - 1);
+    ExtendedTextLine newLine = line.subline(position.getCharacter(), line.size());
     line.trim(position.getCharacter());
 
     lines.add(position.getLine() + 1, newLine);

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextLine.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextLine.java
@@ -127,12 +127,12 @@ public class ExtendedTextLine {
    * Creates a new line objects with characters in the given range
    *
    * @param start - start position of the range
-   * @param end - end position of the range
+   * @param end - exclusive end position of the range
    * @return a new line object
    */
   ExtendedTextLine subline(int start, int end) {
     List<MappedCharacter> newCharacters =
-        characters.subList(start, end + 1).stream()
+        characters.subList(start, end).stream()
             .map(MappedCharacter::shadowCopy)
             .collect(Collectors.toList());
 

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/MappingHelper.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/MappingHelper.java
@@ -15,6 +15,7 @@
 package org.eclipse.lsp.cobol.common.mapping;
 
 import lombok.experimental.UtilityClass;
+import org.eclipse.lsp4j.Range;
 
 /** Maping helper class */
 @UtilityClass
@@ -29,5 +30,20 @@ public class MappingHelper {
    */
   public String[] split(String text) {
     return text.split(SEPARATOR);
+  }
+
+  static void validateRange(Range range) {
+    if (range.getStart().getLine() < 0 || range.getEnd().getLine() < 0) {
+      throw new IllegalArgumentException("Invalid range");
+    }
+    if (range.getStart().getLine() > range.getEnd().getLine()) {
+      throw new IllegalArgumentException("Invalid range");
+    }
+    if (range.getStart().getCharacter() < 0 || range.getEnd().getCharacter() < 0) {
+      throw new IllegalArgumentException("Invalid range");
+    }
+    if (range.getStart().getCharacter() > range.getEnd().getCharacter()) {
+      throw new IllegalArgumentException("Invalid range");
+    }
   }
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/MappingHelper.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/MappingHelper.java
@@ -42,7 +42,8 @@ public class MappingHelper {
     if (range.getStart().getCharacter() < 0 || range.getEnd().getCharacter() < 0) {
       throw new IllegalArgumentException("Invalid range");
     }
-    if (range.getStart().getCharacter() > range.getEnd().getCharacter()) {
+    if ((range.getStart().getLine() == range.getEnd().getLine())
+        && (range.getStart().getCharacter() > range.getEnd().getCharacter())) {
       throw new IllegalArgumentException("Invalid range");
     }
   }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/MappingHelper.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/MappingHelper.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.lsp.cobol.common.mapping;
 
+import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 import org.eclipse.lsp4j.Range;
 
@@ -32,19 +33,25 @@ public class MappingHelper {
     return text.split(SEPARATOR);
   }
 
-  static void validateRange(Range range) {
+  static void validateRange(@NonNull Range range) {
+    if (range.getStart() == null) {
+      throw new IllegalArgumentException("Range start is null");
+    }
+    if (range.getEnd() == null) {
+      throw new IllegalArgumentException("Range end is null");
+    }
     if (range.getStart().getLine() < 0 || range.getEnd().getLine() < 0) {
-      throw new IllegalArgumentException("Invalid range");
+      throw new IllegalArgumentException("Invalid range: " + range);
     }
     if (range.getStart().getLine() > range.getEnd().getLine()) {
-      throw new IllegalArgumentException("Invalid range");
+      throw new IllegalArgumentException("Invalid range: " + range);
     }
     if (range.getStart().getCharacter() < 0 || range.getEnd().getCharacter() < 0) {
-      throw new IllegalArgumentException("Invalid range");
+      throw new IllegalArgumentException("Invalid range: " + range);
     }
     if ((range.getStart().getLine() == range.getEnd().getLine())
         && (range.getStart().getCharacter() > range.getEnd().getCharacter())) {
-      throw new IllegalArgumentException("Invalid range");
+      throw new IllegalArgumentException("Invalid range: " + range);
     }
   }
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/SingleLineReplaceStrategy.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/SingleLineReplaceStrategy.java
@@ -43,7 +43,7 @@ class SingleLineReplaceStrategy implements ReplaceStrategy {
       extendedText.insert(
           new Position(position.getLine() + 1, 0),
           new ExtendedTextLine(newLines[newLines.length - 1], instantLocation));
-      for (int i = 1; i < newLines.length - 2; i++) {
+      for (int i = 1; i < newLines.length - 1; i++) {
         extendedText.insert(
             position.getLine() + i, new ExtendedTextLine(newLines[i], instantLocation));
       }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2025 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.common.mapping;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+/**
+ * Replacer of the text with the replacement map. Replacement text is also a map that contains token
+ * names. The actual replacement data will be calculated using token names. And the original value
+ * of the token, situated in the appropriate range. For example: text document contains the line:
+ * "this and this text will be replaced" (*). The statement map can be: "{this} and {that}" (1).
+ * {this} points to 1st "this" token and {that} points to the 2nd "this" token. These token names:
+ * {this} and {that} now can be replaced with the replacement map. Replacement map can be: "{this}
+ * and even {that} text was replaced" (2). When TextMapReplacer apply replacement using (1)
+ * statement map and replacement map (2) to the document line "this and this text will be replaced"
+ * the result will be: "this and even that text was replaced", so token name {that} was substituted
+ * with actual token value "this". The mapping location for the 1st "this" token will be pointing to
+ * the 1st original "this" token and for the 2nd "this" token mapping will be pointing to the 2nd
+ * original "this" token. All other characters will be pointed to the provided range
+ */
+@AllArgsConstructor
+class TextMapReplacer {
+  private final ExtendedText extendedText;
+
+  @Value
+  private static class Token {
+    String value;
+    Location originalLocation;
+  }
+
+  /**
+   * Replaces given range of text with a new text using replacement map
+   *
+   * @param range - range of text to replace
+   * @param statementRange - a statement range within the text range
+   * @param statementMap - an original text map
+   * @param replacementMap - a new text replacement map
+   */
+  public void execute(
+      Range range, Range statementRange, String statementMap, String replacementMap) {
+    Map<String, Token> tokens = new HashMap<>();
+
+    Location statementLocation = extendedText.mapLocation(statementRange);
+
+    String[] statementMapArray = MappingHelper.split(statementMap);
+    String[] replacementMapArray = MappingHelper.split(replacementMap);
+
+    for (int i = 0; i < statementMapArray.length; i++) {
+      scanForTokens(tokens, statementMapArray, i, range);
+    }
+
+    extendedText.replace(range, replacementMap, statementLocation);
+
+    for (int i = 0; i < replacementMapArray.length; i++) {
+      applyReplacementForLine(tokens, replacementMapArray, i, range);
+    }
+  }
+
+  private void scanForTokens(
+      Map<String, Token> tokens, String[] statementMapArray, int index, Range range) {
+    char[] statementLine = statementMapArray[index].toCharArray();
+
+    int symbolCount = 0;
+    StringBuilder temp = new StringBuilder();
+
+    for (int i = 0; i < statementLine.length; i++) {
+      if (symbolCount % 2 == 0) {
+        if (statementLine[i] == '{') {
+          symbolCount++;
+        }
+      } else {
+        if (statementLine[i] == '}') {
+          int line = range.getStart().getLine() + index;
+          int character = range.getStart().getCharacter() + i - symbolCount - temp.length();
+          Location originalLocation =
+              extendedText.mapLocation(
+                  new Range(
+                      new Position(line, character),
+                      new Position(line, character + temp.length() - 1)));
+          ExtendedTextLine extendedTextLine = extendedText.getLines().get(line);
+          String value =
+              extendedTextLine.subline(character, character + temp.length() - 1).toString();
+
+          tokens.put(temp.toString(), new Token(value, originalLocation));
+
+          symbolCount++;
+          temp = new StringBuilder();
+        } else {
+          temp.append(statementLine[i]);
+        }
+      }
+    }
+  }
+
+  private void applyReplacementForLine(
+      Map<String, Token> tokens, String[] replacementMapArray, int index, Range range) {
+    char[] replacementLine = replacementMapArray[index].toCharArray();
+
+    int symbolCount = 0;
+    StringBuilder temp = new StringBuilder();
+
+    for (int i = 0; i < replacementLine.length; i++) {
+      if (symbolCount % 2 == 0) {
+        if (replacementLine[i] == '{') {
+          symbolCount++;
+        }
+      } else {
+        if (replacementLine[i] == '}') {
+          int line = range.getStart().getLine() + index;
+          int character = range.getStart().getCharacter() + i - symbolCount - temp.length();
+
+          Token token = tokens.get(temp.toString());
+          Range tokenRange =
+              new Range(
+                  new Position(line, character), new Position(line, character + temp.length() + 2));
+          extendedText.replace(tokenRange, token.getValue(), token.getOriginalLocation());
+
+          symbolCount++;
+          temp = new StringBuilder();
+        } else {
+          temp.append(replacementLine[i]);
+        }
+      }
+    }
+  }
+}

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -137,7 +137,7 @@ class TextMapReplacer {
             extendedText.mapLocation(
                 new Range(
                     new Position(line, character),
-                    new Position(line, character + tokenName.length() - 1)));
+                    new Position(line, character + tokenName.length())));
         ExtendedTextLine extendedTextLine = extendedText.getLines().get(line);
         String value =
             extendedTextLine.subline(character, character + tokenName.length() - 1).toString();

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -65,9 +65,17 @@ class TextMapReplacer {
       Range range, Range statementRange, String statementMap, String replacementMap) {
     Map<String, Token> tokens = new HashMap<>();
 
+    MappingHelper.validateRange(range);
+    MappingHelper.validateRange(statementRange);
+    validateMapSize(statementMap);
+    validateMapSize(replacementMap);
+
     String[] statementMapArray = MappingHelper.split(statementMap);
     for (int i = 0; i < statementMapArray.length; i++) {
       scanForTokens(tokens, statementMapArray, i, range);
+    }
+    if (tokens.isEmpty()) {
+      throw new IllegalArgumentException("Statement map must contain at least 1 token name");
     }
 
     Map<Range, Token> tokenReplacements = new HashMap<>();
@@ -85,38 +93,69 @@ class TextMapReplacer {
   }
 
   private void scanForTokens(
-      Map<String, Token> tokens, String[] statementMapArray, int index, Range range) {
-    char[] statementLine = statementMapArray[index].toCharArray();
+      Map<String, Token> tokens, String[] statementMapArray, int mapLine, Range range) {
+    char[] statementLine = statementMapArray[mapLine].toCharArray();
 
+    int bracesIndicator = 0;
     int symbolCount = 0;
     StringBuilder temp = new StringBuilder();
 
     for (int i = 0; i < statementLine.length; i++) {
-      if (symbolCount % 2 == 0) {
-        if (statementLine[i] == BRACE_OPEN) {
-          symbolCount++;
-        }
-      } else {
-        if (statementLine[i] == BRACE_CLOSE) {
-          int line = range.getStart().getLine() + index;
-          int character = i - symbolCount - temp.length();
-          Location originalLocation =
-              extendedText.mapLocation(
-                  new Range(
-                      new Position(line, character),
-                      new Position(line, character + temp.length() - 1)));
-          ExtendedTextLine extendedTextLine = extendedText.getLines().get(line);
-          String value =
-              extendedTextLine.subline(character, character + temp.length() - 1).toString();
+      int line = range.getStart().getLine() + mapLine;
 
-          tokens.put(temp.toString(), new Token(value, originalLocation));
-
-          symbolCount++;
-          temp = new StringBuilder();
-        } else {
-          temp.append(statementLine[i]);
+      if (statementLine[i] == BRACE_OPEN) {
+        if (bracesIndicator > 0) {
+          String message =
+              String.format("expected \"%s\" instead of \"%s\"", BRACE_CLOSE, BRACE_OPEN);
+          throwInvalidParameters("Statement map error", message, mapLine, i);
         }
+        bracesIndicator++;
+        symbolCount++;
+      } else if (statementLine[i] == BRACE_CLOSE) {
+        if (bracesIndicator <= 0) {
+          String message =
+              String.format("expected \"%s\" instead of \"%s\"", BRACE_OPEN, BRACE_CLOSE);
+          throwInvalidParameters("Statement map error", message, mapLine, i);
+        }
+        bracesIndicator--;
+
+        String tokenName = temp.toString();
+        int character = i - symbolCount - tokenName.length();
+
+        if (tokenName.isEmpty()) {
+          throwInvalidParameters(
+              "Statement map error", "token name cannot be empty", mapLine, i - 1);
+        }
+        if (tokens.containsKey(tokenName)) {
+          throwInvalidParameters(
+              String.format("Statement map contains duplicated token \"%s\"", tokenName),
+              mapLine,
+              i - tokenName.length());
+        }
+
+        Location originalLocation =
+            extendedText.mapLocation(
+                new Range(
+                    new Position(line, character),
+                    new Position(line, character + tokenName.length() - 1)));
+        ExtendedTextLine extendedTextLine = extendedText.getLines().get(line);
+        String value =
+            extendedTextLine.subline(character, character + tokenName.length() - 1).toString();
+
+        tokens.put(tokenName, new Token(value, originalLocation));
+
+        symbolCount++;
+        temp = new StringBuilder();
+      } else if (bracesIndicator == 1) {
+        temp.append(statementLine[i]);
       }
+    }
+    if (bracesIndicator > 0) {
+      throwInvalidParameters(
+          "Statement map error",
+          "opening brace { has no matching closing brace",
+          mapLine,
+          statementLine.length - 1);
     }
   }
 
@@ -128,14 +167,15 @@ class TextMapReplacer {
     StringBuilder result = new StringBuilder();
     String[] replacementMapArray = MappingHelper.split(replacementMap);
 
-    for (int line = 0; line < replacementMapArray.length; line++) {
-      char[] replacementLine = replacementMapArray[line].toCharArray();
-      boolean bracesOpened = false;
+    for (int mapLine = 0; mapLine < replacementMapArray.length; mapLine++) {
+      char[] replacementLine = replacementMapArray[mapLine].toCharArray();
+      int bracesIndicator = 0;
       boolean escapeCharacter = false;
       StringBuilder tokenName = new StringBuilder();
 
       StringBuilder outputLine = new StringBuilder();
-      for (char c : replacementLine) {
+      for (int i = 0; i < replacementLine.length; i++) {
+        char c = replacementLine[i];
         if (c == ESCAPE_CHAR && !escapeCharacter) {
           escapeCharacter = true;
           continue;
@@ -146,50 +186,108 @@ class TextMapReplacer {
           continue;
         }
         if (c == BRACE_OPEN) {
-          bracesOpened = true;
+          if (bracesIndicator > 0) {
+            String message =
+                String.format("expected \"%s\" instead of \"%s\"", BRACE_CLOSE, BRACE_OPEN);
+            throwInvalidParameters("Replacement map error", message, mapLine, i);
+          }
+          bracesIndicator++;
           continue;
         }
         if (c == BRACE_CLOSE) {
-          bracesOpened = false;
+          if (bracesIndicator <= 0) {
+            String message =
+                String.format("expected \"%s\" instead of \"%s\"", BRACE_OPEN, BRACE_CLOSE);
+            throwInvalidParameters("Replacement map error", message, mapLine, i);
+          }
+          bracesIndicator--;
 
           ImmutablePair<String, String> tokenNameAndValue =
-              getTokenNameAndValue(tokenName.toString());
+              getTokenNameAndValue(tokenName.toString(), mapLine, i - tokenName.length());
 
           Token token = tokens.get(tokenNameAndValue.getLeft());
-          if (token != null) {
-            String value =
-                Optional.ofNullable(tokenNameAndValue.getRight()).orElse(token.getValue());
-            int character = outputLine.length() + (line == 0 ? startPosition.getCharacter() : 0);
-            Range range =
-                new Range(
-                    new Position(startPosition.getLine() + line, character),
-                    new Position(startPosition.getLine() + line, character + value.length()));
-            tokenReplacements.put(range, new Token(value, token.getOriginalLocation()));
-            outputLine.append(value);
+
+          if (token == null) {
+            String message = String.format("token \"%s\" not found", tokenNameAndValue.getLeft());
+            throwInvalidParameters(
+                "Replacement map error", message, mapLine, i - tokenName.length());
           }
+          String value = Optional.ofNullable(tokenNameAndValue.getRight()).orElse(token.getValue());
+          int character = outputLine.length() + (mapLine == 0 ? startPosition.getCharacter() : 0);
+          Range range =
+              new Range(
+                  new Position(startPosition.getLine() + mapLine, character),
+                  new Position(startPosition.getLine() + mapLine, character + value.length()));
+          tokenReplacements.put(range, new Token(value, token.getOriginalLocation()));
+          outputLine.append(value);
+
           tokenName = new StringBuilder();
           continue;
         }
-        if (bracesOpened) {
+        if (bracesIndicator > 0) {
           tokenName.append(c);
         } else {
           outputLine.append(c);
         }
       }
-      if (line != replacementMapArray.length - 1) {
+      if (mapLine != replacementMapArray.length - 1) {
         outputLine.append("\n");
       }
       result.append(outputLine);
+      if (bracesIndicator > 0) {
+        throwInvalidParameters(
+            "Replacement map error",
+            "opening brace { has no matching closing brace",
+            mapLine,
+            replacementLine.length - 1);
+      }
     }
     return result.toString();
   }
 
-  private ImmutablePair<String, String> getTokenNameAndValue(String token) {
+  private ImmutablePair<String, String> getTokenNameAndValue(
+      String token, int line, int character) {
     int indexOfSeparator = token.indexOf(VALUE_REPLACEMENT_CHAR);
-    if (indexOfSeparator > 0) {
-      return new ImmutablePair<>(
-          token.substring(0, indexOfSeparator), token.substring(indexOfSeparator + 1));
+    if (indexOfSeparator >= 0) {
+      String name = token.substring(0, indexOfSeparator);
+      String value = token.substring(indexOfSeparator + 1);
+
+      if (value.isEmpty()) {
+        throwInvalidParameters(
+            "Replacement map error",
+            "token value cannot be empty",
+            line,
+            character + name.length() + 1);
+      }
+      int nextSeparator = value.indexOf(VALUE_REPLACEMENT_CHAR);
+      if (nextSeparator > 0) {
+        String message =
+            String.format("duplicated separator symbol \"%s\"", VALUE_REPLACEMENT_CHAR);
+        throwInvalidParameters(
+            "Replacement map error", message, line, character + nextSeparator + name.length() + 1);
+      }
+      return new ImmutablePair<>(name, value);
     }
     return new ImmutablePair<>(token, null);
+  }
+
+  private String generatePositionString(int line, int character) {
+    return String.format("Line: %d, character: %d", line, character);
+  }
+
+  private void validateMapSize(String map) {
+    if (Optional.ofNullable(map).map(String::length).orElse(0) <= 0) {
+      throw new IllegalArgumentException("Map cannot be empty");
+    }
+  }
+
+  private void throwInvalidParameters(String header, String message, int line, int character) {
+    throw new IllegalArgumentException(
+        String.format("%s: %s. %s", header, message, generatePositionString(line, character)));
+  }
+
+  private void throwInvalidParameters(String message, int line, int character) {
+    throw new IllegalArgumentException(
+        String.format("%s. %s", message, generatePositionString(line, character)));
   }
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -17,8 +17,8 @@ package org.eclipse.lsp.cobol.common.mapping;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
 import lombok.Value;
+import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -38,14 +38,12 @@ import org.eclipse.lsp4j.Range;
  * the 1st original "this" token and for the 2nd "this" token mapping will be pointing to the 2nd
  * original "this" token. All other characters will be pointed to the provided range
  */
-@AllArgsConstructor
+@UtilityClass
 class TextMapReplacer {
   private static final char BRACE_OPEN = '{';
   private static final char BRACE_CLOSE = '}';
   private static final char ESCAPE_CHAR = '&';
   private static final char VALUE_REPLACEMENT_CHAR = '|';
-
-  private final ExtendedText extendedText;
 
   @Value
   private static class Token {
@@ -56,13 +54,18 @@ class TextMapReplacer {
   /**
    * Replaces given range of text with a new text using replacement map
    *
+   * @param extendedText - the extended text object
    * @param range - range of text to replace
    * @param statementRange - a statement range within the text range
    * @param statementMap - an original text map
    * @param replacementMap - a new text replacement map
    */
   public void execute(
-      Range range, Range statementRange, String statementMap, String replacementMap) {
+      ExtendedText extendedText,
+      Range range,
+      Range statementRange,
+      String statementMap,
+      String replacementMap) {
     Map<String, Token> tokens = new HashMap<>();
 
     MappingHelper.validateRange(range);
@@ -72,7 +75,12 @@ class TextMapReplacer {
 
     String[] statementMapArray = MappingHelper.split(statementMap);
     for (int i = 0; i < statementMapArray.length; i++) {
-      scanForTokens(tokens, statementMapArray[i].toCharArray(), i, range.getStart().getLine() + i);
+      scanForTokens(
+          extendedText,
+          tokens,
+          statementMapArray[i].toCharArray(),
+          i,
+          range.getStart().getLine() + i);
     }
     if (tokens.isEmpty()) {
       throw new IllegalArgumentException("Statement map must contain at least 1 token name");
@@ -93,7 +101,11 @@ class TextMapReplacer {
   }
 
   private void scanForTokens(
-      Map<String, Token> tokens, char[] statementLine, int mapLine, int line) {
+      ExtendedText extendedText,
+      Map<String, Token> tokens,
+      char[] statementLine,
+      int mapLine,
+      int line) {
     int bracesIndicator = 0;
     int symbolCount = 0;
     StringBuilder temp = new StringBuilder();

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -72,7 +72,7 @@ class TextMapReplacer {
 
     String[] statementMapArray = MappingHelper.split(statementMap);
     for (int i = 0; i < statementMapArray.length; i++) {
-      scanForTokens(tokens, statementMapArray, i, range);
+      scanForTokens(tokens, statementMapArray[i].toCharArray(), i, range.getStart().getLine() + i);
     }
     if (tokens.isEmpty()) {
       throw new IllegalArgumentException("Statement map must contain at least 1 token name");
@@ -94,15 +94,11 @@ class TextMapReplacer {
 
   private void scanForTokens(
       Map<String, Token> tokens, char[] statementLine, int mapLine, int line) {
-    char[] statementLine = statementMapArray[mapLine].toCharArray();
-
     int bracesIndicator = 0;
     int symbolCount = 0;
     StringBuilder temp = new StringBuilder();
 
     for (int i = 0; i < statementLine.length; i++) {
-      int line = range.getStart().getLine() + mapLine;
-
       if (statementLine[i] == BRACE_OPEN) {
         if (bracesIndicator > 0) {
           String message =
@@ -221,7 +217,7 @@ class TextMapReplacer {
           tokenReplacements.put(range, new Token(value, token.getOriginalLocation()));
           outputLine.append(value);
 
-          tokenWithValue.setLength(0);
+          tokenName.setLength(0);
           continue;
         }
         if (bracesIndicator > 0) {
@@ -238,6 +234,13 @@ class TextMapReplacer {
         throwInvalidParameters(
             "Replacement map error",
             "opening brace { has no matching closing brace",
+            mapLine,
+            replacementLine.length - 1);
+      }
+      if (escapeCharacter) {
+        throwInvalidParameters(
+            "Replacement map error",
+            "Dangling escape character in the input string",
             mapLine,
             replacementLine.length - 1);
       }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -15,6 +15,7 @@
 package org.eclipse.lsp.cobol.common.mapping;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.Value;
@@ -57,36 +58,26 @@ class TextMapReplacer {
    * @param extendedText - the extended text object
    * @param range - range of text to replace
    * @param statementRange - a statement range within the text range
-   * @param statementMap - an original text map
+   * @param statementMap - a map of token names and its ranges from the original text
    * @param replacementMap - a new text replacement map
    */
   public void execute(
       ExtendedText extendedText,
       Range range,
       Range statementRange,
-      String statementMap,
+      Map<String, Range> statementMap,
       String replacementMap) {
-    Map<String, Token> tokens = new HashMap<>();
 
     MappingHelper.validateRange(range);
     MappingHelper.validateRange(statementRange);
-    validateMapSize(statementMap);
     validateMapSize(replacementMap);
-
-    String[] statementMapArray = MappingHelper.split(statementMap);
-    for (int i = 0; i < statementMapArray.length; i++) {
-      scanForTokens(
-          extendedText,
-          tokens,
-          statementMapArray[i].toCharArray(),
-          i,
-          range.getStart().getLine() + i,
-          i == 0 ? range.getStart().getCharacter() : 0);
-    }
-    if (tokens.isEmpty()) {
+    validateDocumentRange(extendedText, range, "Replacing range error: ");
+    validateDocumentRange(extendedText, statementRange, "Statement range error: ");
+    if (statementMap.isEmpty()) {
       throw new IllegalArgumentException("Statement map must contain at least 1 token name");
     }
 
+    Map<String, Token> tokens = mapStatementTokens(extendedText, statementMap);
     Map<Range, Token> tokenReplacements = new HashMap<>();
     String processedText =
         scanForReplacements(range.getStart(), tokens, replacementMap, tokenReplacements);
@@ -101,72 +92,25 @@ class TextMapReplacer {
         });
   }
 
-  private void scanForTokens(
-      ExtendedText extendedText,
-      Map<String, Token> tokens,
-      char[] statementLine,
-      int mapLine,
-      int line,
-      int startCharacter) {
-    int bracesIndicator = 0;
-    int symbolCount = 0;
-    StringBuilder temp = new StringBuilder();
+  private Map<String, Token> mapStatementTokens(
+      ExtendedText extendedText, Map<String, Range> statementMap) {
+    Map<String, Token> tokens = new HashMap<>();
 
-    for (int i = 0; i < statementLine.length; i++) {
-      if (statementLine[i] == BRACE_OPEN) {
-        if (bracesIndicator > 0) {
-          String message =
-              String.format("expected \"%s\" instead of \"%s\"", BRACE_CLOSE, BRACE_OPEN);
-          throwInvalidParameters("Statement map error", message, mapLine, i);
-        }
-        bracesIndicator++;
-        symbolCount++;
-      } else if (statementLine[i] == BRACE_CLOSE) {
-        if (bracesIndicator <= 0) {
-          String message =
-              String.format("expected \"%s\" instead of \"%s\"", BRACE_OPEN, BRACE_CLOSE);
-          throwInvalidParameters("Statement map error", message, mapLine, i);
-        }
-        bracesIndicator--;
+    statementMap.forEach(
+        (tokenName, range) -> {
+          validateTokenName(extendedText, tokenName, range);
+          Location originalLocation = extendedText.mapLocation(range);
 
-        String tokenName = temp.toString();
-        int character = i - symbolCount - tokenName.length() + startCharacter;
+          ExtendedTextLine extendedTextLine =
+              extendedText.getLines().get(range.getStart().getLine());
+          String value =
+              extendedTextLine
+                  .subline(range.getStart().getCharacter(), range.getEnd().getCharacter() - 1)
+                  .toString();
 
-        if (tokenName.isEmpty()) {
-          throwInvalidParameters(
-              "Statement map error", "token name cannot be empty", mapLine, i - 1);
-        }
-        if (tokens.containsKey(tokenName)) {
-          throwInvalidParameters(
-              String.format("Statement map contains duplicated token \"%s\"", tokenName),
-              mapLine,
-              i - tokenName.length());
-        }
-
-        Location originalLocation =
-            extendedText.mapLocation(
-                new Range(
-                    new Position(line, character),
-                    new Position(line, character + tokenName.length())));
-        ExtendedTextLine extendedTextLine = extendedText.getLines().get(line);
-        String value =
-            extendedTextLine.subline(character, character + tokenName.length() - 1).toString();
-
-        tokens.put(tokenName, new Token(value, originalLocation));
-
-        symbolCount++;
-        temp.setLength(0);
-      } else if (bracesIndicator == 1) {
-        temp.append(statementLine[i]);
-      }
-    }
-    if (bracesIndicator > 0) {
-      throwInvalidParameters(
-          "Statement map error",
-          "opening brace { has no matching closing brace",
-          mapLine,
-          statementLine.length - 1);
-    }
+          tokens.put(tokenName, new Token(value, originalLocation));
+        });
+    return tokens;
   }
 
   private String scanForReplacements(
@@ -215,7 +159,7 @@ class TextMapReplacer {
         if (bracesIndicator > 0) {
           String message =
               String.format("expected \"%s\" instead of \"%s\"", BRACE_CLOSE, BRACE_OPEN);
-          throwInvalidParameters("Replacement map error", message, mapLine, i);
+          throwInvalidParameters(message, mapLine, i);
         }
         bracesIndicator++;
         continue;
@@ -224,7 +168,7 @@ class TextMapReplacer {
         if (bracesIndicator <= 0) {
           String message =
               String.format("expected \"%s\" instead of \"%s\"", BRACE_OPEN, BRACE_CLOSE);
-          throwInvalidParameters("Replacement map error", message, mapLine, i);
+          throwInvalidParameters(message, mapLine, i);
         }
         bracesIndicator--;
 
@@ -235,7 +179,7 @@ class TextMapReplacer {
 
         if (token == null) {
           String message = String.format("token \"%s\" not found", tokenNameAndValue.getLeft());
-          throwInvalidParameters("Replacement map error", message, mapLine, i - tokenName.length());
+          throwInvalidParameters(message, mapLine, i - tokenName.length());
         }
         String value = Optional.ofNullable(tokenNameAndValue.getRight()).orElse(token.getValue());
         int character = outputLine.length() + (mapLine == 0 ? startPosition.getCharacter() : 0);
@@ -257,17 +201,11 @@ class TextMapReplacer {
     }
     if (bracesIndicator > 0) {
       throwInvalidParameters(
-          "Replacement map error",
-          "opening brace { has no matching closing brace",
-          mapLine,
-          replacementLine.length - 1);
+          "opening brace { has no matching closing brace", mapLine, replacementLine.length - 1);
     }
     if (escapeCharacter) {
       throwInvalidParameters(
-          "Replacement map error",
-          "Dangling escape character in the input string",
-          mapLine,
-          replacementLine.length - 1);
+          "Dangling escape character in the input string", mapLine, replacementLine.length - 1);
     }
     return outputLine;
   }
@@ -280,11 +218,7 @@ class TextMapReplacer {
       String value = token.substring(indexOfSeparator + 1);
 
       if (value.isEmpty()) {
-        throwInvalidParameters(
-            "Replacement map error",
-            "token value cannot be empty",
-            line,
-            character + name.length() + 1);
+        throwInvalidParameters("token value cannot be empty", line, character + name.length() + 1);
       }
       return new ImmutablePair<>(name, value);
     }
@@ -301,13 +235,37 @@ class TextMapReplacer {
     }
   }
 
-  private void throwInvalidParameters(String header, String message, int line, int character) {
-    throw new IllegalArgumentException(
-        String.format("%s: %s. %s", header, message, generatePositionString(line, character)));
+  private void validateDocumentRange(ExtendedText extendedText, Range range, String entityName) {
+    List<ExtendedTextLine> lines = extendedText.getLines();
+    if (range.getStart().getLine() >= lines.size()) {
+      throw new IllegalArgumentException(entityName + "range start line out of bounds");
+    }
+    if (range.getStart().getCharacter() > lines.get(range.getStart().getLine()).size()) {
+      throw new IllegalArgumentException(entityName + "range start character out of bounds");
+    }
+    if (range.getEnd().getLine() >= lines.size()) {
+      throw new IllegalArgumentException(entityName + "range end line out of bounds");
+    }
+    if (range.getEnd().getCharacter() > lines.get(range.getEnd().getLine()).size()) {
+      throw new IllegalArgumentException(entityName + "range end character out of bounds");
+    }
+  }
+
+  private void validateTokenName(ExtendedText extendedText, String tokenName, Range range) {
+    MappingHelper.validateRange(range);
+    if (range.getStart().getLine() != range.getEnd().getLine()) {
+      throw new IllegalArgumentException("Token name " + tokenName + " must be on the same line");
+    }
+    if (tokenName.isEmpty()) {
+      throw new IllegalArgumentException("Token name cannot be empty");
+    }
+    validateDocumentRange(extendedText, range, "Token name \"" + tokenName + "\" range error: ");
   }
 
   private void throwInvalidParameters(String message, int line, int character) {
     throw new IllegalArgumentException(
-        String.format("%s. %s", message, generatePositionString(line, character)));
+        String.format(
+            "%s: %s. %s",
+            "Replacement map error", message, generatePositionString(line, character)));
   }
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -165,87 +165,97 @@ class TextMapReplacer {
 
     for (int mapLine = 0; mapLine < replacementMapArray.length; mapLine++) {
       char[] replacementLine = replacementMapArray[mapLine].toCharArray();
-      int bracesIndicator = 0;
-      boolean escapeCharacter = false;
-      StringBuilder tokenName = new StringBuilder();
-
-      StringBuilder outputLine = new StringBuilder();
-      for (int i = 0; i < replacementLine.length; i++) {
-        char c = replacementLine[i];
-        if (c == ESCAPE_CHAR && !escapeCharacter) {
-          escapeCharacter = true;
-          continue;
-        }
-        if (escapeCharacter) {
-          outputLine.append(c);
-          escapeCharacter = false;
-          continue;
-        }
-        if (c == BRACE_OPEN) {
-          if (bracesIndicator > 0) {
-            String message =
-                String.format("expected \"%s\" instead of \"%s\"", BRACE_CLOSE, BRACE_OPEN);
-            throwInvalidParameters("Replacement map error", message, mapLine, i);
-          }
-          bracesIndicator++;
-          continue;
-        }
-        if (c == BRACE_CLOSE) {
-          if (bracesIndicator <= 0) {
-            String message =
-                String.format("expected \"%s\" instead of \"%s\"", BRACE_OPEN, BRACE_CLOSE);
-            throwInvalidParameters("Replacement map error", message, mapLine, i);
-          }
-          bracesIndicator--;
-
-          ImmutablePair<String, String> tokenNameAndValue =
-              getTokenNameAndValue(tokenName.toString(), mapLine, i - tokenName.length());
-
-          Token token = tokens.get(tokenNameAndValue.getLeft());
-
-          if (token == null) {
-            String message = String.format("token \"%s\" not found", tokenNameAndValue.getLeft());
-            throwInvalidParameters(
-                "Replacement map error", message, mapLine, i - tokenName.length());
-          }
-          String value = Optional.ofNullable(tokenNameAndValue.getRight()).orElse(token.getValue());
-          int character = outputLine.length() + (mapLine == 0 ? startPosition.getCharacter() : 0);
-          Range range =
-              new Range(
-                  new Position(startPosition.getLine() + mapLine, character),
-                  new Position(startPosition.getLine() + mapLine, character + value.length()));
-          tokenReplacements.put(range, new Token(value, token.getOriginalLocation()));
-          outputLine.append(value);
-
-          tokenName.setLength(0);
-          continue;
-        }
-        if (bracesIndicator > 0) {
-          tokenName.append(c);
-        } else {
-          outputLine.append(c);
-        }
-      }
+      StringBuilder outputLine =
+          buildOutputLine(tokens, tokenReplacements, replacementLine, mapLine, startPosition);
       if (mapLine != replacementMapArray.length - 1) {
         outputLine.append("\n");
       }
       result.append(outputLine);
-      if (bracesIndicator > 0) {
-        throwInvalidParameters(
-            "Replacement map error",
-            "opening brace { has no matching closing brace",
-            mapLine,
-            replacementLine.length - 1);
-      }
-      if (escapeCharacter) {
-        throwInvalidParameters(
-            "Replacement map error",
-            "Dangling escape character in the input string",
-            mapLine,
-            replacementLine.length - 1);
-      }
     }
     return result.toString();
+  }
+
+  private StringBuilder buildOutputLine(
+      Map<String, Token> tokens,
+      Map<Range, Token> tokenReplacements,
+      char[] replacementLine,
+      int mapLine,
+      Position startPosition) {
+    int bracesIndicator = 0;
+    boolean escapeCharacter = false;
+    StringBuilder tokenName = new StringBuilder();
+
+    StringBuilder outputLine = new StringBuilder();
+    for (int i = 0; i < replacementLine.length; i++) {
+      char c = replacementLine[i];
+      if (c == ESCAPE_CHAR && !escapeCharacter) {
+        escapeCharacter = true;
+        continue;
+      }
+      if (escapeCharacter) {
+        outputLine.append(c);
+        escapeCharacter = false;
+        continue;
+      }
+      if (c == BRACE_OPEN) {
+        if (bracesIndicator > 0) {
+          String message =
+              String.format("expected \"%s\" instead of \"%s\"", BRACE_CLOSE, BRACE_OPEN);
+          throwInvalidParameters("Replacement map error", message, mapLine, i);
+        }
+        bracesIndicator++;
+        continue;
+      }
+      if (c == BRACE_CLOSE) {
+        if (bracesIndicator <= 0) {
+          String message =
+              String.format("expected \"%s\" instead of \"%s\"", BRACE_OPEN, BRACE_CLOSE);
+          throwInvalidParameters("Replacement map error", message, mapLine, i);
+        }
+        bracesIndicator--;
+
+        ImmutablePair<String, String> tokenNameAndValue =
+            getTokenNameAndValue(tokenName.toString(), mapLine, i - tokenName.length());
+
+        Token token = tokens.get(tokenNameAndValue.getLeft());
+
+        if (token == null) {
+          String message = String.format("token \"%s\" not found", tokenNameAndValue.getLeft());
+          throwInvalidParameters("Replacement map error", message, mapLine, i - tokenName.length());
+        }
+        String value = Optional.ofNullable(tokenNameAndValue.getRight()).orElse(token.getValue());
+        int character = outputLine.length() + (mapLine == 0 ? startPosition.getCharacter() : 0);
+        Range range =
+            new Range(
+                new Position(startPosition.getLine() + mapLine, character),
+                new Position(startPosition.getLine() + mapLine, character + value.length()));
+        tokenReplacements.put(range, new Token(value, token.getOriginalLocation()));
+        outputLine.append(value);
+
+        tokenName.setLength(0);
+        continue;
+      }
+      if (bracesIndicator > 0) {
+        tokenName.append(c);
+      } else {
+        outputLine.append(c);
+      }
+    }
+    if (bracesIndicator > 0) {
+      throwInvalidParameters(
+          "Replacement map error",
+          "opening brace { has no matching closing brace",
+          mapLine,
+          replacementLine.length - 1);
+    }
+    if (escapeCharacter) {
+      throwInvalidParameters(
+          "Replacement map error",
+          "Dangling escape character in the input string",
+          mapLine,
+          replacementLine.length - 1);
+    }
+    return outputLine;
   }
 
   private ImmutablePair<String, String> getTokenNameAndValue(
@@ -261,13 +271,6 @@ class TextMapReplacer {
             "token value cannot be empty",
             line,
             character + name.length() + 1);
-      }
-      int nextSeparator = value.indexOf(VALUE_REPLACEMENT_CHAR);
-      if (nextSeparator > 0) {
-        String message =
-            String.format("duplicated separator symbol \"%s\"", VALUE_REPLACEMENT_CHAR);
-        throwInvalidParameters(
-            "Replacement map error", message, line, character + nextSeparator + name.length() + 1);
       }
       return new ImmutablePair<>(name, value);
     }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -80,7 +80,8 @@ class TextMapReplacer {
           tokens,
           statementMapArray[i].toCharArray(),
           i,
-          range.getStart().getLine() + i);
+          range.getStart().getLine() + i,
+          i == 0 ? range.getStart().getCharacter() : 0);
     }
     if (tokens.isEmpty()) {
       throw new IllegalArgumentException("Statement map must contain at least 1 token name");
@@ -105,7 +106,8 @@ class TextMapReplacer {
       Map<String, Token> tokens,
       char[] statementLine,
       int mapLine,
-      int line) {
+      int line,
+      int startCharacter) {
     int bracesIndicator = 0;
     int symbolCount = 0;
     StringBuilder temp = new StringBuilder();
@@ -128,7 +130,7 @@ class TextMapReplacer {
         bracesIndicator--;
 
         String tokenName = temp.toString();
-        int character = i - symbolCount - tokenName.length();
+        int character = i - symbolCount - tokenName.length() + startCharacter;
 
         if (tokenName.isEmpty()) {
           throwInvalidParameters(

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -221,7 +221,7 @@ class TextMapReplacer {
           tokenReplacements.put(range, new Token(value, token.getOriginalLocation()));
           outputLine.append(value);
 
-          tokenName = new StringBuilder();
+          tokenWithValue.setLength(0);
           continue;
         }
         if (bracesIndicator > 0) {

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -145,7 +145,7 @@ class TextMapReplacer {
         tokens.put(tokenName, new Token(value, originalLocation));
 
         symbolCount++;
-        temp = new StringBuilder();
+        temp.setLength(0);
       } else if (bracesIndicator == 1) {
         temp.append(statementLine[i]);
       }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -16,8 +16,10 @@ package org.eclipse.lsp.cobol.common.mapping;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Value;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -38,6 +40,11 @@ import org.eclipse.lsp4j.Range;
  */
 @AllArgsConstructor
 class TextMapReplacer {
+  private static final char BRACE_OPEN = '{';
+  private static final char BRACE_CLOSE = '}';
+  private static final char ESCAPE_CHAR = '&';
+  private static final char VALUE_REPLACEMENT_CHAR = '|';
+
   private final ExtendedText extendedText;
 
   @Value
@@ -58,20 +65,23 @@ class TextMapReplacer {
       Range range, Range statementRange, String statementMap, String replacementMap) {
     Map<String, Token> tokens = new HashMap<>();
 
-    Location statementLocation = extendedText.mapLocation(statementRange);
-
     String[] statementMapArray = MappingHelper.split(statementMap);
-    String[] replacementMapArray = MappingHelper.split(replacementMap);
-
     for (int i = 0; i < statementMapArray.length; i++) {
       scanForTokens(tokens, statementMapArray, i, range);
     }
 
-    extendedText.replace(range, replacementMap, statementLocation);
+    Map<Range, Token> tokenReplacements = new HashMap<>();
+    String processedText =
+        scanForReplacements(range.getStart(), tokens, replacementMap, tokenReplacements);
 
-    for (int i = 0; i < replacementMapArray.length; i++) {
-      applyReplacementForLine(tokens, replacementMapArray, i, range);
-    }
+    Location statementLocation = extendedText.mapLocation(statementRange);
+    extendedText.replace(range, processedText, statementLocation);
+    tokenReplacements.forEach(
+        (r, t) -> {
+          extendedText.delete(r);
+          extendedText.insert(
+              r.getStart(), new ExtendedTextLine(t.getValue(), t.getOriginalLocation()));
+        });
   }
 
   private void scanForTokens(
@@ -83,13 +93,13 @@ class TextMapReplacer {
 
     for (int i = 0; i < statementLine.length; i++) {
       if (symbolCount % 2 == 0) {
-        if (statementLine[i] == '{') {
+        if (statementLine[i] == BRACE_OPEN) {
           symbolCount++;
         }
       } else {
-        if (statementLine[i] == '}') {
+        if (statementLine[i] == BRACE_CLOSE) {
           int line = range.getStart().getLine() + index;
-          int character = range.getStart().getCharacter() + i - symbolCount - temp.length();
+          int character = i - symbolCount - temp.length();
           Location originalLocation =
               extendedText.mapLocation(
                   new Range(
@@ -110,35 +120,76 @@ class TextMapReplacer {
     }
   }
 
-  private void applyReplacementForLine(
-      Map<String, Token> tokens, String[] replacementMapArray, int index, Range range) {
-    char[] replacementLine = replacementMapArray[index].toCharArray();
+  private String scanForReplacements(
+      Position startPosition,
+      Map<String, Token> tokens,
+      String replacementMap,
+      Map<Range, Token> tokenReplacements) {
+    StringBuilder result = new StringBuilder();
+    String[] replacementMapArray = MappingHelper.split(replacementMap);
 
-    int symbolCount = 0;
-    StringBuilder temp = new StringBuilder();
+    for (int line = 0; line < replacementMapArray.length; line++) {
+      char[] replacementLine = replacementMapArray[line].toCharArray();
+      boolean bracesOpened = false;
+      boolean escapeCharacter = false;
+      StringBuilder tokenName = new StringBuilder();
 
-    for (int i = 0; i < replacementLine.length; i++) {
-      if (symbolCount % 2 == 0) {
-        if (replacementLine[i] == '{') {
-          symbolCount++;
+      StringBuilder outputLine = new StringBuilder();
+      for (char c : replacementLine) {
+        if (c == ESCAPE_CHAR && !escapeCharacter) {
+          escapeCharacter = true;
+          continue;
         }
-      } else {
-        if (replacementLine[i] == '}') {
-          int line = range.getStart().getLine() + index;
-          int character = range.getStart().getCharacter() + i - symbolCount - temp.length();
+        if (escapeCharacter) {
+          outputLine.append(c);
+          escapeCharacter = false;
+          continue;
+        }
+        if (c == BRACE_OPEN) {
+          bracesOpened = true;
+          continue;
+        }
+        if (c == BRACE_CLOSE) {
+          bracesOpened = false;
 
-          Token token = tokens.get(temp.toString());
-          Range tokenRange =
-              new Range(
-                  new Position(line, character), new Position(line, character + temp.length() + 2));
-          extendedText.replace(tokenRange, token.getValue(), token.getOriginalLocation());
+          ImmutablePair<String, String> tokenNameAndValue =
+              getTokenNameAndValue(tokenName.toString());
 
-          symbolCount++;
-          temp = new StringBuilder();
+          Token token = tokens.get(tokenNameAndValue.getLeft());
+          if (token != null) {
+            String value =
+                Optional.ofNullable(tokenNameAndValue.getRight()).orElse(token.getValue());
+            int character = outputLine.length() + (line == 0 ? startPosition.getCharacter() : 0);
+            Range range =
+                new Range(
+                    new Position(startPosition.getLine() + line, character),
+                    new Position(startPosition.getLine() + line, character + value.length()));
+            tokenReplacements.put(range, new Token(value, token.getOriginalLocation()));
+            outputLine.append(value);
+          }
+          tokenName = new StringBuilder();
+          continue;
+        }
+        if (bracesOpened) {
+          tokenName.append(c);
         } else {
-          temp.append(replacementLine[i]);
+          outputLine.append(c);
         }
       }
+      if (line != replacementMapArray.length - 1) {
+        outputLine.append("\n");
+      }
+      result.append(outputLine);
     }
+    return result.toString();
+  }
+
+  private ImmutablePair<String, String> getTokenNameAndValue(String token) {
+    int indexOfSeparator = token.indexOf(VALUE_REPLACEMENT_CHAR);
+    if (indexOfSeparator > 0) {
+      return new ImmutablePair<>(
+          token.substring(0, indexOfSeparator), token.substring(indexOfSeparator + 1));
+    }
+    return new ImmutablePair<>(token, null);
   }
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -93,7 +93,7 @@ class TextMapReplacer {
   }
 
   private void scanForTokens(
-      Map<String, Token> tokens, String[] statementMapArray, int mapLine, Range range) {
+      Map<String, Token> tokens, char[] statementLine, int mapLine, int line) {
     char[] statementLine = statementMapArray[mapLine].toCharArray();
 
     int bracesIndicator = 0;

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacer.java
@@ -29,12 +29,13 @@ import org.eclipse.lsp4j.Range;
  * Replacer of the text with the replacement map. Replacement text is also a map that contains token
  * names. The actual replacement data will be calculated using token names. And the original value
  * of the token, situated in the appropriate range. For example: text document contains the line:
- * "this and this text will be replaced" (*). The statement map can be: "{this} and {that}" (1).
- * {this} points to 1st "this" token and {that} points to the 2nd "this" token. These token names:
- * {this} and {that} now can be replaced with the replacement map. Replacement map can be: "{this}
+ * "this and this text will be replaced" (*). The statement map can be: Token 1: name: "this",
+ * range: (0, 0); (0, 4) Token 2: name: "that", range: (0, 9); (0, 13) "this" token points to 1st
+ * "this" original token and "that" points to the 2nd "this" original token. These token names:
+ * "this" and "that" now can be replaced with the replacement map. Replacement map can be: "{this}
  * and even {that} text was replaced" (2). When TextMapReplacer apply replacement using (1)
  * statement map and replacement map (2) to the document line "this and this text will be replaced"
- * the result will be: "this and even that text was replaced", so token name {that} was substituted
+ * the result will be: "this and even that text was replaced", so token name "that" was substituted
  * with actual token value "this". The mapping location for the 1st "this" token will be pointing to
  * the 1st original "this" token and for the 2nd "this" token mapping will be pointing to the 2nd
  * original "this" token. All other characters will be pointed to the provided range
@@ -105,7 +106,7 @@ class TextMapReplacer {
               extendedText.getLines().get(range.getStart().getLine());
           String value =
               extendedTextLine
-                  .subline(range.getStart().getCharacter(), range.getEnd().getCharacter() - 1)
+                  .subline(range.getStart().getCharacter(), range.getEnd().getCharacter())
                   .toString();
 
           tokens.put(tokenName, new Token(value, originalLocation));

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextLineTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextLineTest.java
@@ -98,7 +98,7 @@ class ExtendedTextLineTest {
   @Test
   void testSubline() {
     ExtendedTextLine line = new ExtendedTextLine("text end", 7, "uri");
-    ExtendedTextLine subline = line.subline(2, 5);
+    ExtendedTextLine subline = line.subline(2, 6);
     assertEquals("xt e", subline.toString());
   }
 }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -373,4 +373,51 @@ class ExtendedTextTest {
     assertEquals(
         expectedCopybook.getLines().get(2).toString(), copybook1.getLines().get(2).toString());
   }
+
+  @Test
+  void testReplaceWithMap() {
+    // Extended text contains 3 lines, last 2 lines we are going to replace, using replacement map
+    ExtendedText extendedText =
+        new ExtendedText("MOVE 1 TO A\n" + "VOID AAA THRU \n PAR OF PAR. CONTINUE.", "uri");
+    Range range = new Range(new Position(1, 0), new Position(2, 12));
+    Range statementRange = new Range(new Position(1, 0), new Position(1, 3));
+
+    // The statement map that will be using to replace actual "VOID AAA THRU \n PAR OF PAR." text
+    // The name of the token {PAR} is the same as its value (1st "PAR" token)
+    // The name of the token {SEC} is different from its actual value "PAR" (2nd "PAR" token)
+    String statementMap = "VOID {AAA} THRU \n {PAR} OF {SEC}.";
+    String replacementMap = "MOVE 1 TO {AAA}\n" + "GO TO {PAR} OF {SEC}.";
+
+    Location statementLocation = new Location("uri", statementRange);
+    Location variableLocation =
+        new Location("uri", new Range(new Position(1, 5), new Position(1, 7)));
+    Location parLocation = new Location("uri", new Range(new Position(2, 1), new Position(2, 3)));
+    Location secLocation = new Location("uri", new Range(new Position(2, 8), new Position(2, 10)));
+
+    extendedText.replace(range, statementRange, statementMap, replacementMap);
+
+    assertEquals(
+        "MOVE 1 TO A\n" + "MOVE 1 TO AAA\n" + "GO TO PAR OF PAR. CONTINUE.",
+        extendedText.toString());
+
+    // MOVE
+    Location location = extendedText.mapLocation(new Range(new Position(1, 0), new Position(1, 3)));
+    assertEquals(statementLocation.toString(), location.toString());
+
+    // GO TO
+    location = extendedText.mapLocation(new Range(new Position(2, 0), new Position(2, 5)));
+    assertEquals(statementLocation.toString(), location.toString());
+
+    // AAA
+    location = extendedText.mapLocation(new Range(new Position(1, 10), new Position(1, 13)));
+    assertEquals(variableLocation.toString(), location.toString());
+
+    // PAR before OF
+    location = extendedText.mapLocation(new Range(new Position(2, 7), new Position(2, 9)));
+    assertEquals(parLocation.toString(), location.toString());
+
+    // PAR after OF
+    location = extendedText.mapLocation(new Range(new Position(2, 13), new Position(2, 15)));
+    assertEquals(secLocation.toString(), location.toString());
+  }
 }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -470,15 +470,15 @@ class ExtendedTextTest {
         new Location("uri", new Range(new Position(0, 13), new Position(0, 17)));
 
     // line 1: DISPLAY
-    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 6)));
+    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 7)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // line 1: VAR2
-    location = extendedText.mapLocation(new Range(new Position(0, 8), new Position(0, 11)));
+    location = extendedText.mapLocation(new Range(new Position(0, 8), new Position(0, 12)));
     assertEquals(var2Location.toString(), location.toString());
 
     // line 2: D(ISPLAY)
-    location = extendedText.mapLocation(new Range(new Position(1, 1), new Position(1, 6)));
+    location = extendedText.mapLocation(new Range(new Position(1, 1), new Position(1, 7)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // line 2: VAR1
@@ -504,7 +504,7 @@ class ExtendedTextTest {
         new Location("uri", new Range(new Position(0, 10), new Position(0, 14)));
 
     // DISPLAY
-    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 6)));
+    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 7)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // 1st VAR1
@@ -537,15 +537,15 @@ class ExtendedTextTest {
     assertEquals("DISPLAY '{VAR1}'. DISPLAY VAR1.", extendedText.toString());
 
     // DISPLAY
-    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 6)));
+    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 7)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // {VAR1}
-    location = extendedText.mapLocation(new Range(new Position(0, 9), new Position(0, 12)));
+    location = extendedText.mapLocation(new Range(new Position(0, 9), new Position(0, 15)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // VAR1
-    location = extendedText.mapLocation(new Range(new Position(0, 26), new Position(0, 29)));
+    location = extendedText.mapLocation(new Range(new Position(0, 26), new Position(0, 30)));
     assertEquals(var1Location.toString(), location.toString());
   }
 
@@ -565,7 +565,7 @@ class ExtendedTextTest {
 
     // BAR
     Location location =
-        extendedText.mapLocation(new Range(new Position(0, 21), new Position(0, 23)));
+        extendedText.mapLocation(new Range(new Position(0, 21), new Position(0, 24)));
     assertEquals(barLocation.toString(), location.toString());
   }
 
@@ -598,15 +598,15 @@ class ExtendedTextTest {
     assertEquals("FOOBAR STATEMENT", extendedText.toString());
 
     // FOOBAR
-    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 5)));
+    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 6)));
     assertEquals(fooLocation.toString(), location.toString());
 
     // FOO(BAR)
-    location = extendedText.mapLocation(new Range(new Position(0, 3), new Position(0, 5)));
+    location = extendedText.mapLocation(new Range(new Position(0, 3), new Position(0, 6)));
     assertEquals(fooLocation.toString(), location.toString());
 
     // STATEMENT
-    location = extendedText.mapLocation(new Range(new Position(0, 7), new Position(0, 15)));
+    location = extendedText.mapLocation(new Range(new Position(0, 7), new Position(0, 16)));
     assertEquals(statementLocation.toString(), location.toString());
   }
 
@@ -630,19 +630,19 @@ class ExtendedTextTest {
     assertEquals("FOOBAR STATEMENT. DISPLAY FOO\nDISPLAY NEW_VALUE", extendedText.toString());
 
     // FOOBAR
-    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 5)));
+    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 6)));
     assertEquals(fooLocation.toString(), location.toString());
 
     // STATEMENT
-    location = extendedText.mapLocation(new Range(new Position(0, 7), new Position(0, 15)));
+    location = extendedText.mapLocation(new Range(new Position(0, 7), new Position(0, 16)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // DISPLAY
-    location = extendedText.mapLocation(new Range(new Position(0, 18), new Position(0, 23)));
+    location = extendedText.mapLocation(new Range(new Position(0, 18), new Position(0, 25)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // FOO
-    location = extendedText.mapLocation(new Range(new Position(0, 26), new Position(0, 28)));
+    location = extendedText.mapLocation(new Range(new Position(0, 26), new Position(0, 29)));
     assertEquals(fooLocation.toString(), location.toString());
 
     // NEWVALUE

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -690,6 +690,11 @@ class ExtendedTextTest {
     Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
     extendedText.replace(range, statementRange, statementMap, "STATEMENT {A}\nSTATEMENT {B}");
 
+    Location location =
+        extendedText.mapLocation(new Range(new Position(1, 10), new Position(1, 11)));
+
     assertEquals("STATEMENT A\n" + "STATEMENT B", extendedText.toString());
+    assertEquals(
+        new Location("uri", new Range(new Position(0, 11), new Position(0, 12))), location);
   }
 }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -702,4 +702,26 @@ class ExtendedTextTest {
 
     assertEquals("DISPLAY FOO.", extendedText.toString());
   }
+
+  @Test
+  void testReplaceWithMap_misplaced_value_separator() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    extendedText.replace(range, statementRange, "STATEMENT {FOO}", "DISPLAY | {FOO}.");
+
+    assertEquals("DISPLAY | FOO.", extendedText.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_double_value_separator() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    extendedText.replace(range, statementRange, "STATEMENT {FOO}", "DISPLAY {FOO||BAR}.");
+
+    assertEquals("DISPLAY |BAR.", extendedText.toString());
+  }
 }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -375,33 +375,50 @@ class ExtendedTextTest {
   }
 
   @Test
-  void testReplaceWithMap() {
+  void testReplace_three_lines() {
+    ExtendedText extendedText = new ExtendedText("MOVE VAR1 TO VAR2", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    Location location = new Location("replacement", statementRange);
+    extendedText.replace(range, "DISPLAY VAR2.\nDISPLAY VAR1.\nMOVE VAR2 TO VAR1\n", location);
+
+    assertEquals(
+        "DISPLAY VAR2.\n" + "DISPLAY VAR1.\n" + "MOVE VAR2 TO VAR1", extendedText.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_general() {
     // Extended text contains 3 lines, last 2 lines we are going to replace, using replacement map
     ExtendedText extendedText =
-        new ExtendedText("MOVE 1 TO A\n" + "VOID AAA THRU \n PAR OF PAR. CONTINUE.", "uri");
-    Range range = new Range(new Position(1, 0), new Position(2, 12));
-    Range statementRange = new Range(new Position(1, 0), new Position(1, 3));
+        new ExtendedText("MOVE 1 TO A\n" + "     VOID AAA THRU \n PAR OF PAR. CONTINUE.", "uri");
+    Range range = new Range(new Position(1, 5), new Position(2, 12));
+    Range statementRange = new Range(new Position(1, 5), new Position(1, 8));
 
     // The statement map that will be using to replace actual "VOID AAA THRU \n PAR OF PAR." text
     // The name of the token {PAR} is the same as its value (1st "PAR" token)
     // The name of the token {SEC} is different from its actual value "PAR" (2nd "PAR" token)
-    String statementMap = "VOID {AAA} THRU \n {PAR} OF {SEC}.";
+    String statementMap = "     VOID {AAA} THRU \n {PAR} OF {SEC}.";
     String replacementMap = "MOVE 1 TO {AAA}\n" + "GO TO {PAR} OF {SEC}.";
 
     Location statementLocation = new Location("uri", statementRange);
     Location variableLocation =
-        new Location("uri", new Range(new Position(1, 5), new Position(1, 7)));
+        new Location("uri", new Range(new Position(1, 10), new Position(1, 12)));
     Location parLocation = new Location("uri", new Range(new Position(2, 1), new Position(2, 3)));
     Location secLocation = new Location("uri", new Range(new Position(2, 8), new Position(2, 10)));
 
     extendedText.replace(range, statementRange, statementMap, replacementMap);
 
     assertEquals(
-        "MOVE 1 TO A\n" + "MOVE 1 TO AAA\n" + "GO TO PAR OF PAR. CONTINUE.",
+        "MOVE 1 TO A\n" + "     MOVE 1 TO AAA\n" + "GO TO PAR OF PAR. CONTINUE.",
         extendedText.toString());
 
     // MOVE
-    Location location = extendedText.mapLocation(new Range(new Position(1, 0), new Position(1, 3)));
+    Location location = extendedText.mapLocation(new Range(new Position(1, 5), new Position(1, 8)));
+    assertEquals(statementLocation.toString(), location.toString());
+
+    // TO
+    location = extendedText.mapLocation(new Range(new Position(1, 12), new Position(1, 13)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // GO TO
@@ -409,7 +426,7 @@ class ExtendedTextTest {
     assertEquals(statementLocation.toString(), location.toString());
 
     // AAA
-    location = extendedText.mapLocation(new Range(new Position(1, 10), new Position(1, 13)));
+    location = extendedText.mapLocation(new Range(new Position(1, 15), new Position(1, 18)));
     assertEquals(variableLocation.toString(), location.toString());
 
     // PAR before OF
@@ -419,5 +436,270 @@ class ExtendedTextTest {
     // PAR after OF
     location = extendedText.mapLocation(new Range(new Position(2, 13), new Position(2, 15)));
     assertEquals(secLocation.toString(), location.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_order() {
+    ExtendedText extendedText = new ExtendedText("MOVE VAR1 TO VAR2", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    extendedText.replace(
+        range,
+        statementRange,
+        "MOVE {VAR1} TO {VAR2}",
+        "DISPLAY {VAR2}.\nDISPLAY {VAR1}.\nMOVE {VAR2} TO {VAR1}\n");
+
+    assertEquals(
+        "DISPLAY VAR2.\n" + "DISPLAY VAR1.\n" + "MOVE VAR2 TO VAR1", extendedText.toString());
+
+    Location statementLocation = new Location("uri", statementRange);
+    Location var1Location = new Location("uri", new Range(new Position(0, 5), new Position(0, 8)));
+    Location var2Location =
+        new Location("uri", new Range(new Position(0, 13), new Position(0, 16)));
+
+    // line 1: DISPLAY
+    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 6)));
+    assertEquals(statementLocation.toString(), location.toString());
+
+    // line 1: VAR2
+    location = extendedText.mapLocation(new Range(new Position(0, 8), new Position(0, 11)));
+    assertEquals(var2Location.toString(), location.toString());
+
+    // line 2: D(ISPLAY)
+    location = extendedText.mapLocation(new Range(new Position(2, 1), new Position(2, 6)));
+    assertEquals(statementLocation.toString(), location.toString());
+
+    // line 2: VAR1
+    location = extendedText.mapLocation(new Range(new Position(1, 8), new Position(1, 11)));
+    assertEquals(var1Location.toString(), location.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_duplication() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT VAR1", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    extendedText.replace(
+        range,
+        statementRange,
+        "STATEMENT {VAR1}",
+        "DISPLAY {VAR1}. DISPLAY {VAR1}. MOVE 1 TO {VAR1}.\n");
+
+    assertEquals("DISPLAY VAR1. DISPLAY VAR1. MOVE 1 TO VAR1.", extendedText.toString());
+
+    Location statementLocation = new Location("uri", statementRange);
+    Location var1Location =
+        new Location("uri", new Range(new Position(0, 10), new Position(0, 13)));
+
+    // DISPLAY
+    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 6)));
+    assertEquals(statementLocation.toString(), location.toString());
+
+    // 1st VAR1
+    location = extendedText.mapLocation(new Range(new Position(0, 8), new Position(0, 11)));
+    assertEquals(var1Location.toString(), location.toString());
+
+    // 2nd VAR1
+    location = extendedText.mapLocation(new Range(new Position(0, 22), new Position(0, 25)));
+    assertEquals(var1Location.toString(), location.toString());
+
+    // 2rd VAR1
+    location = extendedText.mapLocation(new Range(new Position(0, 38), new Position(0, 41)));
+    assertEquals(var1Location.toString(), location.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_with_braces() {
+    ExtendedText extendedText = new ExtendedText("MOVE VAR1 TO VAR2", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    extendedText.replace(
+        range, statementRange, "MOVE {VAR1} TO VAR2", "DISPLAY '&{VAR1&}'. DISPLAY {VAR1}.\n");
+
+    Location statementLocation = new Location("uri", statementRange);
+    Location var1Location = new Location("uri", new Range(new Position(0, 5), new Position(0, 8)));
+
+    assertEquals("DISPLAY '{VAR1}'. DISPLAY VAR1.", extendedText.toString());
+
+    // DISPLAY
+    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 6)));
+    assertEquals(statementLocation.toString(), location.toString());
+
+    // {VAR1}
+    location = extendedText.mapLocation(new Range(new Position(0, 9), new Position(0, 12)));
+    assertEquals(statementLocation.toString(), location.toString());
+
+    // VAR1
+    location = extendedText.mapLocation(new Range(new Position(0, 26), new Position(0, 29)));
+    assertEquals(var1Location.toString(), location.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_with_double_escape_character() {
+    ExtendedText extendedText = new ExtendedText("MOVE 1 TO FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    extendedText.replace(range, statementRange, "MOVE 1 TO {BAR}", "DISPLAY '&&'. DISPLAY {BAR}");
+
+    Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 12)));
+
+    assertEquals("DISPLAY '&'. DISPLAY FOO", extendedText.toString());
+
+    // BAR
+    Location location =
+        extendedText.mapLocation(new Range(new Position(0, 21), new Position(0, 23)));
+    assertEquals(fooLocation.toString(), location.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_missing_statement_token() {
+    ExtendedText extendedText = new ExtendedText("MOVE 1 TO FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    extendedText.replace(range, statementRange, "MOVE 1 TO {BAR}", "DISPLAY BAR");
+
+    assertEquals("DISPLAY BAR", extendedText.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_missing_replacement_token() {
+    ExtendedText extendedText = new ExtendedText("MOVE 1 TO FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    extendedText.replace(range, statementRange, "MOVE 1 TO {FOO}", "DISPLAY {BAR}. DISPLAY {FOO}");
+
+    Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 12)));
+
+    assertEquals("DISPLAY . DISPLAY FOO", extendedText.toString());
+
+    // FOO
+    Location location =
+        extendedText.mapLocation(new Range(new Position(0, 18), new Position(0, 20)));
+    assertEquals(fooLocation.toString(), location.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_replace_value() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    extendedText.replace(range, statementRange, "STATEMENT {FOO}", "{FOO|FOOBAR} STATEMENT");
+
+    Location statementLocation = new Location("uri", statementRange);
+    Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 12)));
+
+    assertEquals("FOOBAR STATEMENT", extendedText.toString());
+
+    // FOOBAR
+    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 5)));
+    assertEquals(fooLocation.toString(), location.toString());
+
+    // FOO(BAR)
+    location = extendedText.mapLocation(new Range(new Position(0, 3), new Position(0, 5)));
+    assertEquals(fooLocation.toString(), location.toString());
+
+    // STATEMENT
+    location = extendedText.mapLocation(new Range(new Position(0, 7), new Position(0, 15)));
+    assertEquals(statementLocation.toString(), location.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_replace_multiple_values() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    extendedText.replace(
+        range,
+        statementRange,
+        "STATEMENT {FOO}",
+        "{FOO|FOOBAR} STATEMENT. DISPLAY {FOO}\nDISPLAY {FOO|NEW_VALUE}");
+
+    Location statementLocation = new Location("uri", statementRange);
+    Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 12)));
+
+    assertEquals("FOOBAR STATEMENT. DISPLAY FOO\nDISPLAY NEW_VALUE", extendedText.toString());
+
+    // FOOBAR
+    Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 5)));
+    assertEquals(fooLocation.toString(), location.toString());
+
+    // STATEMENT
+    location = extendedText.mapLocation(new Range(new Position(0, 7), new Position(0, 15)));
+    assertEquals(statementLocation.toString(), location.toString());
+
+    // DISPLAY
+    location = extendedText.mapLocation(new Range(new Position(0, 18), new Position(0, 23)));
+    assertEquals(statementLocation.toString(), location.toString());
+
+    // FOO
+    location = extendedText.mapLocation(new Range(new Position(0, 26), new Position(0, 28)));
+    assertEquals(fooLocation.toString(), location.toString());
+
+    // NEWVALUE
+    location = extendedText.mapLocation(new Range(new Position(1, 8), new Position(0, 16)));
+    assertEquals(fooLocation.toString(), location.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_replace_blank() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    extendedText.replace(range, statementRange, "STATEMENT {FOO}", "{FOO|} STATEMENT");
+
+    assertEquals(" STATEMENT", extendedText.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_statement_braces_open() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    extendedText.replace(range, statementRange, "STATEMENT {FOO", "DISPLAY {FOO}.");
+
+    assertEquals("DISPLAY .", extendedText.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_statement_braces_close() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    extendedText.replace(range, statementRange, "STATEMENT FOO}", "DISPLAY {FOO}.");
+
+    assertEquals("DISPLAY .", extendedText.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_replacement_braces_open() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    extendedText.replace(range, statementRange, "STATEMENT {FOO}", "DISPLAY {FOO. IGNORED TEXT");
+
+    assertEquals("DISPLAY ", extendedText.toString());
+  }
+
+  @Test
+  void testReplaceWithMap_replacement_braces_close() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    extendedText.replace(range, statementRange, "STATEMENT FOO}", "DISPLAY FOO}.");
+
+    assertEquals("DISPLAY FOO.", extendedText.toString());
   }
 }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -379,7 +379,7 @@ class ExtendedTextTest {
     ExtendedText extendedText = new ExtendedText("MOVE VAR1 TO VAR2", "uri");
 
     Range range = new Range(new Position(0, 0), new Position(0, 18));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 4));
     Location location = new Location("replacement", statementRange);
     extendedText.replace(range, "DISPLAY VAR2.\nDISPLAY VAR1.\nMOVE VAR2 TO VAR1\n", location);
 
@@ -393,7 +393,7 @@ class ExtendedTextTest {
     ExtendedText extendedText =
         new ExtendedText("MOVE 1 TO A\n" + "     VOID AAA THRU \n PAR OF PAR. CONTINUE.", "uri");
     Range range = new Range(new Position(1, 5), new Position(2, 12));
-    Range statementRange = new Range(new Position(1, 5), new Position(1, 8));
+    Range statementRange = new Range(new Position(1, 5), new Position(1, 9));
 
     // The statement map that will be using to replace actual "VOID AAA THRU \n PAR OF PAR." text
     // The name of the token {PAR} is the same as its value (1st "PAR" token)
@@ -403,9 +403,9 @@ class ExtendedTextTest {
 
     Location statementLocation = new Location("uri", statementRange);
     Location variableLocation =
-        new Location("uri", new Range(new Position(1, 10), new Position(1, 12)));
-    Location parLocation = new Location("uri", new Range(new Position(2, 1), new Position(2, 3)));
-    Location secLocation = new Location("uri", new Range(new Position(2, 8), new Position(2, 10)));
+        new Location("uri", new Range(new Position(1, 10), new Position(1, 13)));
+    Location parLocation = new Location("uri", new Range(new Position(2, 1), new Position(2, 4)));
+    Location secLocation = new Location("uri", new Range(new Position(2, 8), new Position(2, 11)));
 
     extendedText.replace(range, statementRange, statementMap, replacementMap);
 
@@ -414,15 +414,15 @@ class ExtendedTextTest {
         extendedText.toString());
 
     // MOVE
-    Location location = extendedText.mapLocation(new Range(new Position(1, 5), new Position(1, 8)));
+    Location location = extendedText.mapLocation(new Range(new Position(1, 5), new Position(1, 9)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // TO
-    location = extendedText.mapLocation(new Range(new Position(1, 12), new Position(1, 13)));
+    location = extendedText.mapLocation(new Range(new Position(1, 12), new Position(1, 14)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // GO TO
-    location = extendedText.mapLocation(new Range(new Position(2, 0), new Position(2, 5)));
+    location = extendedText.mapLocation(new Range(new Position(2, 0), new Position(2, 6)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // AAA
@@ -430,11 +430,11 @@ class ExtendedTextTest {
     assertEquals(variableLocation.toString(), location.toString());
 
     // PAR before OF
-    location = extendedText.mapLocation(new Range(new Position(2, 7), new Position(2, 9)));
+    location = extendedText.mapLocation(new Range(new Position(2, 7), new Position(2, 10)));
     assertEquals(parLocation.toString(), location.toString());
 
     // PAR after OF
-    location = extendedText.mapLocation(new Range(new Position(2, 13), new Position(2, 15)));
+    location = extendedText.mapLocation(new Range(new Position(2, 13), new Position(2, 16)));
     assertEquals(secLocation.toString(), location.toString());
   }
 
@@ -443,7 +443,7 @@ class ExtendedTextTest {
     ExtendedText extendedText = new ExtendedText("MOVE VAR1 TO VAR2", "uri");
 
     Range range = new Range(new Position(0, 0), new Position(0, 18));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 4));
     extendedText.replace(
         range,
         statementRange,
@@ -454,9 +454,9 @@ class ExtendedTextTest {
         "DISPLAY VAR2.\n" + "DISPLAY VAR1.\n" + "MOVE VAR2 TO VAR1", extendedText.toString());
 
     Location statementLocation = new Location("uri", statementRange);
-    Location var1Location = new Location("uri", new Range(new Position(0, 5), new Position(0, 8)));
+    Location var1Location = new Location("uri", new Range(new Position(0, 5), new Position(0, 9)));
     Location var2Location =
-        new Location("uri", new Range(new Position(0, 13), new Position(0, 16)));
+        new Location("uri", new Range(new Position(0, 13), new Position(0, 17)));
 
     // line 1: DISPLAY
     Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 6)));
@@ -480,7 +480,7 @@ class ExtendedTextTest {
     ExtendedText extendedText = new ExtendedText("STATEMENT VAR1", "uri");
 
     Range range = new Range(new Position(0, 0), new Position(0, 18));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
     extendedText.replace(
         range,
         statementRange,
@@ -491,7 +491,7 @@ class ExtendedTextTest {
 
     Location statementLocation = new Location("uri", statementRange);
     Location var1Location =
-        new Location("uri", new Range(new Position(0, 10), new Position(0, 13)));
+        new Location("uri", new Range(new Position(0, 10), new Position(0, 14)));
 
     // DISPLAY
     Location location = extendedText.mapLocation(new Range(new Position(0, 0), new Position(0, 6)));
@@ -515,12 +515,12 @@ class ExtendedTextTest {
     ExtendedText extendedText = new ExtendedText("MOVE VAR1 TO VAR2", "uri");
 
     Range range = new Range(new Position(0, 0), new Position(0, 18));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 4));
     extendedText.replace(
         range, statementRange, "MOVE {VAR1} TO VAR2", "DISPLAY '&{VAR1&}'. DISPLAY {VAR1}.\n");
 
     Location statementLocation = new Location("uri", statementRange);
-    Location var1Location = new Location("uri", new Range(new Position(0, 5), new Position(0, 8)));
+    Location var1Location = new Location("uri", new Range(new Position(0, 5), new Position(0, 9)));
 
     assertEquals("DISPLAY '{VAR1}'. DISPLAY VAR1.", extendedText.toString());
 
@@ -542,17 +542,17 @@ class ExtendedTextTest {
     ExtendedText extendedText = new ExtendedText("MOVE 1 TO FOO", "uri");
 
     Range range = new Range(new Position(0, 0), new Position(0, 18));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 4));
     extendedText.replace(range, statementRange, "MOVE 1 TO {BAR}", "DISPLAY '&&'. DISPLAY {BAR}");
 
-    Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 12)));
+    Location barLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 13)));
 
     assertEquals("DISPLAY '&'. DISPLAY FOO", extendedText.toString());
 
     // BAR
     Location location =
         extendedText.mapLocation(new Range(new Position(0, 21), new Position(0, 23)));
-    assertEquals(fooLocation.toString(), location.toString());
+    assertEquals(barLocation.toString(), location.toString());
   }
 
   @Test
@@ -560,7 +560,7 @@ class ExtendedTextTest {
     ExtendedText extendedText = new ExtendedText("MOVE 1 TO FOO", "uri");
 
     Range range = new Range(new Position(0, 0), new Position(0, 18));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 4));
     extendedText.replace(range, statementRange, "MOVE 1 TO {BAR}", "DISPLAY BAR");
 
     assertEquals("DISPLAY BAR", extendedText.toString());
@@ -571,11 +571,11 @@ class ExtendedTextTest {
     ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
 
     Range range = new Range(new Position(0, 0), new Position(0, 13));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
     extendedText.replace(range, statementRange, "STATEMENT {FOO}", "{FOO|FOOBAR} STATEMENT");
 
     Location statementLocation = new Location("uri", statementRange);
-    Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 12)));
+    Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 13)));
 
     assertEquals("FOOBAR STATEMENT", extendedText.toString());
 
@@ -597,7 +597,7 @@ class ExtendedTextTest {
     ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
 
     Range range = new Range(new Position(0, 0), new Position(0, 13));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
     extendedText.replace(
         range,
         statementRange,
@@ -605,7 +605,7 @@ class ExtendedTextTest {
         "{FOO|FOOBAR} STATEMENT. DISPLAY {FOO}\nDISPLAY {FOO|NEW_VALUE}");
 
     Location statementLocation = new Location("uri", statementRange);
-    Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 12)));
+    Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 13)));
 
     assertEquals("FOOBAR STATEMENT. DISPLAY FOO\nDISPLAY NEW_VALUE", extendedText.toString());
 
@@ -635,7 +635,7 @@ class ExtendedTextTest {
     ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
 
     Range range = new Range(new Position(0, 0), new Position(0, 13));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
     extendedText.replace(range, statementRange, "STATEMENT {FOO}", "DISPLAY | {FOO}.");
 
     assertEquals("DISPLAY | FOO.", extendedText.toString());
@@ -646,7 +646,7 @@ class ExtendedTextTest {
     ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
 
     Range range = new Range(new Position(0, 0), new Position(0, 13));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
     extendedText.replace(range, statementRange, "STATEMENT {FOO}", "DISPLAY {FOO||BAR}.");
 
     assertEquals("DISPLAY |BAR.", extendedText.toString());

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -690,11 +690,15 @@ class ExtendedTextTest {
     Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
     extendedText.replace(range, statementRange, statementMap, "STATEMENT {A}\nSTATEMENT {B}");
 
-    Location location =
+    Location locationA =
+        extendedText.mapLocation(new Range(new Position(0, 10), new Position(0, 11)));
+    Location locationB =
         extendedText.mapLocation(new Range(new Position(1, 10), new Position(1, 11)));
 
     assertEquals("STATEMENT A\n" + "STATEMENT B", extendedText.toString());
     assertEquals(
-        new Location("uri", new Range(new Position(0, 11), new Position(0, 12))), location);
+        new Location("uri", new Range(new Position(0, 10), new Position(0, 11))), locationA);
+    assertEquals(
+        new Location("uri", new Range(new Position(0, 11), new Position(0, 12))), locationB);
   }
 }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -567,24 +567,6 @@ class ExtendedTextTest {
   }
 
   @Test
-  void testReplaceWithMap_missing_replacement_token() {
-    ExtendedText extendedText = new ExtendedText("MOVE 1 TO FOO", "uri");
-
-    Range range = new Range(new Position(0, 0), new Position(0, 18));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 3));
-    extendedText.replace(range, statementRange, "MOVE 1 TO {FOO}", "DISPLAY {BAR}. DISPLAY {FOO}");
-
-    Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 12)));
-
-    assertEquals("DISPLAY . DISPLAY FOO", extendedText.toString());
-
-    // FOO
-    Location location =
-        extendedText.mapLocation(new Range(new Position(0, 18), new Position(0, 20)));
-    assertEquals(fooLocation.toString(), location.toString());
-  }
-
-  @Test
   void testReplaceWithMap_replace_value() {
     ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
 
@@ -646,61 +628,6 @@ class ExtendedTextTest {
     // NEWVALUE
     location = extendedText.mapLocation(new Range(new Position(1, 8), new Position(0, 16)));
     assertEquals(fooLocation.toString(), location.toString());
-  }
-
-  @Test
-  void testReplaceWithMap_replace_blank() {
-    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
-
-    Range range = new Range(new Position(0, 0), new Position(0, 13));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
-    extendedText.replace(range, statementRange, "STATEMENT {FOO}", "{FOO|} STATEMENT");
-
-    assertEquals(" STATEMENT", extendedText.toString());
-  }
-
-  @Test
-  void testReplaceWithMap_statement_braces_open() {
-    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
-
-    Range range = new Range(new Position(0, 0), new Position(0, 13));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
-    extendedText.replace(range, statementRange, "STATEMENT {FOO", "DISPLAY {FOO}.");
-
-    assertEquals("DISPLAY .", extendedText.toString());
-  }
-
-  @Test
-  void testReplaceWithMap_statement_braces_close() {
-    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
-
-    Range range = new Range(new Position(0, 0), new Position(0, 13));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
-    extendedText.replace(range, statementRange, "STATEMENT FOO}", "DISPLAY {FOO}.");
-
-    assertEquals("DISPLAY .", extendedText.toString());
-  }
-
-  @Test
-  void testReplaceWithMap_replacement_braces_open() {
-    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
-
-    Range range = new Range(new Position(0, 0), new Position(0, 13));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
-    extendedText.replace(range, statementRange, "STATEMENT {FOO}", "DISPLAY {FOO. IGNORED TEXT");
-
-    assertEquals("DISPLAY ", extendedText.toString());
-  }
-
-  @Test
-  void testReplaceWithMap_replacement_braces_close() {
-    ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
-
-    Range range = new Range(new Position(0, 0), new Position(0, 13));
-    Range statementRange = new Range(new Position(0, 0), new Position(0, 8));
-    extendedText.replace(range, statementRange, "STATEMENT FOO}", "DISPLAY FOO}.");
-
-    assertEquals("DISPLAY FOO.", extendedText.toString());
   }
 
   @Test

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -482,7 +482,7 @@ class ExtendedTextTest {
     assertEquals(statementLocation.toString(), location.toString());
 
     // line 2: VAR1
-    location = extendedText.mapLocation(new Range(new Position(1, 8), new Position(1, 11)));
+    location = extendedText.mapLocation(new Range(new Position(1, 8), new Position(1, 12)));
     assertEquals(var1Location.toString(), location.toString());
   }
 

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -398,7 +398,7 @@ class ExtendedTextTest {
     // The statement map that will be using to replace actual "VOID AAA THRU \n PAR OF PAR." text
     // The name of the token {PAR} is the same as its value (1st "PAR" token)
     // The name of the token {SEC} is different from its actual value "PAR" (2nd "PAR" token)
-    String statementMap = "     VOID {AAA} THRU \n {PAR} OF {SEC}.";
+    String statementMap = "VOID {AAA} THRU \n {PAR} OF {SEC}.";
     String replacementMap = "MOVE 1 TO {AAA}\n" + "GO TO {PAR} OF {SEC}.";
 
     Location statementLocation = new Location("uri", statementRange);

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -16,6 +16,8 @@ package org.eclipse.lsp.cobol.common.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -396,9 +398,14 @@ class ExtendedTextTest {
     Range statementRange = new Range(new Position(1, 5), new Position(1, 9));
 
     // The statement map that will be using to replace actual "VOID AAA THRU \n PAR OF PAR." text
-    // The name of the token {PAR} is the same as its value (1st "PAR" token)
-    // The name of the token {SEC} is different from its actual value "PAR" (2nd "PAR" token)
-    String statementMap = "VOID {AAA} THRU \n {PAR} OF {SEC}.";
+    // The name of the token PAR is the same as its value (1st "PAR" token)
+    // The name of the token SEC is different from its actual value "PAR" (2nd "PAR" token)
+    Map<String, Range> statementMap =
+        ImmutableMap.of(
+            "AAA", new Range(new Position(1, 10), new Position(1, 13)),
+            "PAR", new Range(new Position(2, 1), new Position(2, 4)),
+            "SEC", new Range(new Position(2, 8), new Position(2, 11)));
+
     String replacementMap = "MOVE 1 TO {AAA}\n" + "GO TO {PAR} OF {SEC}.";
 
     Location statementLocation = new Location("uri", statementRange);
@@ -441,13 +448,17 @@ class ExtendedTextTest {
   @Test
   void testReplaceWithMap_order() {
     ExtendedText extendedText = new ExtendedText("MOVE VAR1 TO VAR2", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of(
+            "VAR1", new Range(new Position(0, 5), new Position(0, 9)),
+            "VAR2", new Range(new Position(0, 13), new Position(0, 17)));
 
-    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range range = new Range(new Position(0, 0), new Position(0, 17));
     Range statementRange = new Range(new Position(0, 0), new Position(0, 4));
     extendedText.replace(
         range,
         statementRange,
-        "MOVE {VAR1} TO {VAR2}",
+        statementMap,
         "DISPLAY {VAR2}.\nDISPLAY {VAR1}.\nMOVE {VAR2} TO {VAR1}\n");
 
     assertEquals(
@@ -478,14 +489,13 @@ class ExtendedTextTest {
   @Test
   void testReplaceWithMap_duplication() {
     ExtendedText extendedText = new ExtendedText("STATEMENT VAR1", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("VAR1", new Range(new Position(0, 10), new Position(0, 14)));
 
-    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range range = new Range(new Position(0, 0), new Position(0, 14));
     Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
     extendedText.replace(
-        range,
-        statementRange,
-        "STATEMENT {VAR1}",
-        "DISPLAY {VAR1}. DISPLAY {VAR1}. MOVE 1 TO {VAR1}.\n");
+        range, statementRange, statementMap, "DISPLAY {VAR1}. DISPLAY {VAR1}. MOVE 1 TO {VAR1}.\n");
 
     assertEquals("DISPLAY VAR1. DISPLAY VAR1. MOVE 1 TO VAR1.", extendedText.toString());
 
@@ -513,11 +523,13 @@ class ExtendedTextTest {
   @Test
   void testReplaceWithMap_with_braces() {
     ExtendedText extendedText = new ExtendedText("MOVE VAR1 TO VAR2", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("VAR1", new Range(new Position(0, 5), new Position(0, 9)));
 
-    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range range = new Range(new Position(0, 0), new Position(0, 17));
     Range statementRange = new Range(new Position(0, 0), new Position(0, 4));
     extendedText.replace(
-        range, statementRange, "MOVE {VAR1} TO VAR2", "DISPLAY '&{VAR1&}'. DISPLAY {VAR1}.\n");
+        range, statementRange, statementMap, "DISPLAY '&{VAR1&}'. DISPLAY {VAR1}.\n");
 
     Location statementLocation = new Location("uri", statementRange);
     Location var1Location = new Location("uri", new Range(new Position(0, 5), new Position(0, 9)));
@@ -540,10 +552,12 @@ class ExtendedTextTest {
   @Test
   void testReplaceWithMap_with_double_escape_character() {
     ExtendedText extendedText = new ExtendedText("MOVE 1 TO FOO", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("BAR", new Range(new Position(0, 10), new Position(0, 13)));
 
-    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
     Range statementRange = new Range(new Position(0, 0), new Position(0, 4));
-    extendedText.replace(range, statementRange, "MOVE 1 TO {BAR}", "DISPLAY '&&'. DISPLAY {BAR}");
+    extendedText.replace(range, statementRange, statementMap, "DISPLAY '&&'. DISPLAY {BAR}");
 
     Location barLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 13)));
 
@@ -558,10 +572,12 @@ class ExtendedTextTest {
   @Test
   void testReplaceWithMap_missing_statement_token() {
     ExtendedText extendedText = new ExtendedText("MOVE 1 TO FOO", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("BAR", new Range(new Position(0, 10), new Position(0, 13)));
 
-    Range range = new Range(new Position(0, 0), new Position(0, 18));
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
     Range statementRange = new Range(new Position(0, 0), new Position(0, 4));
-    extendedText.replace(range, statementRange, "MOVE 1 TO {BAR}", "DISPLAY BAR");
+    extendedText.replace(range, statementRange, statementMap, "DISPLAY BAR");
 
     assertEquals("DISPLAY BAR", extendedText.toString());
   }
@@ -569,10 +585,12 @@ class ExtendedTextTest {
   @Test
   void testReplaceWithMap_replace_value() {
     ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("FOO", new Range(new Position(0, 10), new Position(0, 13)));
 
     Range range = new Range(new Position(0, 0), new Position(0, 13));
     Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
-    extendedText.replace(range, statementRange, "STATEMENT {FOO}", "{FOO|FOOBAR} STATEMENT");
+    extendedText.replace(range, statementRange, statementMap, "{FOO|FOOBAR} STATEMENT");
 
     Location statementLocation = new Location("uri", statementRange);
     Location fooLocation = new Location("uri", new Range(new Position(0, 10), new Position(0, 13)));
@@ -595,13 +613,15 @@ class ExtendedTextTest {
   @Test
   void testReplaceWithMap_replace_multiple_values() {
     ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("FOO", new Range(new Position(0, 10), new Position(0, 13)));
 
     Range range = new Range(new Position(0, 0), new Position(0, 13));
     Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
     extendedText.replace(
         range,
         statementRange,
-        "STATEMENT {FOO}",
+        statementMap,
         "{FOO|FOOBAR} STATEMENT. DISPLAY {FOO}\nDISPLAY {FOO|NEW_VALUE}");
 
     Location statementLocation = new Location("uri", statementRange);
@@ -633,10 +653,12 @@ class ExtendedTextTest {
   @Test
   void testReplaceWithMap_misplaced_value_separator() {
     ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("FOO", new Range(new Position(0, 10), new Position(0, 13)));
 
     Range range = new Range(new Position(0, 0), new Position(0, 13));
     Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
-    extendedText.replace(range, statementRange, "STATEMENT {FOO}", "DISPLAY | {FOO}.");
+    extendedText.replace(range, statementRange, statementMap, "DISPLAY | {FOO}.");
 
     assertEquals("DISPLAY | FOO.", extendedText.toString());
   }
@@ -644,10 +666,12 @@ class ExtendedTextTest {
   @Test
   void testReplaceWithMap_double_value_separator() {
     ExtendedText extendedText = new ExtendedText("STATEMENT FOO", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("FOO", new Range(new Position(0, 10), new Position(0, 13)));
 
     Range range = new Range(new Position(0, 0), new Position(0, 13));
     Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
-    extendedText.replace(range, statementRange, "STATEMENT {FOO}", "DISPLAY {FOO||BAR}.");
+    extendedText.replace(range, statementRange, statementMap, "DISPLAY {FOO||BAR}.");
 
     assertEquals("DISPLAY |BAR.", extendedText.toString());
   }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -675,4 +675,21 @@ class ExtendedTextTest {
 
     assertEquals("DISPLAY |BAR.", extendedText.toString());
   }
+
+  @Test
+  void testReplaceWithMap_edge_case() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT AB", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of(
+            "A",
+            new Range(new Position(0, 10), new Position(0, 11)),
+            "B",
+            new Range(new Position(0, 11), new Position(0, 12)));
+
+    Range range = new Range(new Position(0, 0), new Position(0, 12));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
+    extendedText.replace(range, statementRange, statementMap, "STATEMENT {A}\nSTATEMENT {B}");
+
+    assertEquals("STATEMENT A\n" + "STATEMENT B", extendedText.toString());
+  }
 }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -508,15 +508,15 @@ class ExtendedTextTest {
     assertEquals(statementLocation.toString(), location.toString());
 
     // 1st VAR1
-    location = extendedText.mapLocation(new Range(new Position(0, 8), new Position(0, 11)));
+    location = extendedText.mapLocation(new Range(new Position(0, 8), new Position(0, 12)));
     assertEquals(var1Location.toString(), location.toString());
 
     // 2nd VAR1
-    location = extendedText.mapLocation(new Range(new Position(0, 22), new Position(0, 25)));
+    location = extendedText.mapLocation(new Range(new Position(0, 22), new Position(0, 26)));
     assertEquals(var1Location.toString(), location.toString());
 
     // 2rd VAR1
-    location = extendedText.mapLocation(new Range(new Position(0, 38), new Position(0, 41)));
+    location = extendedText.mapLocation(new Range(new Position(0, 38), new Position(0, 42)));
     assertEquals(var1Location.toString(), location.toString());
   }
 

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -478,7 +478,7 @@ class ExtendedTextTest {
     assertEquals(var2Location.toString(), location.toString());
 
     // line 2: D(ISPLAY)
-    location = extendedText.mapLocation(new Range(new Position(2, 1), new Position(2, 6)));
+    location = extendedText.mapLocation(new Range(new Position(1, 1), new Position(1, 6)));
     assertEquals(statementLocation.toString(), location.toString());
 
     // line 2: VAR1

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/ExtendedTextTest.java
@@ -677,7 +677,7 @@ class ExtendedTextTest {
   }
 
   @Test
-  void testReplaceWithMap_edge_case() {
+  void testReplaceWithMap_edge_case_1() {
     ExtendedText extendedText = new ExtendedText("STATEMENT AB", "uri");
     Map<String, Range> statementMap =
         ImmutableMap.of(
@@ -700,5 +700,30 @@ class ExtendedTextTest {
         new Location("uri", new Range(new Position(0, 10), new Position(0, 11))), locationA);
     assertEquals(
         new Location("uri", new Range(new Position(0, 11), new Position(0, 12))), locationB);
+  }
+
+  @Test
+  void testReplaceWithMap_edge_case_2() {
+    ExtendedText extendedText = new ExtendedText("STATEMENT A,B", "uri");
+    Range rangeA = new Range(new Position(0, 10), new Position(0, 11));
+    Range rangeB = new Range(new Position(0, 12), new Position(0, 13));
+
+    Map<String, Range> statementMap =
+        ImmutableMap.of(
+            "A", rangeA,
+            "B", rangeB);
+
+    Range range = new Range(new Position(0, 0), new Position(0, 13));
+    Range statementRange = new Range(new Position(0, 0), new Position(0, 9));
+    extendedText.replace(range, statementRange, statementMap, "STATEMENT {A}{B}");
+
+    Location locationA =
+        extendedText.mapLocation(new Range(new Position(0, 10), new Position(0, 11)));
+    Location locationB =
+        extendedText.mapLocation(new Range(new Position(0, 11), new Position(0, 12)));
+
+    assertEquals("STATEMENT AB", extendedText.toString());
+    assertEquals(new Location("uri", rangeA), locationA);
+    assertEquals(new Location("uri", rangeB), locationB);
   }
 }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/MappingHelperTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/MappingHelperTest.java
@@ -32,11 +32,16 @@ public class MappingHelperTest {
   }
 
   @Test
+  void testValidateRange_character_start_greater_character_end_same_line() {
+    MappingHelper.validateRange(new Range(new Position(0, 7), new Position(4, 2)));
+  }
+
+  @Test
   void testValidateRange_character_start_greater_character_end() {
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> MappingHelper.validateRange(new Range(new Position(0, 7), new Position(4, 2))));
+            () -> MappingHelper.validateRange(new Range(new Position(0, 7), new Position(0, 2))));
     assertEquals("Invalid range", exception.getMessage());
   }
 

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/MappingHelperTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/MappingHelperTest.java
@@ -22,13 +22,39 @@ import org.junit.jupiter.api.Test;
 
 /** Tests for MappingHelper * */
 public class MappingHelperTest {
+
   @Test
-  void testValidateRange_line_start_greater_line_end() {
+  void testValidateRange_null() {
     Exception exception =
         assertThrowsExactly(
-            IllegalArgumentException.class,
-            () -> MappingHelper.validateRange(new Range(new Position(5, 0), new Position(4, 0))));
-    assertEquals("Invalid range", exception.getMessage());
+            IllegalArgumentException.class, () -> MappingHelper.validateRange(null));
+    assertEquals("range is marked non-null but is null", exception.getMessage());
+  }
+
+  @Test
+  void testValidateRange_start_null() {
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class, () -> MappingHelper.validateRange(new Range()));
+    assertEquals("Range start is null", exception.getMessage());
+  }
+
+  @Test
+  void testValidateRange_end_null() {
+    Exception exception =
+        assertThrowsExactly(
+            NullPointerException.class,
+            () -> MappingHelper.validateRange(new Range(new Position(), null)));
+    assertEquals("Property must not be null: end", exception.getMessage());
+  }
+
+  @Test
+  void testValidateRange_line_start_greater_line_end() {
+    Range range = new Range(new Position(5, 0), new Position(4, 0));
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class, () -> MappingHelper.validateRange(range));
+    assertEquals("Invalid range: " + range, exception.getMessage());
   }
 
   @Test
@@ -38,46 +64,46 @@ public class MappingHelperTest {
 
   @Test
   void testValidateRange_character_start_greater_character_end() {
+    Range range = new Range(new Position(0, 7), new Position(0, 2));
     Exception exception =
         assertThrowsExactly(
-            IllegalArgumentException.class,
-            () -> MappingHelper.validateRange(new Range(new Position(0, 7), new Position(0, 2))));
-    assertEquals("Invalid range", exception.getMessage());
+            IllegalArgumentException.class, () -> MappingHelper.validateRange(range));
+    assertEquals("Invalid range: " + range, exception.getMessage());
   }
 
   @Test
   void testValidateRange_line_start_less_zero() {
+    Range range = new Range(new Position(-2, 0), new Position(4, 0));
     Exception exception =
         assertThrowsExactly(
-            IllegalArgumentException.class,
-            () -> MappingHelper.validateRange(new Range(new Position(-2, 0), new Position(4, 0))));
-    assertEquals("Invalid range", exception.getMessage());
+            IllegalArgumentException.class, () -> MappingHelper.validateRange(range));
+    assertEquals("Invalid range: " + range, exception.getMessage());
   }
 
   @Test
   void testValidateRange_line_end_less_zero() {
+    Range range = new Range(new Position(0, 0), new Position(-4, 0));
     Exception exception =
         assertThrowsExactly(
-            IllegalArgumentException.class,
-            () -> MappingHelper.validateRange(new Range(new Position(0, 0), new Position(-4, 0))));
-    assertEquals("Invalid range", exception.getMessage());
+            IllegalArgumentException.class, () -> MappingHelper.validateRange(range));
+    assertEquals("Invalid range: " + range, exception.getMessage());
   }
 
   @Test
   void testValidateRange_char_start_less_zero() {
+    Range range = new Range(new Position(0, -7), new Position(4, 2));
     Exception exception =
         assertThrowsExactly(
-            IllegalArgumentException.class,
-            () -> MappingHelper.validateRange(new Range(new Position(0, -7), new Position(4, 2))));
-    assertEquals("Invalid range", exception.getMessage());
+            IllegalArgumentException.class, () -> MappingHelper.validateRange(range));
+    assertEquals("Invalid range: " + range, exception.getMessage());
   }
 
   @Test
   void testValidateRange_char_end_less_zero() {
+    Range range = new Range(new Position(0, 0), new Position(4, -2));
     Exception exception =
         assertThrowsExactly(
-            IllegalArgumentException.class,
-            () -> MappingHelper.validateRange(new Range(new Position(0, 0), new Position(4, -2))));
-    assertEquals("Invalid range", exception.getMessage());
+            IllegalArgumentException.class, () -> MappingHelper.validateRange(range));
+    assertEquals("Invalid range: " + range, exception.getMessage());
   }
 }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/MappingHelperTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/MappingHelperTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.common.mapping;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/** Tests for MappingHelper * */
+public class MappingHelperTest {
+  @Test
+  void testValidateRange_line_start_greater_line_end() {
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> MappingHelper.validateRange(new Range(new Position(5, 0), new Position(4, 0))));
+    assertEquals("Invalid range", exception.getMessage());
+  }
+
+  @Test
+  void testValidateRange_character_start_greater_character_end() {
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> MappingHelper.validateRange(new Range(new Position(0, 7), new Position(4, 2))));
+    assertEquals("Invalid range", exception.getMessage());
+  }
+
+  @Test
+  void testValidateRange_line_start_less_zero() {
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> MappingHelper.validateRange(new Range(new Position(-2, 0), new Position(4, 0))));
+    assertEquals("Invalid range", exception.getMessage());
+  }
+
+  @Test
+  void testValidateRange_line_end_less_zero() {
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> MappingHelper.validateRange(new Range(new Position(0, 0), new Position(-4, 0))));
+    assertEquals("Invalid range", exception.getMessage());
+  }
+
+  @Test
+  void testValidateRange_char_start_less_zero() {
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> MappingHelper.validateRange(new Range(new Position(0, -7), new Position(4, 2))));
+    assertEquals("Invalid range", exception.getMessage());
+  }
+
+  @Test
+  void testValidateRange_char_end_less_zero() {
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> MappingHelper.validateRange(new Range(new Position(0, 0), new Position(4, -2))));
+    assertEquals("Invalid range", exception.getMessage());
+  }
+}

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
@@ -195,17 +195,12 @@ class TextMapReplacerTest {
   }
 
   @Test
-  void testValidateParameters_replacementMap_duplicate_separator() {
-    TextMapReplacer replacer =
-        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+  void testValidateParameters_replacementMap_allow_duplicate_separator() {
+    ExtendedText extendedText = new ExtendedText("TOKEN in the extended text document", "uri");
+    TextMapReplacer replacer = new TextMapReplacer(extendedText);
 
-    Exception exception =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{TOKEN|BBB|CCC}"));
-    assertEquals(
-        "Replacement map error: duplicated separator symbol \"|\". Line: 0, character: 10",
-        exception.getMessage());
+    replacer.execute(createRange(), createRange(), "{TOKEN}", "{TOKEN|BBB|CCC}");
+    assertEquals(extendedText.toString(), "BBB|CCC in the extended text document");
   }
 
   @Test

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
@@ -260,7 +260,8 @@ class TextMapReplacerTest {
             IllegalArgumentException.class,
             () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "STATEMENT {TOKEN}&"));
     assertEquals(
-        "Replacement map error: Dangling escape character in the input string. Line: 0, character: 17",
+        "Replacement map error: Dangling escape character in the input string. Line: 0, character:"
+            + " 17",
         exception.getMessage());
   }
 

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2025 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.common.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/** Tests for TextMapReplacer * */
+class TextMapReplacerTest {
+  @Test
+  void testValidateParameters_statementMap_empty() {
+    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "", "{TOKEN}"));
+    assertEquals("Map cannot be empty", exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_statementMap_empty_token() {
+    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{}", "{TOKEN}"));
+    assertEquals(
+        "Statement map error: token name cannot be empty. Line: 0, character: 0",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_statementMap_no_tokens() {
+    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "TEXT TEXT", "{TOKEN}"));
+    assertEquals("Statement map must contain at least 1 token name", exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_statementMap_duplicated_tokens() {
+    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{AAA} {AAA}", "{TOKEN}"));
+    assertEquals(
+        "Statement map contains duplicated token \"AAA\". Line: 0, character: 7",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_statementMap_leave_brace_opened() {
+    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{AAA} {AAA", "{TOKEN}"));
+    assertEquals(
+        "Statement map error: opening brace { has no matching closing brace. Line: 0, character: 9",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_statementMap_brace_opened_twice_1() {
+    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{A{", "{TOKEN}"));
+    assertEquals(
+        "Statement map error: expected \"}\" instead of \"{\". Line: 0, character: 2",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_statementMap_brace_opened_twice_2() {
+    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{{", "{TOKEN}"));
+    assertEquals(
+        "Statement map error: expected \"}\" instead of \"{\". Line: 0, character: 1",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_statementMap_brace_closed_before_opened() {
+    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{A}B}", "{TOKEN}"));
+    assertEquals(
+        "Statement map error: expected \"{\" instead of \"}\". Line: 0, character: 4",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_replacementMap_brace_opened_twice_1() {
+    TextMapReplacer replacer =
+        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{A{"));
+    assertEquals(
+        "Replacement map error: expected \"}\" instead of \"{\". Line: 0, character: 2",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_replacementMap_brace_opened_twice_2() {
+    TextMapReplacer replacer =
+        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{{"));
+    assertEquals(
+        "Replacement map error: expected \"}\" instead of \"{\". Line: 0, character: 1",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_replacementMap_brace_closed_before_opened() {
+    TextMapReplacer replacer =
+        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{TOKEN}B}"));
+    assertEquals(
+        "Replacement map error: expected \"{\" instead of \"}\". Line: 0, character: 8",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_replacementMap_leave_brace_opened() {
+    TextMapReplacer replacer =
+        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{TOKEN} {AAA"));
+    assertEquals(
+        "Replacement map error: opening brace { has no matching closing brace. Line: 0, character: "
+            + "11",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_replacementMap_token_not_found() {
+    TextMapReplacer replacer =
+        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{AAA|BBB}{B}"));
+    assertEquals(
+        "Replacement map error: token \"AAA\" not found. Line: 0, character: 1",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_replacementMap_duplicate_separator() {
+    TextMapReplacer replacer =
+        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{TOKEN|BBB|CCC}"));
+    assertEquals(
+        "Replacement map error: duplicated separator symbol \"|\". Line: 0, character: 10",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_replacementMap_misplaced_separator_1() {
+    TextMapReplacer replacer =
+        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{TOKEN|}"));
+    assertEquals(
+        "Replacement map error: token value cannot be empty. Line: 0, character: 7",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_replacementMap_misplaced_separator_2() {
+    TextMapReplacer replacer =
+        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{|TOKEN}"));
+    assertEquals(
+        "Replacement map error: token \"\" not found. Line: 0, character: 1",
+        exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_replacementMap_empty_token() {
+    TextMapReplacer replacer =
+        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{}"));
+    assertEquals(
+        "Replacement map error: token \"\" not found. Line: 0, character: 1",
+        exception.getMessage());
+  }
+
+  private Range createRange() {
+    return new Range(new Position(0, 0), new Position(0, 5));
+  }
+}

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
@@ -250,6 +250,20 @@ class TextMapReplacerTest {
         exception.getMessage());
   }
 
+  @Test
+  void testValidateParameters_replacementMap_dangling_escape_character() {
+    TextMapReplacer replacer =
+        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "STATEMENT {TOKEN}&"));
+    assertEquals(
+        "Replacement map error: Dangling escape character in the input string. Line: 0, character: 17",
+        exception.getMessage());
+  }
+
   private Range createRange() {
     return new Range(new Position(0, 0), new Position(0, 5));
   }

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
@@ -25,23 +25,26 @@ import org.junit.jupiter.api.Test;
 class TextMapReplacerTest {
   @Test
   void testValidateParameters_statementMap_empty() {
-    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+    ExtendedText extendedText = new ExtendedText("text", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "", "{TOKEN}"));
+            () ->
+                TextMapReplacer.execute(extendedText, createRange(), createRange(), "", "{TOKEN}"));
     assertEquals("Map cannot be empty", exception.getMessage());
   }
 
   @Test
   void testValidateParameters_statementMap_empty_token() {
-    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+    ExtendedText extendedText = new ExtendedText("text", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{}", "{TOKEN}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{}", "{TOKEN}"));
     assertEquals(
         "Statement map error: token name cannot be empty. Line: 0, character: 0",
         exception.getMessage());
@@ -49,23 +52,27 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_statementMap_no_tokens() {
-    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+    ExtendedText extendedText = new ExtendedText("text", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "TEXT TEXT", "{TOKEN}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "TEXT TEXT", "{TOKEN}"));
     assertEquals("Statement map must contain at least 1 token name", exception.getMessage());
   }
 
   @Test
   void testValidateParameters_statementMap_duplicated_tokens() {
-    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+    ExtendedText extendedText = new ExtendedText("text", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{AAA} {AAA}", "{TOKEN}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{AAA} {AAA}", "{TOKEN}"));
     assertEquals(
         "Statement map contains duplicated token \"AAA\". Line: 0, character: 7",
         exception.getMessage());
@@ -73,12 +80,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_statementMap_leave_brace_opened() {
-    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+    ExtendedText extendedText = new ExtendedText("text", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{AAA} {AAA", "{TOKEN}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{AAA} {AAA", "{TOKEN}"));
     assertEquals(
         "Statement map error: opening brace { has no matching closing brace. Line: 0, character: 9",
         exception.getMessage());
@@ -86,12 +95,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_statementMap_brace_opened_twice_1() {
-    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+    ExtendedText extendedText = new ExtendedText("text", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{A{", "{TOKEN}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{A{", "{TOKEN}"));
     assertEquals(
         "Statement map error: expected \"}\" instead of \"{\". Line: 0, character: 2",
         exception.getMessage());
@@ -99,12 +110,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_statementMap_brace_opened_twice_2() {
-    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+    ExtendedText extendedText = new ExtendedText("text", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{{", "{TOKEN}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{{", "{TOKEN}"));
     assertEquals(
         "Statement map error: expected \"}\" instead of \"{\". Line: 0, character: 1",
         exception.getMessage());
@@ -112,12 +125,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_statementMap_brace_closed_before_opened() {
-    TextMapReplacer replacer = new TextMapReplacer(new ExtendedText("text", "uri"));
+    ExtendedText extendedText = new ExtendedText("text", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{A}B}", "{TOKEN}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{A}B}", "{TOKEN}"));
     assertEquals(
         "Statement map error: expected \"{\" instead of \"}\". Line: 0, character: 4",
         exception.getMessage());
@@ -125,13 +140,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_replacementMap_brace_opened_twice_1() {
-    TextMapReplacer replacer =
-        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{A{"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{TOKEN}", "{A{"));
     assertEquals(
         "Replacement map error: expected \"}\" instead of \"{\". Line: 0, character: 2",
         exception.getMessage());
@@ -139,13 +155,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_replacementMap_brace_opened_twice_2() {
-    TextMapReplacer replacer =
-        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{{"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{TOKEN}", "{{"));
     assertEquals(
         "Replacement map error: expected \"}\" instead of \"{\". Line: 0, character: 1",
         exception.getMessage());
@@ -153,13 +170,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_replacementMap_brace_closed_before_opened() {
-    TextMapReplacer replacer =
-        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{TOKEN}B}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{TOKEN}", "{TOKEN}B}"));
     assertEquals(
         "Replacement map error: expected \"{\" instead of \"}\". Line: 0, character: 8",
         exception.getMessage());
@@ -167,13 +185,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_replacementMap_leave_brace_opened() {
-    TextMapReplacer replacer =
-        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{TOKEN} {AAA"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{TOKEN}", "{TOKEN} {AAA"));
     assertEquals(
         "Replacement map error: opening brace { has no matching closing brace. Line: 0, character: "
             + "11",
@@ -182,13 +201,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_replacementMap_token_not_found() {
-    TextMapReplacer replacer =
-        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{AAA|BBB}{B}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{TOKEN}", "{AAA|BBB}{B}"));
     assertEquals(
         "Replacement map error: token \"AAA\" not found. Line: 0, character: 1",
         exception.getMessage());
@@ -197,21 +217,22 @@ class TextMapReplacerTest {
   @Test
   void testValidateParameters_replacementMap_allow_duplicate_separator() {
     ExtendedText extendedText = new ExtendedText("TOKEN in the extended text document", "uri");
-    TextMapReplacer replacer = new TextMapReplacer(extendedText);
 
-    replacer.execute(createRange(), createRange(), "{TOKEN}", "{TOKEN|BBB|CCC}");
+    TextMapReplacer.execute(
+        extendedText, createRange(), createRange(), "{TOKEN}", "{TOKEN|BBB|CCC}");
     assertEquals(extendedText.toString(), "BBB|CCC in the extended text document");
   }
 
   @Test
   void testValidateParameters_replacementMap_misplaced_separator_1() {
-    TextMapReplacer replacer =
-        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{TOKEN|}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{TOKEN}", "{TOKEN|}"));
     assertEquals(
         "Replacement map error: token value cannot be empty. Line: 0, character: 7",
         exception.getMessage());
@@ -219,13 +240,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_replacementMap_misplaced_separator_2() {
-    TextMapReplacer replacer =
-        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{|TOKEN}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{TOKEN}", "{|TOKEN}"));
     assertEquals(
         "Replacement map error: token \"\" not found. Line: 0, character: 1",
         exception.getMessage());
@@ -233,13 +255,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_replacementMap_empty_token() {
-    TextMapReplacer replacer =
-        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "{}"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{TOKEN}", "{}"));
     assertEquals(
         "Replacement map error: token \"\" not found. Line: 0, character: 1",
         exception.getMessage());
@@ -247,13 +270,14 @@ class TextMapReplacerTest {
 
   @Test
   void testValidateParameters_replacementMap_dangling_escape_character() {
-    TextMapReplacer replacer =
-        new TextMapReplacer(new ExtendedText("Extended text document", "uri"));
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
-            () -> replacer.execute(createRange(), createRange(), "{TOKEN}", "STATEMENT {TOKEN}&"));
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), "{TOKEN}", "STATEMENT {TOKEN}&"));
     assertEquals(
         "Replacement map error: Dangling escape character in the input string. Line: 0, character:"
             + " 17",

--- a/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
+++ b/server/common/src/test/java/org/eclipse/lsp/cobol/common/mapping/TextMapReplacerTest.java
@@ -17,6 +17,8 @@ package org.eclipse.lsp.cobol.common.mapping;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
@@ -25,121 +27,6 @@ import org.junit.jupiter.api.Test;
 class TextMapReplacerTest {
   @Test
   void testValidateParameters_statementMap_empty() {
-    ExtendedText extendedText = new ExtendedText("text", "uri");
-
-    Exception exception =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () ->
-                TextMapReplacer.execute(extendedText, createRange(), createRange(), "", "{TOKEN}"));
-    assertEquals("Map cannot be empty", exception.getMessage());
-  }
-
-  @Test
-  void testValidateParameters_statementMap_empty_token() {
-    ExtendedText extendedText = new ExtendedText("text", "uri");
-
-    Exception exception =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () ->
-                TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{}", "{TOKEN}"));
-    assertEquals(
-        "Statement map error: token name cannot be empty. Line: 0, character: 0",
-        exception.getMessage());
-  }
-
-  @Test
-  void testValidateParameters_statementMap_no_tokens() {
-    ExtendedText extendedText = new ExtendedText("text", "uri");
-
-    Exception exception =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () ->
-                TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "TEXT TEXT", "{TOKEN}"));
-    assertEquals("Statement map must contain at least 1 token name", exception.getMessage());
-  }
-
-  @Test
-  void testValidateParameters_statementMap_duplicated_tokens() {
-    ExtendedText extendedText = new ExtendedText("text", "uri");
-
-    Exception exception =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () ->
-                TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{AAA} {AAA}", "{TOKEN}"));
-    assertEquals(
-        "Statement map contains duplicated token \"AAA\". Line: 0, character: 7",
-        exception.getMessage());
-  }
-
-  @Test
-  void testValidateParameters_statementMap_leave_brace_opened() {
-    ExtendedText extendedText = new ExtendedText("text", "uri");
-
-    Exception exception =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () ->
-                TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{AAA} {AAA", "{TOKEN}"));
-    assertEquals(
-        "Statement map error: opening brace { has no matching closing brace. Line: 0, character: 9",
-        exception.getMessage());
-  }
-
-  @Test
-  void testValidateParameters_statementMap_brace_opened_twice_1() {
-    ExtendedText extendedText = new ExtendedText("text", "uri");
-
-    Exception exception =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () ->
-                TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{A{", "{TOKEN}"));
-    assertEquals(
-        "Statement map error: expected \"}\" instead of \"{\". Line: 0, character: 2",
-        exception.getMessage());
-  }
-
-  @Test
-  void testValidateParameters_statementMap_brace_opened_twice_2() {
-    ExtendedText extendedText = new ExtendedText("text", "uri");
-
-    Exception exception =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () ->
-                TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{{", "{TOKEN}"));
-    assertEquals(
-        "Statement map error: expected \"}\" instead of \"{\". Line: 0, character: 1",
-        exception.getMessage());
-  }
-
-  @Test
-  void testValidateParameters_statementMap_brace_closed_before_opened() {
-    ExtendedText extendedText = new ExtendedText("text", "uri");
-
-    Exception exception =
-        assertThrowsExactly(
-            IllegalArgumentException.class,
-            () ->
-                TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{A}B}", "{TOKEN}"));
-    assertEquals(
-        "Statement map error: expected \"{\" instead of \"}\". Line: 0, character: 4",
-        exception.getMessage());
-  }
-
-  @Test
-  void testValidateParameters_replacementMap_brace_opened_twice_1() {
     ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
 
     Exception exception =
@@ -147,7 +34,36 @@ class TextMapReplacerTest {
             IllegalArgumentException.class,
             () ->
                 TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{TOKEN}", "{A{"));
+                    extendedText, createRange(), createRange(), ImmutableMap.of(), "{TOKEN}"));
+    assertEquals("Statement map must contain at least 1 token name", exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_statementMap_empty_token() {
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap = ImmutableMap.of("", createRange());
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), statementMap, "{TOKEN}"));
+    assertEquals("Token name cannot be empty", exception.getMessage());
+  }
+
+  @Test
+  void testValidateParameters_replacementMap_brace_opened_twice_1() {
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("TOKEN", new Range(new Position(0, 0), new Position(0, 8)));
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () ->
+                TextMapReplacer.execute(
+                    extendedText, createRange(), createRange(), statementMap, "{A{"));
     assertEquals(
         "Replacement map error: expected \"}\" instead of \"{\". Line: 0, character: 2",
         exception.getMessage());
@@ -156,13 +72,15 @@ class TextMapReplacerTest {
   @Test
   void testValidateParameters_replacementMap_brace_opened_twice_2() {
     ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("TOKEN", new Range(new Position(0, 0), new Position(0, 8)));
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
             () ->
                 TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{TOKEN}", "{{"));
+                    extendedText, createRange(), createRange(), statementMap, "{{"));
     assertEquals(
         "Replacement map error: expected \"}\" instead of \"{\". Line: 0, character: 1",
         exception.getMessage());
@@ -171,13 +89,15 @@ class TextMapReplacerTest {
   @Test
   void testValidateParameters_replacementMap_brace_closed_before_opened() {
     ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("TOKEN", new Range(new Position(0, 0), new Position(0, 8)));
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
             () ->
                 TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{TOKEN}", "{TOKEN}B}"));
+                    extendedText, createRange(), createRange(), statementMap, "{TOKEN}B}"));
     assertEquals(
         "Replacement map error: expected \"{\" instead of \"}\". Line: 0, character: 8",
         exception.getMessage());
@@ -186,13 +106,15 @@ class TextMapReplacerTest {
   @Test
   void testValidateParameters_replacementMap_leave_brace_opened() {
     ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("TOKEN", new Range(new Position(0, 0), new Position(0, 8)));
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
             () ->
                 TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{TOKEN}", "{TOKEN} {AAA"));
+                    extendedText, createRange(), createRange(), statementMap, "{TOKEN} {AAA"));
     assertEquals(
         "Replacement map error: opening brace { has no matching closing brace. Line: 0, character: "
             + "11",
@@ -202,13 +124,15 @@ class TextMapReplacerTest {
   @Test
   void testValidateParameters_replacementMap_token_not_found() {
     ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("TOKEN", new Range(new Position(0, 0), new Position(0, 8)));
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
             () ->
                 TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{TOKEN}", "{AAA|BBB}{B}"));
+                    extendedText, createRange(), createRange(), statementMap, "{AAA|BBB}{B}"));
     assertEquals(
         "Replacement map error: token \"AAA\" not found. Line: 0, character: 1",
         exception.getMessage());
@@ -217,22 +141,26 @@ class TextMapReplacerTest {
   @Test
   void testValidateParameters_replacementMap_allow_duplicate_separator() {
     ExtendedText extendedText = new ExtendedText("TOKEN in the extended text document", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("TOKEN", new Range(new Position(0, 0), new Position(0, 8)));
 
     TextMapReplacer.execute(
-        extendedText, createRange(), createRange(), "{TOKEN}", "{TOKEN|BBB|CCC}");
+        extendedText, createRange(), createRange(), statementMap, "{TOKEN|BBB|CCC}");
     assertEquals(extendedText.toString(), "BBB|CCC in the extended text document");
   }
 
   @Test
   void testValidateParameters_replacementMap_misplaced_separator_1() {
     ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("TOKEN", new Range(new Position(0, 0), new Position(0, 8)));
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
             () ->
                 TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{TOKEN}", "{TOKEN|}"));
+                    extendedText, createRange(), createRange(), statementMap, "{TOKEN|}"));
     assertEquals(
         "Replacement map error: token value cannot be empty. Line: 0, character: 7",
         exception.getMessage());
@@ -241,13 +169,15 @@ class TextMapReplacerTest {
   @Test
   void testValidateParameters_replacementMap_misplaced_separator_2() {
     ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("TOKEN", new Range(new Position(0, 0), new Position(0, 8)));
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
             () ->
                 TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{TOKEN}", "{|TOKEN}"));
+                    extendedText, createRange(), createRange(), statementMap, "{|TOKEN}"));
     assertEquals(
         "Replacement map error: token \"\" not found. Line: 0, character: 1",
         exception.getMessage());
@@ -256,13 +186,15 @@ class TextMapReplacerTest {
   @Test
   void testValidateParameters_replacementMap_empty_token() {
     ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("TOKEN", new Range(new Position(0, 0), new Position(0, 8)));
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
             () ->
                 TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{TOKEN}", "{}"));
+                    extendedText, createRange(), createRange(), statementMap, "{}"));
     assertEquals(
         "Replacement map error: token \"\" not found. Line: 0, character: 1",
         exception.getMessage());
@@ -271,20 +203,107 @@ class TextMapReplacerTest {
   @Test
   void testValidateParameters_replacementMap_dangling_escape_character() {
     ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap =
+        ImmutableMap.of("TOKEN", new Range(new Position(0, 0), new Position(0, 8)));
 
     Exception exception =
         assertThrowsExactly(
             IllegalArgumentException.class,
             () ->
                 TextMapReplacer.execute(
-                    extendedText, createRange(), createRange(), "{TOKEN}", "STATEMENT {TOKEN}&"));
+                    extendedText,
+                    createRange(),
+                    createRange(),
+                    statementMap,
+                    "STATEMENT {TOKEN}&"));
     assertEquals(
         "Replacement map error: Dangling escape character in the input string. Line: 0, character:"
             + " 17",
         exception.getMessage());
   }
 
+  @Test
+  void testValidateReplacementRange_start_line() {
+    testValidateRange(
+        new Range(new Position(1, 0), new Position(1, 5)),
+        new Range(new Position(0, 0), new Position(0, 8)),
+        "Replacing range error: range start line out of bounds");
+  }
+
+  @Test
+  void testValidateReplacementRange_start_character() {
+    testValidateRange(
+        new Range(new Position(0, 30), new Position(0, 35)),
+        new Range(new Position(0, 0), new Position(0, 8)),
+        "Replacing range error: range start character out of bounds");
+  }
+
+  @Test
+  void testValidateReplacementRange_end_line() {
+    testValidateRange(
+        new Range(new Position(0, 0), new Position(4, 5)),
+        new Range(new Position(0, 0), new Position(0, 8)),
+        "Replacing range error: range end line out of bounds");
+  }
+
+  @Test
+  void testValidateReplacementRange_end_character() {
+    testValidateRange(
+        new Range(new Position(0, 0), new Position(0, 50)),
+        new Range(new Position(0, 0), new Position(0, 8)),
+        "Replacing range error: range end character out of bounds");
+  }
+
+  @Test
+  void testValidateTokenRange_start_line() {
+    testValidateRange(
+        new Range(new Position(0, 0), new Position(0, 14)),
+        new Range(new Position(1, 0), new Position(1, 8)),
+        "Token name \"TOKEN\" range error: range start line out of bounds");
+  }
+
+  @Test
+  void testValidateTokenRange_start_character() {
+    testValidateRange(
+        new Range(new Position(0, 0), new Position(0, 14)),
+        new Range(new Position(0, 30), new Position(0, 38)),
+        "Token name \"TOKEN\" range error: range start character out of bounds");
+  }
+
+  @Test
+  void testValidateTokenRange_same_line() {
+    testValidateRange(
+        new Range(new Position(0, 0), new Position(0, 14)),
+        new Range(new Position(0, 0), new Position(1, 8)),
+        "Token name TOKEN must be on the same line");
+  }
+
+  @Test
+  void testValidateTokenRange_end_character() {
+    testValidateRange(
+        new Range(new Position(0, 0), new Position(0, 14)),
+        new Range(new Position(0, 0), new Position(0, 38)),
+        "Token name \"TOKEN\" range error: range end character out of bounds");
+  }
+
   private Range createRange() {
     return new Range(new Position(0, 0), new Position(0, 5));
+  }
+
+  private void testValidateRange(Range statementRange, Range tokenRange, String message) {
+    ExtendedText extendedText = new ExtendedText("Extended text document", "uri");
+    Map<String, Range> statementMap = ImmutableMap.of("TOKEN", tokenRange);
+
+    Exception exception =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () ->
+                TextMapReplacer.execute(
+                    extendedText,
+                    statementRange,
+                    createRange(),
+                    statementMap,
+                    "STATEMENT {TOKEN}&"));
+    assertEquals(message, exception.getMessage());
   }
 }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -19,7 +19,7 @@
     </modules>
 
     <properties>
-        <dialect.api.version>1.0.15</dialect.api.version>
+        <dialect.api.version>1.0.16</dialect.api.version>
         <maven.compiler.release>8</maven.compiler.release>
         <commons.text.version>1.14.0</commons.text.version>
     </properties>


### PR DESCRIPTION
This improvement is needed to properly map possible dialect's statement constructions like:
```
STATEMENT VAR1 BY VAR2 WITH PAR1 AND PAR2
``` 
that can be replaced by the dialect to the code:

```
MOVE  VAR1 TO VAR2.
PERFORM PAR1 THRU PAR2.
```

For now it is not possible to map VAR1, PAR1 and PAR2 to the original VAR1, PAR1 and PAR2 and in the same time all other characters to the ```STATEMENT``` keyword.

This PR is covering this case

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
