### PR TITLE
Only raise copybook error for actual errors

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/errors/ErrorFinalizerService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/errors/ErrorFinalizerService.java
@@ -267,7 +267,8 @@ public class ErrorFinalizerService {
     return err ->
         (err.getLocation() != null
             && err.getLocation().getCopybookId() != null
-            && !processedErrors.contains(err));
+            && !processedErrors.contains(err)
+            && err.getSeverity() == ErrorSeverity.ERROR);
   }
 
   /**


### PR DESCRIPTION
Do not raise "Errors inside the copybook" for warning or lower severity messages.

## How Has This Been Tested?

Ran all existing tests and they passed.

## Checklist:
- [x] Each of my commits contains one meaningful change
- [x] I have performed rebase of my branch on top of the development
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
