### PR TITLE
fix: Prevent ReDoS in multi-line REPLACE pseudo-text matching

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/replacement/ReplacingServiceImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/replacement/ReplacingServiceImpl.java
@@ -32,6 +32,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp.cobol.common.ResultWithErrors;
+import org.eclipse.lsp.cobol.common.UserInterruptException;
 import org.eclipse.lsp.cobol.common.dialects.CobolLanguageId;
 import org.eclipse.lsp.cobol.common.error.ErrorSeverity;
 import org.eclipse.lsp.cobol.common.error.ErrorSource;
@@ -170,7 +171,9 @@ public class ReplacingServiceImpl implements ReplacingService {
     String text = extendedDocument.getBaseText(startLine, endLine);
     final List<Integer> lineMap = makeLineMap(text);
     try {
-      Matcher matcher = Pattern.compile(pattern.getLeft(), Pattern.CASE_INSENSITIVE).matcher(text);
+      Matcher matcher =
+          Pattern.compile(pattern.getLeft(), Pattern.CASE_INSENSITIVE)
+              .matcher(new InterruptibleCharSequence(text));
       while (matcher.find()) {
         Range range =
             new Range(
@@ -214,5 +217,42 @@ public class ReplacingServiceImpl implements ReplacingService {
   private Function<String, Boolean> checkContainWord(String check) {
     return text ->
         Arrays.stream(text.toUpperCase().split("\b")).anyMatch(txt -> txt.equalsIgnoreCase(check));
+  }
+
+  /**
+   * A {@link CharSequence} wrapper that lets a regex {@link Matcher} honor cooperative thread
+   * interruption.
+   * The matcher reads the sequence exclusively through {@code charAt}, so checking there is
+   * enough to make matching on this text interruptible.
+   */
+  private static final class InterruptibleCharSequence implements CharSequence {
+    private final CharSequence inner;
+
+    private InterruptibleCharSequence(CharSequence inner) {
+      this.inner = inner;
+    }
+
+    @Override
+    public int length() {
+      return inner.length();
+    }
+
+    @Override
+    public char charAt(int index) {
+      if (Thread.currentThread().isInterrupted()) {
+        throw new UserInterruptException("Replacing interrupted by user.");
+      }
+      return inner.charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      return new InterruptibleCharSequence(inner.subSequence(start, end));
+    }
+
+    @Override
+    public String toString() {
+      return inner.toString();
+    }
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/replacement/ReplacingServiceImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/replacement/ReplacingServiceImpl.java
@@ -221,9 +221,8 @@ public class ReplacingServiceImpl implements ReplacingService {
 
   /**
    * A {@link CharSequence} wrapper that lets a regex {@link Matcher} honor cooperative thread
-   * interruption.
-   * The matcher reads the sequence exclusively through {@code charAt}, so checking there is
-   * enough to make matching on this text interruptible.
+   * interruption. The matcher reads the sequence exclusively through {@code charAt}, so checking
+   * there is enough to make matching on this text interruptible.
    */
   private static final class InterruptibleCharSequence implements CharSequence {
     private final CharSequence inner;

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/replacement/ReplacingServiceImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/replacement/ReplacingServiceImpl.java
@@ -32,7 +32,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp.cobol.common.ResultWithErrors;
-import org.eclipse.lsp.cobol.common.UserInterruptException;
 import org.eclipse.lsp.cobol.common.dialects.CobolLanguageId;
 import org.eclipse.lsp.cobol.common.error.ErrorSeverity;
 import org.eclipse.lsp.cobol.common.error.ErrorSource;
@@ -171,9 +170,7 @@ public class ReplacingServiceImpl implements ReplacingService {
     String text = extendedDocument.getBaseText(startLine, endLine);
     final List<Integer> lineMap = makeLineMap(text);
     try {
-      Matcher matcher =
-          Pattern.compile(pattern.getLeft(), Pattern.CASE_INSENSITIVE)
-              .matcher(new InterruptibleCharSequence(text));
+      Matcher matcher = Pattern.compile(pattern.getLeft(), Pattern.CASE_INSENSITIVE).matcher(text);
       while (matcher.find()) {
         Range range =
             new Range(
@@ -217,41 +214,5 @@ public class ReplacingServiceImpl implements ReplacingService {
   private Function<String, Boolean> checkContainWord(String check) {
     return text ->
         Arrays.stream(text.toUpperCase().split("\b")).anyMatch(txt -> txt.equalsIgnoreCase(check));
-  }
-
-  /**
-   * A {@link CharSequence} wrapper that lets a regex {@link Matcher} honor cooperative thread
-   * interruption. The matcher reads the sequence exclusively through {@code charAt}, so checking
-   * there is enough to make matching on this text interruptible.
-   */
-  private static final class InterruptibleCharSequence implements CharSequence {
-    private final CharSequence inner;
-
-    private InterruptibleCharSequence(CharSequence inner) {
-      this.inner = inner;
-    }
-
-    @Override
-    public int length() {
-      return inner.length();
-    }
-
-    @Override
-    public char charAt(int index) {
-      if (Thread.currentThread().isInterrupted()) {
-        throw new UserInterruptException("Replacing interrupted by user.");
-      }
-      return inner.charAt(index);
-    }
-
-    @Override
-    public CharSequence subSequence(int start, int end) {
-      return new InterruptibleCharSequence(inner.subSequence(start, end));
-    }
-
-    @Override
-    public String toString() {
-      return inner.toString();
-    }
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/replacement/SearchPattern.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/preprocessor/delegates/replacement/SearchPattern.java
@@ -60,7 +60,7 @@ public enum SearchPattern {
       Matcher matcher = NEW_LINE_PATTERN.matcher(trim);
       CobolProgramLayout layout = languageId.getLayout();
       int avoidCharLength = layout.getIndicatorLength() + layout.getSequenceLength();
-      String regex = String.format("( *)(?:(\\n.{%d})? ?)+", avoidCharLength);
+      String regex = String.format("(?:\\n.{%d}| )*+", avoidCharLength);
       if (matcher.find()) {
         String[] split = trim.split(NEW_LINE_PATTERN.pattern());
         return Arrays.stream(split)


### PR DESCRIPTION
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
