### PR TITLE
fix: fix daco exec statement coloring

### DIFF
--- a/clients/daco-dialect-support/syntaxes/daco.injection.json
+++ b/clients/daco-dialect-support/syntaxes/daco.injection.json
@@ -15,7 +15,7 @@
             "name": "keyword.cobol"
           },
       "exec-statement": {
-        "begin": "\\b(EXEC)\\b",
+        "begin": "\\b(EXEC(?!(?i) +(?:SQL|CICS)))\\b",
         "beginCaptures": {
           "1": { "name": "keyword.cobol.daco" }
         },

--- a/clients/daco-dialect-support/syntaxes/daco.injection.json
+++ b/clients/daco-dialect-support/syntaxes/daco.injection.json
@@ -30,6 +30,10 @@
             "name": "string.quoted.single.daco"
           },
           {
+            "match": "\"[^\"]*\"",
+            "name": "string.quoted.double.daco"
+          },
+          {
             "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b",
             "name": "source.cobol.daco"
           }

--- a/clients/daco-dialect-support/syntaxes/daco.injection.json
+++ b/clients/daco-dialect-support/syntaxes/daco.injection.json
@@ -1,7 +1,10 @@
 {
     "scopeName": "daco.injection",
-    "injectionSelector": "R:source.cobol",
+    "injectionSelector": "L:source.cobol",
     "patterns": [
+      {
+        "include": "#exec-statement"
+      },
       {
         "include": "#da-co-keywords"
       }
@@ -10,6 +13,27 @@
         "da-co-keywords": {
             "match": "(?<![\\-\\w])(?i:ASC|BUFFER|CHECK|DEBUG-CONTENTS|DEBUG-ITEM|DEBUG-LINE|DEBUG-NAME|DEBUG-SUB-1|DEBUG-SUB-2|DEBUG-SUB-3|DES|DESCRIPTION|DFLD|DOM|DUPLICATE|ENDRPT|ENTITY|GRS|INVERT|ITEM|JNIENVPTR|JOB|LINE-COUNTER|MODIFY|ODETTE|PACKET|PAGE-COUNTER|PRIOR|RESTORE|RESULT|RETURN-CODE|ROW|RCU|SHIFT-IN|SHIFT-OUT|SHOW|SINGLE|SORT-CONTROL|SORT-CORE-SIZE|SORT-FILE-SIZE|SORT-MESSAGE|SORT-MODE-SIZE|SORT-RETURN|TALLY|TASK|TRANSACTION|USER|YES|TRANSFER|ABEND|ATTACH|BIND|CHANGE|COMMIT|CONNECT|DC|DEQUEUE|DISCONNECT|ENDPAGE|ENQUEUE|ERASE|FINISH|FREE|INQUIRE|KEEP|LOAD|OBTAIN|POST|PUT|ROLLBACK|SNAP|STARTPAGE|STORE)(?![\\-\\w])",
             "name": "keyword.cobol"
+          },
+      "exec-statement": {
+        "begin": "\\b(EXEC)\\b",
+        "beginCaptures": {
+          "1": { "name": "keyword.cobol.daco" }
+        },
+        "end": "(?=\\s*\\.?\\n)|(?=^.{72,})|$",
+        "patterns": [
+          {
+            "match": "\\b(USING)\\b",
+            "name": "keyword.cobol.daco"
+          },
+          {
+            "match": "'[^']*'",
+            "name": "string.quoted.single.daco"
+          },
+          {
+            "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b",
+            "name": "source.cobol.daco"
           }
+        ]
+      }
     }
   }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test no regression introduced in coloring apart from the fix of #3041 

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
