### PR TITLE
Cache processor groups glob patterns

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListSources.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListSources.java
@@ -57,7 +57,7 @@ public class ListSources implements Callable<Integer> {
     }
     JsonObject result = new JsonObject();
     JsonArray sources = new JsonArray();
-    if (Objects.nonNull(workspace)) {
+    if (Objects.nonNull(workspace) && Objects.nonNull(parent.processorGroupsResolver)) {
       try (Stream<Path> paths = Files.walk(workspace)) {
         Stream<Path> pathStream =
             paths
@@ -75,9 +75,6 @@ public class ListSources implements Callable<Integer> {
   }
 
   private boolean isSourceFile(Path f) {
-    if (Objects.isNull(parent.processorGroupsResolver)) {
-      return false;
-    }
     return parent.processorGroupsResolver.isSourceFile(f);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListSources.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/command/ListSources.java
@@ -18,14 +18,11 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.Callable;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.eclipse.lsp.cobol.cli.processorgroups.Program;
 import picocli.CommandLine;
 
 /** list sources cli command */
@@ -81,16 +78,6 @@ public class ListSources implements Callable<Integer> {
     if (Objects.isNull(parent.processorGroupsResolver)) {
       return false;
     }
-    java.util.List<String> programRegexList =
-        parent.processorGroupsResolver.getProgramList().stream()
-            .map(Program::getProgram)
-            .collect(Collectors.toList());
-    for (String globPattern : programRegexList) {
-      boolean matches = FileSystems.getDefault().getPathMatcher("glob:" + globPattern).matches(f);
-      if (matches) {
-        return true;
-      }
-    }
-    return false;
+    return parent.processorGroupsResolver.isSourceFile(f);
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/processorgroups/ProcessorGroupsResolver.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/processorgroups/ProcessorGroupsResolver.java
@@ -17,22 +17,58 @@ package org.eclipse.lsp.cobol.cli.processorgroups;
 import com.google.gson.Gson;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Resolve settings based on processor groups configuration */
 @Getter
 public class ProcessorGroupsResolver {
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessorGroupsResolver.class);
   private static final Gson GSON = new Gson();
+
+  /**
+   * Patterns with more wildcard segments than this are rejected instead of compiled, since glob
+   * patterns are translated to regex and pathological combinations of wildcards can make matching
+   * take super-linear time on directories with many long, similar file names.
+   */
+  private static final int MAX_WILDCARD_COUNT = 20;
 
   private final List<Program> programList;
   private final List<ProcessorGroup> processorGroupList;
+  private final Map<Program, PathMatcher> compiledMatchers;
 
   public ProcessorGroupsResolver(String programs, String groups) {
     this.programList = GSON.fromJson(programs, ProgramsJson.class).getPgms();
     this.processorGroupList = GSON.fromJson(groups, ProcessorGroupsJson.class).getPgroups();
+    this.compiledMatchers = compileMatchers(this.programList);
+  }
+
+  private static Map<Program, PathMatcher> compileMatchers(List<Program> programs) {
+    Map<Program, PathMatcher> result = new LinkedHashMap<>();
+    for (Program program : programs) {
+      String pattern = program.getProgram();
+      if (Objects.isNull(pattern)) {
+        continue;
+      }
+      long wildcardCount = pattern.chars().filter(c -> c == '*' || c == '?').count();
+      if (wildcardCount > MAX_WILDCARD_COUNT) {
+        LOG.warn(
+            "Skipping program pattern with too many wildcards ({}): {}", wildcardCount, pattern);
+        continue;
+      }
+      try {
+        result.put(program, FileSystems.getDefault().getPathMatcher("glob:" + pattern));
+      } catch (PatternSyntaxException | UnsupportedOperationException e) {
+        LOG.warn("Skipping invalid program glob pattern '{}': {}", pattern, e.getMessage());
+      }
+    }
+    return result;
   }
 
   /**
@@ -71,10 +107,24 @@ public class ProcessorGroupsResolver {
   }
 
   private boolean match(Program p, Path srcPath, Path workspacePath) {
+    PathMatcher matcher = compiledMatchers.get(p);
+    if (Objects.isNull(matcher)) {
+      return false;
+    }
     if (srcPath.startsWith(workspacePath)) {
       srcPath = workspacePath.relativize(srcPath);
     }
-    return FileSystems.getDefault().getPathMatcher("glob:" + p.getProgram()).matches(srcPath);
+    return matcher.matches(srcPath);
+  }
+
+  /**
+   * Checks whether the given workspace-relative path matches any configured program pattern.
+   *
+   * @param relativeSrcPath path relative to the workspace.
+   * @return true if any program pattern matches the path.
+   */
+  public boolean isSourceFile(Path relativeSrcPath) {
+    return compiledMatchers.values().stream().anyMatch(m -> m.matches(relativeSrcPath));
   }
 
   private ProcessorGroup findProcessorGroup(String pgName) {

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/processorgroups/ProcessorGroupsResolver.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/cli/processorgroups/ProcessorGroupsResolver.java
@@ -23,13 +23,10 @@ import java.util.*;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Resolve settings based on processor groups configuration */
 @Getter
 public class ProcessorGroupsResolver {
-  private static final Logger LOG = LoggerFactory.getLogger(ProcessorGroupsResolver.class);
   private static final Gson GSON = new Gson();
 
   /**
@@ -58,14 +55,16 @@ public class ProcessorGroupsResolver {
       }
       long wildcardCount = pattern.chars().filter(c -> c == '*' || c == '?').count();
       if (wildcardCount > MAX_WILDCARD_COUNT) {
-        LOG.warn(
-            "Skipping program pattern with too many wildcards ({}): {}", wildcardCount, pattern);
-        continue;
+        throw new IllegalArgumentException(
+            String.format(
+                "Invalid program pattern '%s': too many wildcards (%d), maximum allowed is %d",
+                pattern, wildcardCount, MAX_WILDCARD_COUNT));
       }
       try {
         result.put(program, FileSystems.getDefault().getPathMatcher("glob:" + pattern));
       } catch (PatternSyntaxException | UnsupportedOperationException e) {
-        LOG.warn("Skipping invalid program glob pattern '{}': {}", pattern, e.getMessage());
+        throw new IllegalArgumentException(
+            String.format("Invalid program glob pattern '%s': %s", pattern, e.getMessage()), e);
       }
     }
     return result;

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/cli/CliProcessorGroupsTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/cli/CliProcessorGroupsTest.java
@@ -15,9 +15,14 @@
 package org.eclipse.lsp.cobol.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.google.common.collect.ImmutableList;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
+import java.util.Map;
+import org.eclipse.lsp.cobol.cli.processorgroups.Program;
 import org.eclipse.lsp.cobol.cli.processorgroups.ProcessorGroupsResolver;
 import org.junit.jupiter.api.Test;
 
@@ -52,5 +57,46 @@ class CliProcessorGroupsTest {
     assertEquals(
         ImmutableList.of("", ".CPY"),
         pg.resolveCopybooksExtensions(Paths.get("/root/COBPGM/SLICKP3"), Paths.get("/root")));
+  }
+
+  @Test
+  void cachedGlobPattern() {
+    String groups =
+        "{\n"
+            + "    \"pgroups\": [\n"
+            + "        {\"name\": \"GROUP_A\", \"copybook-extensions\": [\".CPY\"], \"libs\": [\"COBCOPY/A\"]},\n"
+            + "        {\"name\": \"GROUP_B\", \"copybook-extensions\": [\".CPY\"], \"libs\": [\"COBCOPY/B\"]}\n"
+            + "    ]\n"
+            + "}";
+    String programs =
+        "{\n"
+            + "    \"pgms\": [\n"
+            + "        {\"program\": \"COBPGM/A*\", \"pgroup\": \"GROUP_A\"},\n"
+            + "        {\"program\": \"COBPGM/B*\", \"pgroup\": \"GROUP_B\"}\n"
+            + "    ]\n"
+            + "}";
+
+    ProcessorGroupsResolver pg = new ProcessorGroupsResolver(programs, groups);
+    Map<Program, PathMatcher> compiledMatchers = pg.getCompiledMatchers();
+
+    assertEquals(2, pg.getProgramList().size());
+    assertEquals(
+        2, compiledMatchers.size(), "each program pattern should be compiled into its own entry");
+
+    Path workspace = Paths.get("/root");
+    assertEquals(
+        Paths.get("/root/COBCOPY/A"),
+        pg.resolveCopybooksPaths(Paths.get("/root/COBPGM/APGM1"), workspace).get(0));
+    assertEquals(
+        Paths.get("/root/COBCOPY/B"),
+        pg.resolveCopybooksPaths(Paths.get("/root/COBPGM/BPGM1"), workspace).get(0));
+
+    // no recompilation
+    Program firstProgram = pg.getProgramList().get(0);
+    PathMatcher matcherBefore = compiledMatchers.get(firstProgram);
+    pg.resolveCopybooksPaths(Paths.get("/root/COBPGM/APGM2"), workspace);
+    pg.resolveCopybooksPaths(Paths.get("/root/COBPGM/BPGM2"), workspace);
+    PathMatcher matcherAfter = pg.getCompiledMatchers().get(firstProgram);
+    assertSame(matcherBefore, matcherAfter, "compiled glob pattern must be cached, not recompiled");
   }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/cli/CliProcessorGroupsTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/cli/CliProcessorGroupsTest.java
@@ -22,8 +22,8 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.Map;
-import org.eclipse.lsp.cobol.cli.processorgroups.Program;
 import org.eclipse.lsp.cobol.cli.processorgroups.ProcessorGroupsResolver;
+import org.eclipse.lsp.cobol.cli.processorgroups.Program;
 import org.junit.jupiter.api.Test;
 
 /** Test processor groups support. */

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/cli/CliProcessorGroupsTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/cli/CliProcessorGroupsTest.java
@@ -16,6 +16,7 @@ package org.eclipse.lsp.cobol.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
@@ -100,5 +101,36 @@ class CliProcessorGroupsTest {
     pg.resolveCopybooksPaths(Paths.get("/root/COBPGM/BPGM2"), workspace);
     PathMatcher matcherAfter = pg.getCompiledMatchers().get(firstProgram);
     assertSame(matcherBefore, matcherAfter, "compiled glob pattern must be cached, not recompiled");
+  }
+
+  @Test
+  void invalidGlobPatternIsRejected() {
+    String groups = "{\"pgroups\": []}";
+    String programs =
+        "{\n"
+            + "    \"pgms\": [\n"
+            + "        {\"program\": \"COBPGM/[\", \"pgroup\": \"GROUP_A\"}\n"
+            + "    ]\n"
+            + "}";
+
+    assertThrows(
+        IllegalArgumentException.class, () -> new ProcessorGroupsResolver(programs, groups));
+  }
+
+  @Test
+  void tooManyWildcardsIsRejected() {
+    String groups = "{\"pgroups\": []}";
+    String manyWildcards = String.join("", java.util.Collections.nCopies(21, "*"));
+    String programs =
+        "{\n"
+            + "    \"pgms\": [\n"
+            + "        {\"program\": \""
+            + manyWildcards
+            + "\", \"pgroup\": \"GROUP_A\"}\n"
+            + "    ]\n"
+            + "}";
+
+    assertThrows(
+        IllegalArgumentException.class, () -> new ProcessorGroupsResolver(programs, groups));
   }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/cli/CliProcessorGroupsTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/cli/CliProcessorGroupsTest.java
@@ -64,8 +64,10 @@ class CliProcessorGroupsTest {
     String groups =
         "{\n"
             + "    \"pgroups\": [\n"
-            + "        {\"name\": \"GROUP_A\", \"copybook-extensions\": [\".CPY\"], \"libs\": [\"COBCOPY/A\"]},\n"
-            + "        {\"name\": \"GROUP_B\", \"copybook-extensions\": [\".CPY\"], \"libs\": [\"COBCOPY/B\"]}\n"
+            + "        {\"name\": \"GROUP_A\", \"copybook-extensions\": [\".CPY\"], \"libs\":"
+            + " [\"COBCOPY/A\"]},\n"
+            + "        {\"name\": \"GROUP_B\", \"copybook-extensions\": [\".CPY\"], \"libs\":"
+            + " [\"COBCOPY/B\"]}\n"
             + "    ]\n"
             + "}";
     String programs =


### PR DESCRIPTION
Compile and cache glob patterns in processor groups to avoid evaluation per file in user workspace
