### PR TITLE
fix: Java 8 rejects unrestricted lookback in regex

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/replacement/SearchPattern.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/replacement/SearchPattern.java
@@ -88,7 +88,7 @@ public enum SearchPattern {
   };
 
   private static String adjustSpaces(String escapeSpecialCharacters) {
-    return String.join("\\s+", escapeSpecialCharacters.split("[\\r\\n]*\\s+"));
+    return String.join("\\s{1,999}", escapeSpecialCharacters.split("[\\r\\n]*\\s+"));
   }
 
   private static boolean isQuotedString(String text) {

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/util/impl/ReplacingServiceImplTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/util/impl/ReplacingServiceImplTest.java
@@ -91,7 +91,7 @@ class ReplacingServiceImplTest {
             ImmutablePair.of("", ""), locality, CobolLanguageId.COBOL, SearchPattern.EXACT));
     assertEquals(
         new ResultWithErrors<>(
-            Pair.of("a\\s+b\\s+c(?<=(?:^|[.,;]?\\s)a\\s+b\\s+c)(?=[,;]?\\s|\\.|$)", ""),
+            Pair.of("a\\s{1,999}b\\s{1,999}c(?<=(?:^|[.,;]?\\s)a\\s{1,999}b\\s{1,999}c)(?=[,;]?\\s|\\.|$)", ""),
             Collections.emptyList()),
         replacingService.retrievePseudoTextReplacingPattern(
             ImmutablePair.of("a   b  \nc", ""),
@@ -127,7 +127,7 @@ class ReplacingServiceImplTest {
         replacingService.retrieveTokenReplacingPattern(
             Pair.of("IDENTIFICATION", "DIVISION"), CobolLanguageId.COBOL));
     assertEquals(
-        Pair.of("\\s+A(?<=(?:^|[.,;]?\\s)\\s+A)(?=[,;]?\\s|\\.|$)", "B"),
+        Pair.of("\\s{1,999}A(?<=(?:^|[.,;]?\\s)\\s{1,999}A)(?=[,;]?\\s|\\.|$)", "B"),
         replacingService.retrieveTokenReplacingPattern(
             Pair.of("\n" + "A", "\n" + "  B "), CobolLanguageId.COBOL));
   }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/util/impl/ReplacingServiceImplTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/util/impl/ReplacingServiceImplTest.java
@@ -91,7 +91,9 @@ class ReplacingServiceImplTest {
             ImmutablePair.of("", ""), locality, CobolLanguageId.COBOL, SearchPattern.EXACT));
     assertEquals(
         new ResultWithErrors<>(
-            Pair.of("a\\s{1,999}b\\s{1,999}c(?<=(?:^|[.,;]?\\s)a\\s{1,999}b\\s{1,999}c)(?=[,;]?\\s|\\.|$)", ""),
+            Pair.of(
+                "a\\s{1,999}b\\s{1,999}c(?<=(?:^|[.,;]?\\s)a\\s{1,999}b\\s{1,999}c)(?=[,;]?\\s|\\.|$)",
+                ""),
             Collections.emptyList()),
         replacingService.retrievePseudoTextReplacingPattern(
             ImmutablePair.of("a   b  \nc", ""),


### PR DESCRIPTION
The following exception is generated whenever we try to use a regex with unrestrict lookback:

```
ERROR org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService - Encountered Exception java.util.regex.PatternSyntaxException: Look-behind group does not have an obvious maximum length near index 37
01\s+SQLCA(?<=(?:^|[.,;]?\s)01\s+SQLCA)(?=[,;]?\s|\.|$)
```

At the same time we cannot place simpler lookback at the beginning of the regex pattern as it was causing performance issues.