### PR TITLE
fix: clear copybook resolution cache when endevor dependencies configuration changes

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/services/util/ConfigurationWatcher.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/ConfigurationWatcher.ts
@@ -13,10 +13,15 @@
  */
 
 import * as vscode from "vscode";
-import { SERVER_RUNTIME } from "../../constants";
+import {
+  SERVER_RUNTIME,
+  SETTINGS_CPY_NDVR_DEPENDENCIES,
+  SETTINGS_CPY_SECTION,
+} from "../../constants";
 import { SettingsService } from "../Settings";
 import { telemetryEvent } from "../reporter";
 import { clearDiagnostics } from "../ExternalAPIsService";
+import { clearWorkspaceConfigCache } from "../ProcessorGroupsLoader";
 
 export class ConfigurationWatcher {
   private static async restartVsCode() {
@@ -51,6 +56,13 @@ export class ConfigurationWatcher {
     vscode.workspace.onDidChangeConfiguration(async (event) => {
       if (event.affectsConfiguration(SERVER_RUNTIME)) {
         await this.handleServerRuntimeConfigurationChange();
+      }
+      if (
+        event.affectsConfiguration(
+          `${SETTINGS_CPY_SECTION}.${SETTINGS_CPY_NDVR_DEPENDENCIES}`,
+        )
+      ) {
+        clearWorkspaceConfigCache();
       }
       clearDiagnostics();
     });


### PR DESCRIPTION
Fix for [DE661366](https://rally1.rallydev.com/#/?detail=/defect/841954252859&fdp=true): Endevor copybooks are not getting resolved when VSC settings corrected

Clears workspace config cache when `cobol-lsp.cpy-manager.endevor-dependencies` configuration value changes - that forces re-resolve the copybook location.

## How Has This Been Tested?

Manual testing.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
