### PR TITLE
fix: fix unbounded recursion in SourceUnitGraph

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/SourceUnitGraph.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/lsp/SourceUnitGraph.java
@@ -249,12 +249,18 @@ public class SourceUnitGraph implements AnalysisStateListener {
    */
   public List<String> getAllAssociatedFilesForACopybook(String uri) {
     List<String> result = new ArrayList<>();
-    List<String> linkedUris =
-        documentGraphIndexedByCopybook.getOrDefault(uri, Collections.emptyList());
-    linkedUris.remove(uri);
-    for (String linkedUri : linkedUris) {
-      if (documentGraphIndexedByCopybook.containsKey(linkedUri)) {
-        result.addAll(getAllAssociatedFilesForACopybook(linkedUri));
+    Set<String> visited = new HashSet<>();
+    visited.add(uri);
+    Deque<String> toVisit =
+        new ArrayDeque<>(documentGraphIndexedByCopybook.getOrDefault(uri, Collections.emptyList()));
+    while (!toVisit.isEmpty()) {
+      String linkedUri = toVisit.pop();
+      if (!visited.add(linkedUri)) {
+        continue;
+      }
+      List<String> linkedUris = documentGraphIndexedByCopybook.get(linkedUri);
+      if (linkedUris != null) {
+        toVisit.addAll(new ArrayList<>(linkedUris));
       } else {
         result.add(linkedUri);
       }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/SourceUnitGraphTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/lsp/SourceUnitGraphTest.java
@@ -110,4 +110,55 @@ class SourceUnitGraphTest {
     assertEquals(1, allAssociatedFilesForACopybook.size());
     assertEquals(URI, allAssociatedFilesForACopybook.get(0));
   }
+
+  @Test
+  void testCyclicCopybooksDoNotCauseStackOverflow() {
+    String mainUri = "file://M.cbl";
+    String copyAUri = "file://A.cpy";
+    String copyBUri = "file://B.cpy";
+    ResolveFileContent resolveFileContent = mock(ResolveFileContent.class);
+    when(resolveFileContent.getFileContent(anyString()))
+        .thenReturn(CompletableFuture.completedFuture("some dummy text"));
+    SourceUnitGraph sourceUnitGraph = new SourceUnitGraph(resolveFileContent);
+    RootNode rootNode = mock(RootNode.class);
+    CopyNode mainCopiesA =
+        new CopyNode(
+            Locality.builder().uri(mainUri).build(),
+            new Location(mainUri, new Range(new Position(0, 0), new Position(0, 5))),
+            "A",
+            copyAUri);
+    CopyNode aCopiesB =
+        new CopyNode(
+            Locality.builder().uri(copyAUri).build(),
+            new Location(copyAUri, new Range(new Position(0, 0), new Position(0, 5))),
+            "B",
+            copyBUri);
+    CopyNode bCopiesA =
+        new CopyNode(
+            Locality.builder().uri(copyBUri).build(),
+            new Location(copyBUri, new Range(new Position(0, 0), new Position(0, 5))),
+            "A",
+            copyAUri);
+    when(rootNode.getDepthFirstStream()).thenReturn(Stream.of(mainCopiesA, aCopiesB, bCopiesA));
+    CobolDocumentModel model =
+        new CobolDocumentModel(
+            mainUri, "text", AnalysisResult.builder().rootNode(rootNode).build());
+
+    // no StackOverflowError here
+    assertDoesNotThrow(() -> sourceUnitGraph.notifyState(AnalysisState.COMPLETED, model));
+
+    // searching it back from either copybook, still resolving to the real owner.
+    assertDoesNotThrow(
+        () -> {
+          List<String> result = sourceUnitGraph.getAllAssociatedFilesForACopybook(copyAUri);
+          assertEquals(1, result.size());
+          assertEquals(mainUri, result.get(0));
+        });
+    assertDoesNotThrow(
+        () -> {
+          List<String> result = sourceUnitGraph.getAllAssociatedFilesForACopybook(copyBUri);
+          assertEquals(1, result.size());
+          assertEquals(mainUri, result.get(0));
+        });
+  }
 }


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] In case of a cyclic copybook dependency, we get an error of recursive copybook (A.cpy -> B.cpy -> A.cpy , this is reproducible when cycle has more than 1 copybook i.e. A.cpy -> A.cpy even works now), but any edit to copybook doesn't work. This should be fixed by this PR 

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
