### PR TITLE
Adjust Help message

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/CliAnalysis.java
@@ -222,7 +222,7 @@ public class CliAnalysis implements Callable<Integer> {
 
     @CommandLine.Option(
         names = {"-ce", "--copybook-extension"},
-        description = "List of copybook paths.")
+        description = "List of copybook extensions.")
     private String[] cpyExt = {"", ".cpy"};
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListCopybooks.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListCopybooks.java
@@ -68,7 +68,7 @@ public class ListCopybooks implements Callable<Integer> {
 
     @CommandLine.Option(
         names = {"-ce", "--copybook-extension"},
-        description = "List of copybook paths.")
+        description = "List of copybook extensions.")
     private String[] cpyExt = {"", ".cpy"};
   }
 


### PR DESCRIPTION
Adjust the help message to reflect that the `-ce` flag is used for the extension types, not the paths.

## How Has This Been Tested?

Replaced the string, built the .jar file and ran the command to see the corrected help message.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
