### PR TITLE
fix: make sure E4E download path is contained inside the extension gl…

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForE4E.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForE4E.ts
@@ -240,8 +240,19 @@ export class CopybookDownloaderForE4E {
     );
     let finishedPath = downloadFolder;
     for (const subdirectory of subdirectories) {
+      if (
+        subdirectory === ".." ||
+        subdirectory === "." ||
+        subdirectory.includes("/") ||
+        subdirectory.includes("\\")
+      ) {
+        throw Error(
+          `Can't download E4E copybooks. Encountered issue while deciding the download path.
+          Subdirectory ${subdirectory} contains not allowed chars /, \\, or ..
+          `,
+        );
+      }
       finishedPath = vscode.Uri.joinPath(finishedPath, subdirectory);
-
       try {
         await vscode.workspace.fs.createDirectory(finishedPath);
       } catch (err) {


### PR DESCRIPTION
…obal-storage directory

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
