### PR TITLE
fix: cancel hangup LS message upon encountering exception in analysis

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/LspEventConsumer.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/LspEventConsumer.java
@@ -17,19 +17,14 @@ package org.eclipse.lsp.cobol.lsp;
 import static org.eclipse.lsp.cobol.lsp.LspMessageBroker.POISON_PILL;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 /** A consumer of {@link LspMessageBroker} */
 @Slf4j
 public class LspEventConsumer {
-  private static final long MAX_PENDING_MILLIS = TimeUnit.SECONDS.toMillis(30);
-
   @Getter private final LspMessageBroker lspMessageBroker;
   private final ExecutorService singleThreadExecutor =
       Executors.newSingleThreadExecutor(r -> new Thread(r, "LSP Event Consumer"));
@@ -37,10 +32,6 @@ public class LspEventConsumer {
       Executors.newSingleThreadExecutor(r -> new Thread(r, "LSP Notification Consumer"));
   private final ExecutorService queryThreadExecutor =
       Executors.newSingleThreadExecutor(r -> new Thread(r, "LSP Query Consumer"));
-  // Tracks how long each pending LspQuery has been waiting on its dependencies, so a query
-  // whose dependency never becomes satisfied (e.g. analysis kept failing) is not requeued
-  // forever; keyed by event identity since LspQuery implementations don't override equals().
-  private final ConcurrentHashMap<LspQuery<?>, Long> pendingSince = new ConcurrentHashMap<>();
 
   protected LspEventConsumer(LspMessageBroker lspMessageBroker) {
     this.lspMessageBroker = lspMessageBroker;
@@ -64,7 +55,6 @@ public class LspEventConsumer {
   private <T> void handle(LspQuery<T> event) {
     if (event.getResult().isCancelled()) {
       LOG.info(event + " was canceled.");
-      pendingSince.remove(event);
       return;
     }
     try {
@@ -75,31 +65,15 @@ public class LspEventConsumer {
         if (isCanceled) {
           LOG.debug("cancel event: " + event);
           event.getResult().cancel(true);
-          pendingSince.remove(event);
-        } else if (isPendingTooLong(event)) {
-          LOG.warn(event + " timed out waiting for its dependencies to be satisfied.");
-          event
-              .getResult()
-              .completeExceptionally(
-                  new TimeoutException("Timed out waiting for dependencies: " + event));
-          pendingSince.remove(event);
         } else {
           this.lspMessageBroker.putBack(event);
         }
         return;
       }
       event.getResult().complete(event.query());
-      pendingSince.remove(event);
     } catch (Exception e) {
       event.getResult().completeExceptionally(e);
-      pendingSince.remove(event);
     }
-  }
-
-  private boolean isPendingTooLong(LspQuery<?> event) {
-    long now = System.currentTimeMillis();
-    long firstSeen = pendingSince.computeIfAbsent(event, e -> now);
-    return now - firstSeen >= MAX_PENDING_MILLIS;
   }
 
   private void consume() throws InterruptedException {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/LspEventConsumer.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/LspEventConsumer.java
@@ -17,14 +17,19 @@ package org.eclipse.lsp.cobol.lsp;
 import static org.eclipse.lsp.cobol.lsp.LspMessageBroker.POISON_PILL;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 /** A consumer of {@link LspMessageBroker} */
 @Slf4j
 public class LspEventConsumer {
+  private static final long MAX_PENDING_MILLIS = TimeUnit.SECONDS.toMillis(30);
+
   @Getter private final LspMessageBroker lspMessageBroker;
   private final ExecutorService singleThreadExecutor =
       Executors.newSingleThreadExecutor(r -> new Thread(r, "LSP Event Consumer"));
@@ -32,6 +37,10 @@ public class LspEventConsumer {
       Executors.newSingleThreadExecutor(r -> new Thread(r, "LSP Notification Consumer"));
   private final ExecutorService queryThreadExecutor =
       Executors.newSingleThreadExecutor(r -> new Thread(r, "LSP Query Consumer"));
+  // Tracks how long each pending LspQuery has been waiting on its dependencies, so a query
+  // whose dependency never becomes satisfied (e.g. analysis kept failing) is not requeued
+  // forever; keyed by event identity since LspQuery implementations don't override equals().
+  private final ConcurrentHashMap<LspQuery<?>, Long> pendingSince = new ConcurrentHashMap<>();
 
   protected LspEventConsumer(LspMessageBroker lspMessageBroker) {
     this.lspMessageBroker = lspMessageBroker;
@@ -55,6 +64,7 @@ public class LspEventConsumer {
   private <T> void handle(LspQuery<T> event) {
     if (event.getResult().isCancelled()) {
       LOG.info(event + " was canceled.");
+      pendingSince.remove(event);
       return;
     }
     try {
@@ -65,15 +75,29 @@ public class LspEventConsumer {
         if (isCanceled) {
           LOG.debug("cancel event: " + event);
           event.getResult().cancel(true);
+          pendingSince.remove(event);
+        } else if (isPendingTooLong(event)) {
+          LOG.warn(event + " timed out waiting for its dependencies to be satisfied.");
+          event.getResult().completeExceptionally(
+              new TimeoutException("Timed out waiting for dependencies: " + event));
+          pendingSince.remove(event);
         } else {
           this.lspMessageBroker.putBack(event);
         }
         return;
       }
       event.getResult().complete(event.query());
+      pendingSince.remove(event);
     } catch (Exception e) {
       event.getResult().completeExceptionally(e);
+      pendingSince.remove(event);
     }
+  }
+
+  private boolean isPendingTooLong(LspQuery<?> event) {
+    long now = System.currentTimeMillis();
+    long firstSeen = pendingSince.computeIfAbsent(event, e -> now);
+    return now - firstSeen >= MAX_PENDING_MILLIS;
   }
 
   private void consume() throws InterruptedException {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/LspEventConsumer.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/LspEventConsumer.java
@@ -78,8 +78,10 @@ public class LspEventConsumer {
           pendingSince.remove(event);
         } else if (isPendingTooLong(event)) {
           LOG.warn(event + " timed out waiting for its dependencies to be satisfied.");
-          event.getResult().completeExceptionally(
-              new TimeoutException("Timed out waiting for dependencies: " + event));
+          event
+              .getResult()
+              .completeExceptionally(
+                  new TimeoutException("Timed out waiting for dependencies: " + event));
           pendingSince.remove(event);
         } else {
           this.lspMessageBroker.putBack(event);

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/analysis/AsyncAnalysisService.java
@@ -354,14 +354,10 @@ public class AsyncAnalysisService implements AnalysisStateNotifier {
       }
       if (sourceUnitGraph.isUserSuppliedCopybook(uri)) {
         return documentModelService.findMainSource(uri).stream()
-            .map(
-                documentModel ->
-                    documentModel.getLastAnalysisResult() != null
-                        && documentModel.getLastAnalysisResult() != AnalysisResult.EMPTY)
+            .map(documentModel -> documentModel.getLastAnalysisResult() != null)
             .reduce(Boolean.TRUE, Boolean::logicalAnd);
       }
-      return doc.getLastAnalysisResult() != null
-          && doc.getLastAnalysisResult() != AnalysisResult.EMPTY;
+      return doc.getLastAnalysisResult() != null;
     };
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/CompletionQuery.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/CompletionQuery.java
@@ -17,6 +17,7 @@ package org.eclipse.lsp.cobol.lsp.events.queries;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.handlers.text.CompletionHandler;
@@ -51,5 +52,10 @@ public class CompletionQuery implements LspQuery<Either<List<CompletionItem>, Co
   public Either<List<CompletionItem>, CompletionList> query()
       throws ExecutionException, InterruptedException {
     return completionHandler.completion(params);
+  }
+
+  @Override
+  public List<LspEventCancelCondition> getCancelConditions() {
+    return completionHandler.getCancelConditions(params);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/DefinitionQuery.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/DefinitionQuery.java
@@ -17,6 +17,7 @@ package org.eclipse.lsp.cobol.lsp.events.queries;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.handlers.text.DefinitionHandler;
@@ -53,5 +54,10 @@ public class DefinitionQuery
   public Either<List<? extends Location>, List<? extends LocationLink>> query()
       throws ExecutionException, InterruptedException {
     return definitionHandler.definition(params);
+  }
+
+  @Override
+  public List<LspEventCancelCondition> getCancelConditions() {
+    return definitionHandler.getCancelConditions(params);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/DocumentHighlightQuery.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/DocumentHighlightQuery.java
@@ -16,6 +16,7 @@ package org.eclipse.lsp.cobol.lsp.events.queries;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.handlers.text.DocumentHighlightHandler;
@@ -48,5 +49,10 @@ public class DocumentHighlightQuery implements LspQuery<List<? extends DocumentH
   @Override
   public List<? extends DocumentHighlight> query() {
     return this.documentHighlightHandler.documentHighlight(params);
+  }
+
+  @Override
+  public List<LspEventCancelCondition> getCancelConditions() {
+    return documentHighlightHandler.getCancelConditions(params);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/FormattingQuery.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/FormattingQuery.java
@@ -16,6 +16,7 @@ package org.eclipse.lsp.cobol.lsp.events.queries;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.handlers.text.FormattingHandler;
@@ -47,5 +48,10 @@ public class FormattingQuery implements LspQuery<List<? extends TextEdit>> {
   @Override
   public List<? extends TextEdit> query() {
     return formattingHandler.formatting(params);
+  }
+
+  @Override
+  public List<LspEventCancelCondition> getCancelConditions() {
+    return formattingHandler.getCancelConditions(params);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/HoverLspQuery.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/HoverLspQuery.java
@@ -17,6 +17,7 @@ package org.eclipse.lsp.cobol.lsp.events.queries;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.handlers.text.HoverHandler;
@@ -48,5 +49,10 @@ public class HoverLspQuery implements LspQuery<Hover> {
   @Override
   public Hover query() throws ExecutionException, InterruptedException {
     return hoverHandler.hover(params);
+  }
+
+  @Override
+  public List<LspEventCancelCondition> getCancelConditions() {
+    return hoverHandler.getCancelConditions(params);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/ReferenceQuery.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/events/queries/ReferenceQuery.java
@@ -17,6 +17,7 @@ package org.eclipse.lsp.cobol.lsp.events.queries;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.handlers.text.ReferencesHandler;
@@ -49,5 +50,10 @@ public class ReferenceQuery implements LspQuery<List<? extends Location>> {
   @Override
   public List<? extends Location> query() throws ExecutionException, InterruptedException {
     return this.referencesHandler.references(params);
+  }
+
+  @Override
+  public List<LspEventCancelCondition> getCancelConditions() {
+    return referencesHandler.getCancelConditions(params);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/CompletionHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/CompletionHandler.java
@@ -19,6 +19,7 @@ import com.google.inject.Inject;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
@@ -81,5 +82,16 @@ public class CompletionHandler {
   public List<LspEventDependency> getDocumentHighlightDependency(CompletionParams params) {
     return ImmutableList.of(
         asyncAnalysisService.createDependencyOn(params.getTextDocument().getUri()));
+  }
+
+  /**
+   * Cancel condition for the completion event: cancel if the document was closed.
+   *
+   * @param params CompletionParams.
+   * @return list of {@link LspEventCancelCondition}
+   */
+  public List<LspEventCancelCondition> getCancelConditions(CompletionParams params) {
+    return ImmutableList.of(
+        asyncAnalysisService.createCancelConditionOnClose(params.getTextDocument().getUri()));
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DefinitionHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DefinitionHandler.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
@@ -89,5 +90,16 @@ public class DefinitionHandler {
   public List<LspEventDependency> getDefinitionEventDependencies(DefinitionParams params) {
     return ImmutableList.of(
         asyncAnalysisService.createDependencyOn(params.getTextDocument().getUri()));
+  }
+
+  /**
+   * Cancel condition for the definition event: cancel if the document was closed.
+   *
+   * @param params DefinitionParams.
+   * @return list of {@link LspEventCancelCondition}
+   */
+  public List<LspEventCancelCondition> getCancelConditions(DefinitionParams params) {
+    return ImmutableList.of(
+        asyncAnalysisService.createCancelConditionOnClose(params.getTextDocument().getUri()));
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DocumentHighlightHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/DocumentHighlightHandler.java
@@ -17,6 +17,7 @@ package org.eclipse.lsp.cobol.lsp.handlers.text;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import java.util.List;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
@@ -53,6 +54,19 @@ public class DocumentHighlightHandler {
       DocumentHighlightParams documentHighlightParams) {
     return ImmutableList.of(
         asyncAnalysisService.createDependencyOn(
+            documentHighlightParams.getTextDocument().getUri()));
+  }
+
+  /**
+   * Cancel condition for the documentHighlight event: cancel if the document was closed.
+   *
+   * @param documentHighlightParams DocumentHighlightParams.
+   * @return list of {@link LspEventCancelCondition}
+   */
+  public List<LspEventCancelCondition> getCancelConditions(
+      DocumentHighlightParams documentHighlightParams) {
+    return ImmutableList.of(
+        asyncAnalysisService.createCancelConditionOnClose(
             documentHighlightParams.getTextDocument().getUri()));
   }
 

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/FormattingHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/FormattingHandler.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
@@ -73,5 +74,16 @@ public class FormattingHandler {
   public List<LspEventDependency> getDependencies(DocumentFormattingParams params) {
     return ImmutableList.of(
         asyncAnalysisService.createDependencyOn(params.getTextDocument().getUri()));
+  }
+
+  /**
+   * Cancel condition for the formatting event: cancel if the document was closed.
+   *
+   * @param params DocumentFormattingParams.
+   * @return list of {@link LspEventCancelCondition}
+   */
+  public List<LspEventCancelCondition> getCancelConditions(DocumentFormattingParams params) {
+    return ImmutableList.of(
+        asyncAnalysisService.createCancelConditionOnClose(params.getTextDocument().getUri()));
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/HoverHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/HoverHandler.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.SourceUnitGraph;
@@ -100,6 +101,17 @@ public class HoverHandler {
   public ImmutableList<LspEventDependency> getDependencies(HoverParams params) {
     return ImmutableList.of(
         asyncAnalysisService.createDependencyOn(params.getTextDocument().getUri()));
+  }
+
+  /**
+   * Cancel condition for the hover event: cancel if the document was closed.
+   *
+   * @param params HoverParams.
+   * @return list of {@link LspEventCancelCondition}
+   */
+  public List<LspEventCancelCondition> getCancelConditions(HoverParams params) {
+    return ImmutableList.of(
+        asyncAnalysisService.createCancelConditionOnClose(params.getTextDocument().getUri()));
   }
 
   /**

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/ReferencesHandler.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/handlers/text/ReferencesHandler.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import org.eclipse.lsp.cobol.lsp.LspEventCancelCondition;
 import org.eclipse.lsp.cobol.lsp.LspEventDependency;
 import org.eclipse.lsp.cobol.lsp.LspQuery;
 import org.eclipse.lsp.cobol.lsp.analysis.AsyncAnalysisService;
@@ -83,5 +84,16 @@ public class ReferencesHandler {
   public List<LspEventDependency> getReferenceDependency(ReferenceParams params) {
     return ImmutableList.of(
         asyncAnalysisService.createDependencyOn(params.getTextDocument().getUri()));
+  }
+
+  /**
+   * Cancel condition for the references event: cancel if the document was closed.
+   *
+   * @param params LSP ReferenceParams object.
+   * @return list of {@link LspEventCancelCondition}
+   */
+  public List<LspEventCancelCondition> getCancelConditions(ReferenceParams params) {
+    return ImmutableList.of(
+        asyncAnalysisService.createCancelConditionOnClose(params.getTextDocument().getUri()));
   }
 }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] In case an error occurs during analysis, vs code hangs (currently). This PR will try to handle this. No more vscode reload required

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
