### PR TITLE
ci: Run web test in ESM mode

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -576,7 +576,7 @@
     "build:web": "node build.web.js",
     "build:watch": "npm run build -- --watch",
     "test:integration": "npm run compile && node ./out/test/runTest.js",
-    "test:web": "npm run build:web && vscode-test-web --browserType=chromium --headless --extensionDevelopmentPath=. --extensionTestsPath=dist/web/test/suite/extensionTests.js",
+    "test:web": "npm run build:web && vscode-test-web --browserType=chromium --headless --extensionDevelopmentPath=. --extensionTestsPath=dist/web/test/suite/extensionTests.js --esm",
     "compile": "npm run build:worker && tsc -p ./",
     "lint-format": "prettier -c .",
     "lint-quality": "eslint ./src",


### PR DESCRIPTION
It looks like non-ESM mode was removed from the insiders version.