### PR TITLE
fix: Preserve API compatibility with non-VSCode LSP clients

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/extension.ts
@@ -244,7 +244,10 @@ async function initializeLanguageClientService(
     "workspace/configuration",
     (r: Parameters<typeof lspConfigHandler>[0]) => lspConfigHandler(r),
   );
-  languageClientService.addRequestHandler("copybook/uri", resolveCopybookURI);
+  languageClientService.addRequestHandler(
+    "copybook/resolve",
+    resolveCopybookURI,
+  );
   languageClientService.addRequestHandler("file/content", readFileContent);
 
   try {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/jrpc/CobolLanguageClient.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/jrpc/CobolLanguageClient.java
@@ -37,30 +37,15 @@ public interface CobolLanguageClient extends LanguageClient, DialectClientApi {
   }
 
   /**
-   * The copybook/resolve request is sent from the server to the client to resolve copybook local
-   * absolute path if found
-   *
-   * @param cobolFileUri the uri of cobol program
-   * @param copybookName the name of copybook to resolve
-   * @param dialectType the name of copybook dialect
-   * @return corresponding local file absolute path
-   */
-  @JsonRequest("copybook/resolve")
-  default CompletableFuture<String> resolveCopybook(
-      String cobolFileUri, String copybookName, String dialectType) {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * The copybook/uri request is sent from the server to the client to resolve / identify a copybook
-   * name into a file URI.
+   * The copybook/resolve request is sent from the server to the client to resolve / identify a
+   * copybook name into a file URI.
    *
    * @param cobolFileUri the uri of cobol program
    * @param copybookName the name of copybook to resolve
    * @param dialectType the name of copybook dialect
    * @return corresponding a file URI or null.
    */
-  @JsonRequest("copybook/uri")
+  @JsonRequest("copybook/resolve")
   default CompletableFuture<String> resolveCopybookUri(
       String cobolFileUri, String copybookName, String dialectType) {
     throw new UnsupportedOperationException();

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/io/impl/ClientBasedFileContent.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/io/impl/ClientBasedFileContent.java
@@ -16,13 +16,22 @@ package org.eclipse.lsp.cobol.service.io.impl;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import java.io.File;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.common.io.ResolveFileContent;
 import org.eclipse.lsp.cobol.lsp.jrpc.CobolLanguageClient;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 
 /** Resolves content of a URI */
+@Slf4j
 public class ClientBasedFileContent implements ResolveFileContent {
   private final Provider<CobolLanguageClient> clientProvider;
+  private boolean clientSupportsFileContent = true;
 
   @Inject
   public ClientBasedFileContent(Provider<CobolLanguageClient> clientProvider) {
@@ -37,6 +46,37 @@ public class ClientBasedFileContent implements ResolveFileContent {
    */
   @Override
   public CompletableFuture<String> getFileContent(String uri) {
-    return clientProvider.get().getFileContent(uri);
+    if (!clientSupportsFileContent) return CompletableFuture.completedFuture(readFromFile(uri));
+
+    return clientProvider
+        .get()
+        .getFileContent(uri)
+        .exceptionally(
+            ex -> {
+              LOG.warn("getFileContent error:", ex);
+              if (isMethodNotFoundError(ex)) {
+                clientSupportsFileContent = false;
+                return readFromFile(uri);
+              }
+              return null;
+            });
+  }
+
+  private static boolean isMethodNotFoundError(Throwable ex) {
+    return ex instanceof ResponseErrorException
+        && ((ResponseErrorException) ex).getResponseError().getCode()
+            == ResponseErrorCode.MethodNotFound.getValue();
+  }
+
+  private static String readFromFile(String uri) {
+    if (!uri.startsWith("file:")) return null;
+
+    try {
+      return new String(
+          Files.readAllBytes(new File(new URI(uri)).toPath()), StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      LOG.warn("readFromFile error:", e);
+      return null;
+    }
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/io/impl/DiskBasedFileContent.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/io/impl/DiskBasedFileContent.java
@@ -36,10 +36,14 @@ public class DiskBasedFileContent implements ResolveFileContent {
    */
   @Override
   public CompletableFuture<String> getFileContent(String uri) {
-    Path file = fileSystemService.getPathFromURI(uri);
-    return CompletableFuture.completedFuture(
-        fileSystemService.fileExists(file)
-            ? fileSystemService.getContentByPath(Objects.requireNonNull(file))
-            : null);
+    try {
+      final Path file = fileSystemService.getPathFromURI(uri);
+      return CompletableFuture.completedFuture(
+          fileSystemService.fileExists(file)
+              ? fileSystemService.getContentByPath(Objects.requireNonNull(file))
+              : null);
+    } catch (IllegalArgumentException e) {
+      return CompletableFuture.completedFuture(null);
+    }
   }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookServiceTest.java
@@ -41,6 +41,9 @@ import org.eclipse.lsp.cobol.lsp.jrpc.CobolLanguageClient;
 import org.eclipse.lsp.cobol.service.io.impl.DiskBasedFileContent;
 import org.eclipse.lsp.cobol.service.io.impl.NonCacheResolveCopybookUri;
 import org.eclipse.lsp.cobol.service.providers.ClientProvider;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -301,7 +304,13 @@ class CopybookServiceTest {
     CopybookName copybookName = new CopybookName(VALID_CPY_NAME);
     CopybookService copybookService = createCopybookService();
 
-    when(client.resolveCopybook(anyString(), anyString(), any())).thenReturn(completedFuture(null));
+    when(client.resolveCopybookUri(anyString(), anyString(), any()))
+        .thenReturn(
+            supplyAsync(
+                () -> {
+                  throw new ResponseErrorException(
+                      new ResponseError(ResponseErrorCode.InternalError, "Boom", null));
+                }));
     CopybookModel copybookModel =
         copybookService
             .resolve(
@@ -313,8 +322,7 @@ class CopybookServiceTest {
             .getResult();
 
     assertEquals(
-        new CopybookModel(
-            copybookName.toCopybookId(DOCUMENT_URI), copybookName, VALID_CPY_URI, "content"),
+        new CopybookModel(copybookName.toCopybookId(DOCUMENT_URI), copybookName, null, null),
         copybookModel);
   }
 


### PR DESCRIPTION
- Renames the copybook resolve request back to `copybook/resolve`
- Falls back to direct file I/O for `file` URI scheme if `file/content` is not implemented
- Tested with Neovim