### PR TITLE
fix: Change notifications do not trigger re-analysis

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/extension.ts
@@ -122,6 +122,7 @@ export async function activate(
     executeCommand: (command, args, next) => {
       if (command == "missing copybook") {
         externalApis?.clearProfiles();
+        externalApis?.clearCache();
       }
       next(command, args);
     },
@@ -132,6 +133,7 @@ export async function activate(
     languageClientService.invalidateConfiguration,
     tarCache,
   );
+  context.subscriptions.push(externalApis);
 
   const analysisService = new ControlFlowAnalysisService(
     outputChannel,

--- a/clients/cobol-lsp-vscode-extension/src/services/ExternalAPIsService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ExternalAPIsService.ts
@@ -86,13 +86,23 @@ export function clearDiagnostics() {
   diagnosticCollection.clear();
 }
 
-class ExternalAPIsService {
+function makeCreateDeleteWatcher(scheme: string) {
+  return vscode.workspace.createFileSystemWatcher(
+    new vscode.RelativePattern(vscode.Uri.from({ scheme, path: "/" }), "**/*"),
+    false,
+    true,
+    false,
+  );
+}
+
+class ExternalAPIsService implements vscode.Disposable {
   e4eApi: E4E | undefined;
   dsnService?: CopybookDownloaderForDsn;
   ussService?: CopybookDownloaderForUss;
   e4eDownloader?: CopybookDownloaderForE4E;
   binaryDownloader?: CopybookBinaryDownloader;
   tarCache?: Memoize<[tarFileUri: vscode.Uri], TarContent[]>;
+  toDispose: vscode.Disposable[] = [];
 
   constructor(
     private storagePath: vscode.Uri,
@@ -104,6 +114,11 @@ class ExternalAPIsService {
     if (e4e) this.e4eAppeared(e4e);
     if (explorer) this.explorerAppeared(explorer);
     if (tarCache) this.tarCache = tarCache;
+  }
+
+  dispose(): void {
+    for (const d of this.toDispose.reverse()) d.dispose();
+    this.toDispose = [];
   }
 
   /**
@@ -138,8 +153,10 @@ class ExternalAPIsService {
   }
 
   public explorerAppeared(api: IApiRegisterClient) {
-    this.ussService = new CopybookDownloaderForUss();
-    this.dsnService = new CopybookDownloaderForDsn();
+    const ussService = new CopybookDownloaderForUss();
+    const dsnService = new CopybookDownloaderForDsn();
+    this.ussService = ussService;
+    this.dsnService = dsnService;
     this.binaryDownloader = new CopybookBinaryDownloader(this.storagePath, api);
     diagnosticCollection.clear();
     if (api.onProfileUpdated) {
@@ -151,6 +168,16 @@ class ExternalAPIsService {
         }
       });
     }
+    const ussWatcher = makeCreateDeleteWatcher("zowe-uss");
+    const dsWatcher = makeCreateDeleteWatcher("zowe-ds");
+    this.toDispose.push(
+      ussWatcher,
+      ussWatcher.onDidCreate((uri) => ussService.fsChanged(uri)),
+      ussWatcher.onDidDelete((uri) => ussService.fsChanged(uri)),
+      dsWatcher,
+      dsWatcher.onDidCreate((uri) => dsnService.fsChanged(uri)),
+      dsWatcher.onDidDelete((uri) => dsnService.fsChanged(uri)),
+    );
   }
 
   public reenableFailedRequests() {

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/ZoweExplorerDownloader.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/ZoweExplorerDownloader.ts
@@ -20,6 +20,8 @@ export interface MemberCacheItem {
   extension?: string;
 }
 
+const extractPartialId = /\/([^/]+)\/(.*)\/[^/]+/;
+
 export abstract class ZoweExplorerDownloader {
   public static profileStore: Map<string, "locked-profile" | "valid-profile"> =
     new Map();
@@ -35,6 +37,19 @@ export abstract class ZoweExplorerDownloader {
    */
   public clearMemberListCache() {
     this.memberListCache.clear();
+  }
+
+  public fsChanged(uri: vscode.Uri) {
+    const m = extractPartialId.exec(uri.path);
+    if (!m) return;
+
+    const profile = m[1];
+    const partialPath = m[2];
+    const partialKey = `${profile}|${partialPath}`;
+
+    [...this.memberListCache.keys()]
+      .filter((x) => x.startsWith(partialKey))
+      .forEach((k) => this.memberListCache.delete(k));
   }
 
   public reenableFailedRequests() {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/workspace/DidChangeWatchedFilesHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/workspace/DidChangeWatchedFilesHandler.java
@@ -17,11 +17,9 @@ package org.eclipse.lsp.cobol.lsp.handlers.workspace;
 import com.google.inject.Inject;
 import java.net.URI;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -30,8 +28,9 @@ import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp.cobol.common.UserInterruptException;
 import org.eclipse.lsp.cobol.lsp.DisposableLSPStateService;
 import org.eclipse.lsp.cobol.lsp.SourceUnitGraph;
@@ -69,17 +68,25 @@ public class DidChangeWatchedFilesHandler {
   public void didChangeWatchedFiles(@NonNull DidChangeWatchedFilesParams params) {
     if (lspStateService.isServerShutdown()) return;
 
-    Set<FileEvent> relevantChanges = filterRelevantChanges(params.getChanges());
+    List<FileEvent> relevantChanges = filterRelevantChanges(params.getChanges());
     if (relevantChanges.isEmpty()) return;
 
-    logFileChanges(relevantChanges);
+    logFileChanges(relevantChanges.stream().map(FileEvent::getUri).collect(Collectors.toSet()));
     processFileEvents(relevantChanges);
   }
 
-  private Set<FileEvent> filterRelevantChanges(List<FileEvent> changes) {
+  private List<FileEvent> filterRelevantChanges(List<FileEvent> changes) {
     return changes.stream()
         .filter(this::isRelevantFileChange)
-        .collect(Collectors.toCollection(HashSet::new));
+        .filter(
+            event -> {
+              final boolean inEditor = isOpenInEditor(event.getUri());
+              if (inEditor) {
+                LOG.debug("Ignoring change for open file: {}", event.getUri());
+              }
+              return !inEditor;
+            })
+        .collect(Collectors.toList());
   }
 
   private boolean isRelevantFileChange(FileEvent change) {
@@ -96,84 +103,67 @@ public class DidChangeWatchedFilesHandler {
     return uri.startsWith(VSCODE_SCHEME_PREFIX);
   }
 
-  private void logFileChanges(Set<FileEvent> changes) {
-    LOG.info(
-        "[File change event]: {}",
-        changes.stream().map(FileEvent::getUri).collect(Collectors.joining(", ")));
+  private void logFileChanges(Set<String> changes) {
+    LOG.info("[File change event]: {}", changes.stream().collect(Collectors.joining(", ")));
   }
 
-  private void processFileEvents(Set<FileEvent> changes) {
-    Set<ChangeEvent> changeEvents =
-        changes.stream().map(this::mapFileEventToChangeEvent).collect(Collectors.toSet());
-
-    boolean hasNullEvent = changeEvents.stream().anyMatch(Objects::isNull);
-    boolean hasDirectoryEvent =
-        changeEvents.stream().filter(Objects::nonNull).anyMatch(ChangeEvent::isDirectory);
-    if (hasDirectoryEvent || hasNullEvent) {
+  private void processFileEvents(List<FileEvent> changes) {
+    if (changes.stream().anyMatch(DidChangeWatchedFilesHandler::isCreateOrDelete)) {
       analyzeAllOpenedDocuments();
-    } else {
-      Map<String, Set<String>> cobolSourceToCopybookUris =
-          changeEvents.stream()
-              .filter(e -> !e.shouldIgnore)
-              .flatMap(
-                  e ->
-                      e.getAffectedUris().stream()
-                          .map(val -> new AbstractMap.SimpleEntry<>(val, e.getUri())))
-              .collect(
-                  Collectors.groupingBy(
-                      Map.Entry::getKey,
-                      Collectors.mapping(Map.Entry::getValue, Collectors.toSet())));
-
-      cobolSourceToCopybookUris.forEach(
-          (cobolDocUri, copybookUris) -> {
-            if (!sourceUnitGraph.isFileOpened(cobolDocUri)) {
-              asyncAnalysisService.reanalyseProgram(cobolDocUri, copybookUris);
-            }
-          });
+      return;
     }
+
+    final List<Pair<FileEvent, URI>> data =
+        changes.stream()
+            .map(event -> ImmutablePair.of(event, toUri(event)))
+            .filter(p -> p.getRight() != null)
+            .collect(Collectors.toList());
+
+    if (data.stream()
+        .map(p -> p.getRight())
+        .anyMatch(DidChangeWatchedFilesHandler::isDirectoryUri)) {
+      analyzeAllOpenedDocuments();
+      return;
+    }
+
+    Set<ChangeEvent> changeEvents =
+        data.stream()
+            .map(p -> getEffectedSourceChangeEvent(p.getLeft().getUri()))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    Map<String, Set<String>> cobolSourceToCopybookUris =
+        changeEvents.stream()
+            .flatMap(
+                e ->
+                    e.getAffectedUris().stream()
+                        .map(val -> new AbstractMap.SimpleEntry<>(val, e.getUri())))
+            .collect(
+                Collectors.groupingBy(
+                    Map.Entry::getKey,
+                    Collectors.mapping(Map.Entry::getValue, Collectors.toSet())));
+
+    cobolSourceToCopybookUris.forEach(
+        (cobolDocUri, copybookUris) -> {
+          asyncAnalysisService.reanalyseProgram(cobolDocUri, copybookUris);
+        });
   }
 
-  private ChangeEvent mapFileEventToChangeEvent(FileEvent event) {
+  private static boolean isCreateOrDelete(FileEvent event) {
+    return event.getType() == FileChangeType.Deleted || event.getType() == FileChangeType.Created;
+  }
+
+  private static URI toUri(FileEvent event) {
     try {
-      URI uri = URI.create(event.getUri());
-      if (FILE_SCHEME.equals(uri.getScheme())) {
-        return getLocalFileSystemChange(event, uri);
-      } else {
-        return getEffectedSourceChangeEvent(event.getUri());
-      }
+      return URI.create(event.getUri());
     } catch (IllegalArgumentException e) {
       LOG.error("Invalid URI in FileEvent:{}, error:{}", event.getUri(), e.getMessage());
       return null;
     }
   }
 
-  private ChangeEvent getLocalFileSystemChange(FileEvent event, URI uri) {
-    try {
-      Path path = getEffectivePath(event, uri);
-      String fileUri = path.toUri().toString();
-
-      if (isOpenInEditor(fileUri)) {
-        LOG.debug("Ignoring change for open file: {}", fileUri);
-        ChangeEvent changeEvent = new ChangeEvent(uri.getPath(), false);
-        changeEvent.setShouldIgnore(true);
-        return changeEvent;
-      }
-
-      if (Files.isDirectory(path)) {
-        return new ChangeEvent(uri.getPath(), true);
-      } else {
-        return getEffectedSourceChangeEvent(fileUri);
-      }
-    } catch (Exception e) {
-      LOG.error(
-          "Error handling local file system change:{}, for uri {}", e.getMessage(), event.getUri());
-      return null;
-    }
-  }
-
-  private Path getEffectivePath(FileEvent event, URI uri) {
-    Path path = Paths.get(uri);
-    return event.getType() == FileChangeType.Deleted ? path.getParent() : path;
+  private static boolean isDirectoryUri(URI uri) {
+    return FILE_SCHEME.equals(uri.getScheme()) && Files.isDirectory(Paths.get(uri));
   }
 
   private boolean isOpenInEditor(String uri) {
@@ -183,9 +173,7 @@ public class DidChangeWatchedFilesHandler {
   private ChangeEvent getEffectedSourceChangeEvent(String uri) {
     List<String> associatedUris = sourceUnitGraph.getAllAssociatedFilesForACopybook(uri);
     if (associatedUris.isEmpty()) {
-      ChangeEvent event = new ChangeEvent(uri, associatedUris);
-      event.setShouldIgnore(true);
-      return event;
+      return null;
     }
     return new ChangeEvent(uri, associatedUris);
   }
@@ -205,7 +193,6 @@ public class DidChangeWatchedFilesHandler {
     private final String uri;
     private final boolean isDirectory;
     private final List<String> affectedUris;
-    @Setter private boolean shouldIgnore;
 
     private ChangeEvent(String uri, boolean isDirectory) {
       this(uri, isDirectory, Collections.emptyList());
@@ -219,7 +206,6 @@ public class DidChangeWatchedFilesHandler {
       this.uri = uri;
       this.isDirectory = isDirectory;
       this.affectedUris = affectedUris;
-      this.shouldIgnore = false;
     }
   }
 }


### PR DESCRIPTION
Fixes the following issues:
- Creating or deleting data set members does not trigger re-analysis
- Requesting re-analysis manually has no effect